### PR TITLE
fix: Force reindex now fetches latest changes from remote (#124)

### DIFF
--- a/docs/MCP_INTEGRATION_GUIDE.md
+++ b/docs/MCP_INTEGRATION_GUIDE.md
@@ -131,7 +131,7 @@ bun run cli index https://github.com/username/repository --name my-project
 # Index specific branch
 bun run cli index https://github.com/username/repository --branch develop
 
-# Force reindexing
+# Force reindexing (fetches latest changes from remote before reindexing)
 bun run cli index https://github.com/username/repository --force
 ```
 

--- a/docs/integration/agent-triggered-updates.md
+++ b/docs/integration/agent-triggered-updates.md
@@ -124,7 +124,7 @@ bun run --cwd /path/to/PersonalKnowledgeMCP cli update <repository-name>
 # Update a specific repository
 bun run cli update my-project
 
-# Force full re-index (instead of incremental)
+# Force full re-index (fetches latest from remote, then reindexes completely)
 bun run cli update my-project --force
 
 # Update all indexed repositories

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1153,8 +1153,13 @@ bun run cli status
 **Solution:**
 ```bash
 # Force full re-index to ensure consistency
+# This fetches the latest changes from the remote repository and performs a complete re-index
 bun run cli update <repository-name> --force
 ```
+
+> **Note:** The `--force` flag fetches the latest changes from the remote repository
+> before reindexing, ensuring your search results reflect the current state of the
+> remote repository.
 
 ### Common Error Resolution Summary
 

--- a/src/ingestion/errors.ts
+++ b/src/ingestion/errors.ts
@@ -170,6 +170,38 @@ export class ChunkingError extends RepositoryError {
 }
 
 /**
+ * Error thrown when fetching latest changes from remote fails.
+ *
+ * This error occurs when updating an existing local clone to match
+ * the remote state. Common causes include:
+ * - Network issues during fetch
+ * - Branch no longer exists on remote
+ * - Merge conflicts during reset (shouldn't happen with --hard)
+ *
+ * @example
+ * `typescript
+ * try {
+ *   await cloner.clone(url, { fetchLatest: true });
+ * } catch (error) {
+ *   if (error instanceof FetchError) {
+ *     console.error(Fetch failed for ${error.repoPath}:, error.message);
+ *   }
+ * }
+ * `
+ */
+export class FetchError extends RepositoryError {
+  public readonly repoPath: string;
+  public readonly branch: string;
+
+  constructor(message: string, repoPath: string, branch: string, cause?: Error) {
+    super(message, "FETCH_ERROR", cause, true); // Retryable by default
+    this.name = "FetchError";
+    this.repoPath = repoPath;
+    this.branch = branch;
+  }
+}
+
+/**
  * Determine if an error is a retryable clone error based on its type and characteristics.
  *
  * Used to decide whether to retry a git clone operation after a failure.

--- a/src/ingestion/types.ts
+++ b/src/ingestion/types.ts
@@ -40,6 +40,20 @@ export interface CloneOptions {
    * @default false
    */
   fresh?: boolean;
+
+  /**
+   * Fetch latest changes from remote when repository already exists locally.
+   *
+   * When true and the repository already exists locally (and fresh is false),
+   * performs git fetch origin <branch> followed by git reset --hard origin/<branch>
+   * to update the local clone to match the remote state.
+   *
+   * This is used for force reindex operations to ensure the latest remote
+   * content is indexed rather than stale local content.
+   *
+   * @default false
+   */
+  fetchLatest?: boolean;
 }
 
 /**

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -208,6 +208,7 @@ export class IngestionService {
 
       const cloneResult = await this.repositoryCloner.clone(url, {
         branch: options.branch,
+        fetchLatest: options.force, // Fetch latest when force reindexing
       });
       clonePath = cloneResult.path; // Store for cleanup if needed
 


### PR DESCRIPTION
## Summary

- Fixes #124: Force reindex (`--force` flag) now properly fetches the latest changes from the remote repository before reindexing
- Previously, force reindex would use stale local clone data, causing outdated content to be indexed
- Root cause: `repository-cloner.ts` returned early when repository existed locally without fetching updates

## Changes

### Core Fix
- Added `fetchLatest` option to `CloneOptions` interface in `types.ts`
- Implemented `updateToLatest()` method in `RepositoryCloner` that:
  - Fetches latest changes from remote (`git fetch origin <branch> --depth 1`)
  - Resets local clone to match remote (`git reset --hard origin/<branch>`)
  - Handles authenticated URLs when PAT is configured
- Modified `ingestion-service.ts` to pass `fetchLatest: true` when `force: true`

### Error Handling
- Added `FetchError` class for fetch failure handling
- Marked as retryable by default for transient network issues
- Sanitizes URLs in error messages to prevent credential leakage

### Testing
- Added 8 new unit tests for fetchLatest behavior
- Tests cover: skip behavior, fetch+reset execution, branch handling, error handling, PAT authentication, edge cases
- Renamed mock `reset()` to `resetState()` to avoid conflict with git reset mock

### Documentation
- Updated `troubleshooting.md` with note about `--force` fetching from remote
- Updated `MCP_INTEGRATION_GUIDE.md` to clarify force reindexing behavior
- Updated `agent-triggered-updates.md` with clearer description

## Test plan

- [x] All 1742 existing tests pass
- [x] New tests for fetchLatest behavior pass
- [x] TypeScript typecheck passes
- [x] Manual verification: force reindex behavior follows documented changes

## How it works now

When `--force` is used:
1. Checks if repository exists locally
2. If exists, fetches latest from remote (`git fetch origin <branch>`)
3. Resets local to match remote (`git reset --hard origin/<branch>`)
4. Performs complete reindex with updated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)