### PR TITLE
docs: add Phase 1 documentation enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Nothing yet
 
-## [0.1.0] - 2025-01-14 (Phase 1: Core MCP + Vector Search)
+## [0.1.0] - 2025-12-28 (Phase 1: Core MCP + Vector Search)
 
 Phase 1 establishes the core foundation for semantic code search via the Model Context Protocol.
 

--- a/README.md
+++ b/README.md
@@ -954,14 +954,14 @@ Development workflow:
 
 ## Code Statistics
 
-Generated with [cloc](https://github.com/AlDanial/cloc):
+Generated with [cloc](https://github.com/AlDanial/cloc) (excluding node_modules, dist, .bun-cache, coverage):
 
 | Language | Files | Blank | Comment | Code |
 |:---------|------:|------:|--------:|-----:|
-| TypeScript | 209 | 8,974 | 16,291 | 39,933 |
-| Markdown | 34 | 4,596 | 9 | 14,697 |
+| TypeScript | 209 | 8,974 | 14,484 | 41,740 |
+| Markdown | 36 | 4,650 | 9 | 14,899 |
 | YAML | 36 | 141 | 345 | 1,538 |
-| Bourne Shell | 3 | 224 | 241 | 900 |
+| Bourne Shell | 6 | 232 | 242 | 924 |
 | PowerShell | 2 | 185 | 133 | 576 |
 | JSON | 7 | 5 | 0 | 308 |
 | Dockerfile | 1 | 22 | 38 | 36 |
@@ -969,7 +969,7 @@ Generated with [cloc](https://github.com/AlDanial/cloc):
 | SQL | 1 | 3 | 16 | 9 |
 | JavaScript | 1 | 0 | 0 | 3 |
 | Python | 4 | 5 | 24 | 2 |
-| **SUM** | **299** | **14,166** | **17,114** | **58,016** |
+| **SUM** | **304** | **14,228** | **15,308** | **60,049** |
 
 ## License
 

--- a/docs/phase1-feature-summary.md
+++ b/docs/phase1-feature-summary.md
@@ -102,7 +102,7 @@ The following are intentional limitations in Phase 1, to be addressed in future 
 | Azure DevOps Integration | Phase 3 | Enterprise repository support |
 | Graph Database | Phase 4 | Neo4j for code relationships |
 | Automated Webhooks | Phase 4 | GitHub webhook handler |
-| OIDC Authentication | Phase 4 | Microsoft 365 SSO |
+| OIDC Full Integration | Phase 3+ | Microsoft 365 SSO (framework implemented) |
 | Kubernetes Deployment | Phase 4 | Production scaling |
 
 ### Current Constraints


### PR DESCRIPTION
## Summary

- Add Code Statistics section to README.md (required per global CLAUDE.md guidelines)
- Create CHANGELOG.md documenting Phase 1 release following Keep a Changelog format
- Create docs/phase1-feature-summary.md with comprehensive feature matrix and known limitations
- Add Phase 1 Feature Summary link to README documentation index

## Changes

### README.md
- Added `## Code Statistics` section with `cloc` output showing 58K+ lines of code
- Added link to new Phase 1 Feature Summary in documentation index

### CHANGELOG.md (New)
- Documents Phase 1: Core MCP + Vector Search release
- Lists all implemented features: MCP server, CLI commands, storage, incremental updates, auth framework
- Documents performance targets met
- Follows Keep a Changelog 1.1.0 format

### docs/phase1-feature-summary.md (New)
- Feature status matrix for all Phase 1 components
- Known limitations and planned phases
- Performance targets achieved
- Technology stack reference
- Links to related documentation

## Test Plan

- [x] All documentation links validated
- [x] TypeScript type checking passes
- [x] Build succeeds
- [x] Pre-commit hooks (prettier) pass

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)