### PR TITLE
fix(ingestion): record commit SHA during initial indexing

### DIFF
--- a/src/ingestion/types.ts
+++ b/src/ingestion/types.ts
@@ -74,6 +74,18 @@ export interface CloneResult {
    * Branch that was cloned.
    */
   branch: string;
+
+  /**
+   * Git commit SHA of the HEAD after clone.
+   *
+   * This is the full 40-character SHA of the commit that was cloned.
+   * Used to record `lastIndexedCommitSha` for incremental update support.
+   *
+   * Optional because SHA capture may fail in edge cases (e.g., empty repo).
+   *
+   * @example "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+   */
+  commitSha?: string;
 }
 
 /**

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -876,6 +876,7 @@ export class IngestionService {
       fileCount: params.stats.filesProcessed,
       chunkCount: params.stats.chunksCreated,
       lastIndexedAt: new Date().toISOString(),
+      lastIndexedCommitSha: params.cloneResult.commitSha,
       indexDurationMs: params.stats.durationMs,
       status: params.stats.filesFailed > 0 ? "error" : "ready",
       errorMessage: params.errorMessage,


### PR DESCRIPTION
## Summary
- Captures HEAD commit SHA during repository cloning and propagates to repository metadata
- Enables incremental updates (`pk-mcp update`) to work immediately after initial indexing without manual intervention
- Adds comprehensive test coverage for SHA capture and propagation

## Changes

### Core Implementation
- Added `commitSha?: string` field to `CloneResult` interface (`src/ingestion/types.ts`)
- Added `getHeadCommitSha()` method to `RepositoryCloner` using `git rev-parse HEAD`
- Updated all 3 return paths in `clone()` method to include commitSha
- Modified `buildRepositoryMetadata()` to set `lastIndexedCommitSha` from clone result

### Test Coverage
- Enhanced `MockSimpleGit` with configurable commit SHA support for unit tests
- Added 5 unit tests for SHA capture in `RepositoryCloner`
- Added 5 unit tests for SHA propagation in `IngestionService`
- Added 5 integration tests validating real SHA capture with actual git operations

## Test Plan
- [x] All 1850 existing tests pass
- [x] TypeScript type checking passes (`bun run typecheck`)
- [x] Unit tests verify commit SHA is captured in CloneResult
- [x] Unit tests verify SHA propagation to repository metadata
- [x] Integration tests confirm real SHA matches actual HEAD of cloned repo
- [x] SHA is present in all clone scenarios: fresh clone, reuse existing, fetchLatest

## Technical Details
- SHA capture uses `git rev-parse HEAD` via simple-git library
- Graceful fallback to `undefined` if SHA capture fails (won't break indexing)
- SHA is optional in `CloneResult` to maintain backward compatibility
- Uses same pattern as existing `detectCurrentBranch()` method

Fixes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)