### PR TITLE
feat: Enhanced Status Command with Update Information (#51)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -83,6 +83,7 @@ program
   .command("status")
   .description("List indexed repositories and their status")
   .option("--json", "Output as JSON")
+  .option("--check", "Check GitHub for available updates")
   .action(async (options: Record<string, unknown>) => {
     try {
       const validatedOptions = StatusCommandOptionsSchema.parse(options);

--- a/src/cli/utils/validation.ts
+++ b/src/cli/utils/validation.ts
@@ -55,6 +55,7 @@ export const SearchCommandOptionsSchema = z.object({
  */
 export const StatusCommandOptionsSchema = z.object({
   json: z.boolean().optional(),
+  check: z.boolean().optional(),
 });
 
 /**

--- a/src/utils/git-url-parser.ts
+++ b/src/utils/git-url-parser.ts
@@ -1,0 +1,108 @@
+/**
+ * Git URL Parser Utility
+ *
+ * Extracts owner and repository name from GitHub URLs for API calls.
+ * Supports both HTTPS and SSH URL formats.
+ */
+
+/**
+ * Parsed GitHub URL result
+ */
+export interface ParsedGitHubUrl {
+  /**
+   * Repository owner (user or organization)
+   */
+  owner: string;
+
+  /**
+   * Repository name
+   */
+  repo: string;
+
+  /**
+   * Whether the URL is a GitHub URL
+   */
+  isGitHub: boolean;
+}
+
+/**
+ * Parse a Git URL to extract owner and repository name
+ *
+ * Supports the following GitHub URL formats:
+ * - HTTPS: https://github.com/owner/repo
+ * - HTTPS with .git: https://github.com/owner/repo.git
+ * - SSH: git@github.com:owner/repo
+ * - SSH with .git: git@github.com:owner/repo.git
+ *
+ * Returns null for non-GitHub URLs or malformed URLs.
+ *
+ * @param url - Git repository URL
+ * @returns Parsed GitHub URL information, or null if not a valid GitHub URL
+ *
+ * @example
+ * ```typescript
+ * parseGitHubUrl('https://github.com/user/repo.git')
+ * // Returns: { owner: 'user', repo: 'repo', isGitHub: true }
+ *
+ * parseGitHubUrl('https://gitlab.com/user/repo')
+ * // Returns: null (not GitHub)
+ *
+ * parseGitHubUrl('git@github.com:org/project.git')
+ * // Returns: { owner: 'org', repo: 'project', isGitHub: true }
+ * ```
+ */
+export function parseGitHubUrl(url: string): ParsedGitHubUrl | null {
+  if (!url || typeof url !== "string") {
+    return null;
+  }
+
+  const trimmedUrl = url.trim();
+
+  // Try HTTPS format: https://github.com/owner/repo(.git)?
+  // Matches: username/repo-name followed by optional .git
+  const httpsPattern = /^https:\/\/github\.com\/([\w][\w.-]*[\w])\/([\w][\w.-]*[\w])(?:\.git)?$/;
+  const httpsMatch = trimmedUrl.match(httpsPattern);
+
+  if (httpsMatch) {
+    const owner = httpsMatch[1];
+    let repo = httpsMatch[2];
+
+    // Strip .git suffix if present (regex allows dots, so it might be captured)
+    if (repo && repo.endsWith(".git")) {
+      repo = repo.substring(0, repo.length - 4);
+    }
+
+    if (owner && repo) {
+      return {
+        owner,
+        repo,
+        isGitHub: true,
+      };
+    }
+  }
+
+  // Try SSH format: git@github.com:owner/repo(.git)?
+  const sshPattern = /^git@github\.com:([\w][\w.-]*[\w])\/([\w][\w.-]*[\w])(?:\.git)?$/;
+  const sshMatch = trimmedUrl.match(sshPattern);
+
+  if (sshMatch) {
+    const owner = sshMatch[1];
+    let repo = sshMatch[2];
+
+    // Strip .git suffix if present (regex allows dots, so it might be captured)
+    if (repo && repo.endsWith(".git")) {
+      repo = repo.substring(0, repo.length - 4);
+    }
+
+    if (owner && repo) {
+      return {
+        owner,
+        repo,
+        isGitHub: true,
+      };
+    }
+  }
+
+  // Not a recognized GitHub URL format
+  return null;
+}

--- a/tests/unit/utils/git-url-parser.test.ts
+++ b/tests/unit/utils/git-url-parser.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Git URL Parser Tests
+ *
+ * Tests for parsing GitHub URLs to extract owner and repository name.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { parseGitHubUrl } from "../../../src/utils/git-url-parser.js";
+
+describe("parseGitHubUrl", () => {
+  describe("HTTPS URLs", () => {
+    it("should parse HTTPS URL with .git suffix", () => {
+      const result = parseGitHubUrl("https://github.com/user/repo.git");
+      expect(result).toEqual({
+        owner: "user",
+        repo: "repo",
+        isGitHub: true,
+      });
+    });
+
+    it("should parse HTTPS URL without .git suffix", () => {
+      const result = parseGitHubUrl("https://github.com/user/repo");
+      expect(result).toEqual({
+        owner: "user",
+        repo: "repo",
+        isGitHub: true,
+      });
+    });
+
+    it("should parse HTTPS URL with organization owner", () => {
+      const result = parseGitHubUrl("https://github.com/my-org/my-project.git");
+      expect(result).toEqual({
+        owner: "my-org",
+        repo: "my-project",
+        isGitHub: true,
+      });
+    });
+
+    it("should parse HTTPS URL with underscores and hyphens", () => {
+      const result = parseGitHubUrl("https://github.com/my_user-123/my_repo-456.git");
+      expect(result).toEqual({
+        owner: "my_user-123",
+        repo: "my_repo-456",
+        isGitHub: true,
+      });
+    });
+
+    it("should parse HTTPS URL with dots in names", () => {
+      const result = parseGitHubUrl("https://github.com/user.name/repo.name.git");
+      expect(result).toEqual({
+        owner: "user.name",
+        repo: "repo.name",
+        isGitHub: true,
+      });
+    });
+  });
+
+  describe("SSH URLs", () => {
+    it("should parse SSH URL with .git suffix", () => {
+      const result = parseGitHubUrl("git@github.com:user/repo.git");
+      expect(result).toEqual({
+        owner: "user",
+        repo: "repo",
+        isGitHub: true,
+      });
+    });
+
+    it("should parse SSH URL without .git suffix", () => {
+      const result = parseGitHubUrl("git@github.com:user/repo");
+      expect(result).toEqual({
+        owner: "user",
+        repo: "repo",
+        isGitHub: true,
+      });
+    });
+
+    it("should parse SSH URL with organization owner", () => {
+      const result = parseGitHubUrl("git@github.com:my-org/my-project.git");
+      expect(result).toEqual({
+        owner: "my-org",
+        repo: "my-project",
+        isGitHub: true,
+      });
+    });
+
+    it("should parse SSH URL with special characters", () => {
+      const result = parseGitHubUrl("git@github.com:my_user-123/my_repo-456.git");
+      expect(result).toEqual({
+        owner: "my_user-123",
+        repo: "my_repo-456",
+        isGitHub: true,
+      });
+    });
+  });
+
+  describe("Non-GitHub URLs", () => {
+    it("should return null for GitLab URL", () => {
+      const result = parseGitHubUrl("https://gitlab.com/user/repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for Bitbucket URL", () => {
+      const result = parseGitHubUrl("https://bitbucket.org/user/repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for self-hosted Git URL", () => {
+      const result = parseGitHubUrl("https://git.company.com/user/repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for generic SSH URL", () => {
+      const result = parseGitHubUrl("git@gitlab.com:user/repo.git");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("Malformed URLs", () => {
+    it("should return null for empty string", () => {
+      const result = parseGitHubUrl("");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for whitespace-only string", () => {
+      const result = parseGitHubUrl("   ");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for null input", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      const result = parseGitHubUrl(null as any);
+      expect(result).toBeNull();
+    });
+
+    it("should return null for undefined input", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      const result = parseGitHubUrl(undefined as any);
+      expect(result).toBeNull();
+    });
+
+    it("should return null for non-string input", () => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
+      const result = parseGitHubUrl(12345 as any);
+      expect(result).toBeNull();
+    });
+
+    it("should return null for URL with missing owner", () => {
+      const result = parseGitHubUrl("https://github.com//repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for URL with missing repo", () => {
+      const result = parseGitHubUrl("https://github.com/user/");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for URL with only one path segment", () => {
+      const result = parseGitHubUrl("https://github.com/user");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for URL with too many path segments", () => {
+      const result = parseGitHubUrl("https://github.com/user/repo/extra");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for SSH URL with missing colon", () => {
+      const result = parseGitHubUrl("git@github.com/user/repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for incomplete HTTPS URL", () => {
+      const result = parseGitHubUrl("https://github.com/");
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("Edge Cases", () => {
+    it("should handle URL with trailing whitespace", () => {
+      const result = parseGitHubUrl("https://github.com/user/repo.git   ");
+      expect(result).toEqual({
+        owner: "user",
+        repo: "repo",
+        isGitHub: true,
+      });
+    });
+
+    it("should handle URL with leading whitespace", () => {
+      const result = parseGitHubUrl("   https://github.com/user/repo.git");
+      expect(result).toEqual({
+        owner: "user",
+        repo: "repo",
+        isGitHub: true,
+      });
+    });
+
+    it("should return null for HTTP (non-HTTPS) GitHub URL", () => {
+      const result = parseGitHubUrl("http://github.com/user/repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for GitHub URL with www subdomain", () => {
+      const result = parseGitHubUrl("https://www.github.com/user/repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for owner/repo names starting with special char", () => {
+      const result = parseGitHubUrl("https://github.com/-user/repo.git");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for owner/repo names ending with special char", () => {
+      const result = parseGitHubUrl("https://github.com/user-/repo.git");
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Implements issue #51 by enhancing the `status` CLI command to display incremental update information and adding a `--check` option to query GitHub for available updates.

## Features

### New Columns in Table Output
- **Last Commit**: Shows short SHA (7 chars) of last indexed commit
- **Last Update**: Displays relative time (e.g., "2h ago", "1d ago") 
- **Updates**: Shows incremental update count since last full index

### --check Option
Query GitHub API to determine if repositories have available updates:
- ✓ **up-to-date** (green): Local SHA matches remote
- ⚠ **updates available** (yellow): Remote has new commits
- ? **unknown** (gray): Cannot determine (non-GitHub repo or no SHA)
- ✗ **error** (red): GitHub API error occurred

### Example Output

**Without --check:**
```
Repository | Files | Chunks | Last Commit | Last Update | Updates | Status
my-api     | 234   | 1,892  | abc1234     | 2h ago      | 12      | ✓ ready
lib-util   | 89    | 456    | def5678     | 1d ago      | 3       | ✓ ready
```

**With --check:**
```
Repository | Files | Chunks | Last Commit | Last Update | Updates | Status
my-api     | 234   | 1,892  | abc1234     | 2h ago      | 12      | ✓ up-to-date
lib-util   | 89    | 456    | def5678     | 1d ago      | 3       | ⚠ updates available
```

## Technical Changes

### New Files
- `src/utils/git-url-parser.ts`: Parse GitHub URLs to extract owner/repo
- `tests/unit/utils/git-url-parser.test.ts`: Comprehensive test suite (30 test cases)

### Modified Files
- `src/cli/commands/status-command.ts`: Added --check logic
- `src/cli/output/formatters.ts`: Enhanced table/JSON formatters
- `src/cli/index.ts`: Added --check option registration
- `src/cli/utils/validation.ts`: Updated schema

### New Utility Functions
- `formatRelativeTime()`: Convert ISO timestamps to human-readable format
- `formatShortSha()`: Format 40-char SHA to 7-char short form
- `parseGitHubUrl()`: Extract owner/repo from GitHub URLs
- `checkRepositoryUpdates()`: Query GitHub API for update status

## Backward Compatibility

✅ No breaking changes
- Gracefully handles repos without update fields
- Falls back to `lastIndexedAt` when `lastIncrementalUpdateAt` unavailable
- Shows "-" for missing commit SHAs and update counts
- New --check option is opt-in

## Test Coverage

✅ All 967 tests passing
✅ 30 new unit tests for git-url-parser
✅ Type checking passed
✅ Pre-commit hooks (ESLint, Prettier) passed

## Closes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)