### PR TITLE
feat(graph): create src/graph/ module structure

### DIFF
--- a/src/graph/errors.ts
+++ b/src/graph/errors.ts
@@ -1,0 +1,462 @@
+/**
+ * @module graph/errors
+ *
+ * Custom error classes for Neo4j knowledge graph operations.
+ *
+ * These error classes provide structured error handling for graph operations,
+ * making it easier to diagnose issues and handle different failure scenarios.
+ * The error hierarchy follows the pattern established in storage/errors.ts
+ * and providers/errors.ts.
+ *
+ * @see {@link file://./../../docs/architecture/adr/0002-knowledge-graph-architecture.md} ADR-0002
+ */
+
+// =============================================================================
+// Base Error Class
+// =============================================================================
+
+/**
+ * Base error class for all graph-related errors
+ *
+ * Extends the native Error class with additional context and error codes
+ * for integration with the MCP error handling system.
+ *
+ * @example
+ * ```typescript
+ * throw new GraphError("Failed to execute query", "QUERY_FAILED", cause, true);
+ * ```
+ */
+export class GraphError extends Error {
+  /**
+   * Error code for categorization and handling
+   */
+  public readonly code: string;
+
+  /**
+   * Original error that caused this error (if any)
+   *
+   * NOTE: Uses 'override' to explicitly shadow ES2022 Error.cause property.
+   * This provides type safety by restricting cause to Error instances only.
+   */
+  public override readonly cause?: Error;
+
+  /**
+   * Whether this error is transient and the operation should be retried
+   */
+  public readonly retryable: boolean;
+
+  constructor(
+    message: string,
+    code: string = "GRAPH_ERROR",
+    cause?: Error,
+    retryable: boolean = false
+  ) {
+    super(message);
+    this.name = "GraphError";
+    this.code = code;
+    this.cause = cause;
+    this.retryable = retryable;
+
+    // Maintain proper stack trace for where our error was thrown (V8 only)
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    // Include cause stack trace if available
+    if (cause && cause.stack) {
+      this.stack = `${this.stack}\nCaused by: ${cause.stack}`;
+    }
+  }
+}
+
+// =============================================================================
+// Connection Errors
+// =============================================================================
+
+/**
+ * Error thrown when connection to Neo4j fails
+ *
+ * This error indicates that the Neo4j server is unreachable,
+ * not responding, or refusing connections.
+ *
+ * This error is RETRYABLE by default, as connection issues are often transient.
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await client.connect();
+ * } catch (error) {
+ *   throw new GraphConnectionError("Failed to connect to Neo4j", error);
+ * }
+ * ```
+ */
+export class GraphConnectionError extends GraphError {
+  constructor(message: string, cause?: Error, retryable: boolean = true) {
+    super(message, "CONNECTION_ERROR", cause, retryable);
+    this.name = "GraphConnectionError";
+  }
+}
+
+/**
+ * Error thrown when authentication with Neo4j fails
+ *
+ * This indicates invalid credentials or insufficient permissions.
+ * This is NOT retryable as the credentials need to be corrected.
+ */
+export class GraphAuthenticationError extends GraphError {
+  constructor(message: string, cause?: Error) {
+    super(message, "AUTHENTICATION_ERROR", cause, false);
+    this.name = "GraphAuthenticationError";
+  }
+}
+
+// =============================================================================
+// Query Errors
+// =============================================================================
+
+/**
+ * Error thrown when a Cypher query execution fails
+ *
+ * This may be due to syntax errors, constraint violations,
+ * or runtime errors during query execution.
+ *
+ * By default NOT retryable, but transient errors (e.g., deadlocks)
+ * may be marked as retryable.
+ */
+export class GraphQueryError extends GraphError {
+  /**
+   * The Cypher query that failed (sanitized of sensitive data)
+   */
+  public readonly query?: string;
+
+  constructor(message: string, query?: string, cause?: Error, retryable: boolean = false) {
+    super(message, "QUERY_ERROR", cause, retryable);
+    this.name = "GraphQueryError";
+    this.query = query;
+  }
+}
+
+/**
+ * Error thrown when a Cypher query times out
+ *
+ * This is RETRYABLE by default, as timeouts are often transient.
+ */
+export class GraphQueryTimeoutError extends GraphError {
+  /**
+   * Timeout duration in milliseconds
+   */
+  public readonly timeoutMs: number;
+
+  constructor(message: string, timeoutMs: number, cause?: Error) {
+    super(message, "QUERY_TIMEOUT", cause, true);
+    this.name = "GraphQueryTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+// =============================================================================
+// Node Errors
+// =============================================================================
+
+/**
+ * Error thrown when a requested node is not found
+ *
+ * This error is NOT retryable as the node doesn't exist.
+ */
+export class NodeNotFoundError extends GraphError {
+  /**
+   * The node identifier that was not found
+   */
+  public readonly nodeId: string;
+
+  /**
+   * The node type/label that was searched
+   */
+  public readonly nodeType?: string;
+
+  constructor(nodeId: string, nodeType?: string, message?: string) {
+    const defaultMessage = nodeType
+      ? `Node with ID '${nodeId}' of type '${nodeType}' not found`
+      : `Node with ID '${nodeId}' not found`;
+    super(message || defaultMessage, "NODE_NOT_FOUND");
+    this.name = "NodeNotFoundError";
+    this.nodeId = nodeId;
+    this.nodeType = nodeType;
+  }
+}
+
+/**
+ * Error thrown when node creation or update fails due to constraint violation
+ *
+ * This typically occurs when trying to create a node with a duplicate
+ * unique property value.
+ */
+export class NodeConstraintError extends GraphError {
+  /**
+   * The constraint that was violated
+   */
+  public readonly constraintName?: string;
+
+  /**
+   * The property that caused the violation
+   */
+  public readonly propertyName?: string;
+
+  constructor(message: string, constraintName?: string, propertyName?: string, cause?: Error) {
+    super(message, "NODE_CONSTRAINT_ERROR", cause, false);
+    this.name = "NodeConstraintError";
+    this.constraintName = constraintName;
+    this.propertyName = propertyName;
+  }
+}
+
+// =============================================================================
+// Relationship Errors
+// =============================================================================
+
+/**
+ * Error thrown when a relationship operation fails
+ *
+ * This may occur when creating, updating, or deleting relationships.
+ */
+export class RelationshipError extends GraphError {
+  /**
+   * The relationship type involved
+   */
+  public readonly relationshipType?: string;
+
+  /**
+   * Source node ID
+   */
+  public readonly fromNodeId?: string;
+
+  /**
+   * Target node ID
+   */
+  public readonly toNodeId?: string;
+
+  constructor(
+    message: string,
+    relationshipType?: string,
+    fromNodeId?: string,
+    toNodeId?: string,
+    cause?: Error
+  ) {
+    super(message, "RELATIONSHIP_ERROR", cause, false);
+    this.name = "RelationshipError";
+    this.relationshipType = relationshipType;
+    this.fromNodeId = fromNodeId;
+    this.toNodeId = toNodeId;
+  }
+}
+
+/**
+ * Error thrown when a relationship is not found
+ */
+export class RelationshipNotFoundError extends GraphError {
+  /**
+   * The relationship ID that was not found
+   */
+  public readonly relationshipId: string;
+
+  constructor(relationshipId: string, message?: string) {
+    super(
+      message || `Relationship with ID '${relationshipId}' not found`,
+      "RELATIONSHIP_NOT_FOUND"
+    );
+    this.name = "RelationshipNotFoundError";
+    this.relationshipId = relationshipId;
+  }
+}
+
+// =============================================================================
+// Schema Errors
+// =============================================================================
+
+/**
+ * Error thrown when a schema operation fails
+ *
+ * This includes constraint creation, index creation, and schema migrations.
+ */
+export class GraphSchemaError extends GraphError {
+  /**
+   * The schema element that caused the error (e.g., constraint name, index name)
+   */
+  public readonly schemaElement?: string;
+
+  constructor(message: string, schemaElement?: string, cause?: Error) {
+    super(message, "SCHEMA_ERROR", cause, false);
+    this.name = "GraphSchemaError";
+    this.schemaElement = schemaElement;
+  }
+}
+
+// =============================================================================
+// Traversal Errors
+// =============================================================================
+
+/**
+ * Error thrown when graph traversal exceeds limits
+ *
+ * This occurs when a traversal would return too many results
+ * or exceed the maximum allowed depth.
+ */
+export class TraversalLimitError extends GraphError {
+  /**
+   * The limit that was exceeded
+   */
+  public readonly limit: number;
+
+  /**
+   * The actual count that exceeded the limit
+   */
+  public readonly actualCount: number;
+
+  /**
+   * Type of limit exceeded (e.g., 'depth', 'nodes', 'relationships')
+   */
+  public readonly limitType: "depth" | "nodes" | "relationships";
+
+  constructor(limitType: "depth" | "nodes" | "relationships", limit: number, actualCount: number) {
+    super(
+      `Traversal exceeded ${limitType} limit: ${actualCount} > ${limit}`,
+      "TRAVERSAL_LIMIT_ERROR",
+      undefined,
+      false
+    );
+    this.name = "TraversalLimitError";
+    this.limitType = limitType;
+    this.limit = limit;
+    this.actualCount = actualCount;
+  }
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Determine if an error is retryable based on its type and characteristics
+ *
+ * Used to decide whether to retry an operation after a failure.
+ * This handles both our custom error classes and native errors.
+ *
+ * @param error - The error to check
+ * @returns true if the error is retryable
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await client.runQuery(cypher);
+ * } catch (error) {
+ *   if (isRetryableGraphError(error)) {
+ *     await retry(() => client.runQuery(cypher));
+ *   } else {
+ *     throw error;
+ *   }
+ * }
+ * ```
+ */
+export function isRetryableGraphError(error: unknown): boolean {
+  // Check our custom error classes
+  if (error instanceof GraphError) {
+    return error.retryable;
+  }
+
+  // Check native errors for common transient patterns
+  if (error instanceof Error) {
+    const message = error.message.toLowerCase();
+    const retryablePatterns = [
+      // Connection errors
+      "econnrefused",
+      "econnreset",
+      "etimedout",
+      "enotfound",
+      "socket hang up",
+      "network error",
+      "connection refused",
+      "connection reset",
+      // Neo4j transient errors
+      "deadlock",
+      "transaction terminated",
+      "database unavailable",
+      "leader changed",
+      // General transient patterns
+      "temporarily unavailable",
+      "service unavailable",
+      "too many requests",
+    ];
+    return retryablePatterns.some((pattern) => message.includes(pattern));
+  }
+
+  return false;
+}
+
+/**
+ * Create a typed error from a Neo4j driver error
+ *
+ * This helper maps Neo4j driver errors to our typed error classes
+ * for consistent error handling throughout the application.
+ *
+ * @param error - The original Neo4j driver error
+ * @returns A typed GraphError subclass
+ */
+export function mapNeo4jError(error: Error): GraphError {
+  const message = error.message.toLowerCase();
+
+  // Authentication errors
+  if (
+    message.includes("authentication") ||
+    message.includes("unauthorized") ||
+    message.includes("invalid credentials")
+  ) {
+    return new GraphAuthenticationError(error.message, error);
+  }
+
+  // Connection errors
+  if (
+    message.includes("connection") ||
+    message.includes("econnrefused") ||
+    message.includes("econnreset") ||
+    message.includes("etimedout") ||
+    message.includes("socket")
+  ) {
+    return new GraphConnectionError(error.message, error);
+  }
+
+  // Timeout errors
+  if (message.includes("timeout") || message.includes("timed out")) {
+    // Extract timeout value if present in message
+    const timeoutMatch = message.match(/(\d+)\s*(ms|milliseconds|seconds)/i);
+    let timeoutMs = 30000; // default
+    if (timeoutMatch && timeoutMatch[1] && timeoutMatch[2]) {
+      const value = parseInt(timeoutMatch[1], 10);
+      const unit = timeoutMatch[2].toLowerCase();
+      timeoutMs = value * (unit.startsWith("s") ? 1000 : 1);
+    }
+    return new GraphQueryTimeoutError(error.message, timeoutMs, error);
+  }
+
+  // Constraint violations
+  if (message.includes("constraint") || message.includes("already exists")) {
+    return new NodeConstraintError(error.message, undefined, undefined, error);
+  }
+
+  // Schema errors
+  if (message.includes("schema") || message.includes("index")) {
+    return new GraphSchemaError(error.message, undefined, error);
+  }
+
+  // Query errors (syntax, etc.)
+  if (message.includes("syntax") || message.includes("cypher")) {
+    return new GraphQueryError(error.message, undefined, error, false);
+  }
+
+  // Deadlock and transient errors
+  if (message.includes("deadlock") || message.includes("transaction terminated")) {
+    return new GraphQueryError(error.message, undefined, error, true);
+  }
+
+  // Default to base GraphError
+  return new GraphError(error.message, "UNKNOWN_ERROR", error, false);
+}

--- a/src/graph/index.ts
+++ b/src/graph/index.ts
@@ -1,0 +1,133 @@
+/**
+ * @module graph
+ *
+ * Knowledge Graph Module
+ *
+ * This module provides the public API for Neo4j knowledge graph operations.
+ * It exports the storage client interface, types, and error classes for
+ * interacting with the knowledge graph database.
+ *
+ * The knowledge graph complements ChromaDB vector search by storing explicit
+ * relationships between code entities (functions, classes, modules) enabling
+ * relationship-aware queries and dependency analysis.
+ *
+ * @see {@link file://./../docs/architecture/adr/0002-knowledge-graph-architecture.md} ADR-0002
+ *
+ * @example
+ * ```typescript
+ * import {
+ *   Neo4jStorageClient,
+ *   Neo4jConfig,
+ *   GraphTraverseInput,
+ *   RelationshipType,
+ *   GraphError,
+ * } from "./graph/index.js";
+ *
+ * const config: Neo4jConfig = {
+ *   host: "localhost",
+ *   port: 7687,
+ *   username: "neo4j",
+ *   password: process.env.NEO4J_PASSWORD,
+ * };
+ *
+ * // Use the client (implementation in separate issue)
+ * const result = await client.traverse({
+ *   startNode: { type: "function", identifier: "searchService" },
+ *   relationships: [RelationshipType.CALLS],
+ *   depth: 2,
+ * });
+ * ```
+ */
+
+// =============================================================================
+// Configuration Types
+// =============================================================================
+
+export type { Neo4jConfig } from "./types.js";
+
+// =============================================================================
+// Node Types
+// =============================================================================
+
+export type {
+  BaseNode,
+  RepositoryNode,
+  FileNode,
+  FunctionNode,
+  ClassNode,
+  ModuleNode,
+  ChunkNode,
+  ConceptNode,
+  GraphNode,
+  ClassEntityType,
+  ModuleType,
+} from "./types.js";
+
+// =============================================================================
+// Relationship Types
+// =============================================================================
+
+export { RelationshipType } from "./types.js";
+
+export type {
+  BaseRelationship,
+  Relationship,
+  RelationshipProperties,
+  ImportType,
+  ImportsRelationshipProps,
+  CallsRelationshipProps,
+  DefinesRelationshipProps,
+  ReferencesRelationshipProps,
+  HasChunkRelationshipProps,
+  RelatedToRelationshipProps,
+  TaggedWithRelationshipProps,
+} from "./types.js";
+
+// =============================================================================
+// Query Types
+// =============================================================================
+
+export type {
+  NodeTypeFilter,
+  TraversalStartNode,
+  GraphTraverseInput,
+  GraphTraverseResult,
+  DependencyDirection,
+  GraphDependenciesInput,
+  DependencyInfo,
+  GraphDependenciesResult,
+  ContextType,
+  GraphContextInput,
+  ContextItem,
+  GraphContextResult,
+} from "./types.js";
+
+// =============================================================================
+// Client Interface
+// =============================================================================
+
+export type { Neo4jStorageClient } from "./types.js";
+
+// =============================================================================
+// Error Classes
+// =============================================================================
+
+export {
+  GraphError,
+  GraphConnectionError,
+  GraphAuthenticationError,
+  GraphQueryError,
+  GraphQueryTimeoutError,
+  NodeNotFoundError,
+  NodeConstraintError,
+  RelationshipError,
+  RelationshipNotFoundError,
+  GraphSchemaError,
+  TraversalLimitError,
+} from "./errors.js";
+
+// =============================================================================
+// Error Utilities
+// =============================================================================
+
+export { isRetryableGraphError, mapNeo4jError } from "./errors.js";

--- a/src/graph/types.ts
+++ b/src/graph/types.ts
@@ -1,0 +1,699 @@
+/**
+ * @module graph/types
+ *
+ * Type definitions for knowledge graph storage and operations.
+ *
+ * This module defines the interfaces and types for interacting with the Neo4j
+ * knowledge graph database. The graph stores code relationships, dependencies,
+ * and semantic concepts to enable relationship-aware queries and impact analysis.
+ *
+ * @see {@link file://./../../docs/architecture/adr/0002-knowledge-graph-architecture.md} ADR-0002
+ */
+
+import type { RetryConfig } from "../utils/retry.js";
+
+// =============================================================================
+// Configuration Types
+// =============================================================================
+
+/**
+ * Configuration for Neo4j client connection
+ *
+ * @example
+ * ```typescript
+ * const config: Neo4jConfig = {
+ *   host: "localhost",
+ *   port: 7687,
+ *   username: "neo4j",
+ *   password: process.env.NEO4J_PASSWORD,
+ * };
+ * ```
+ */
+export interface Neo4jConfig {
+  /** Neo4j server host (default: 'localhost') */
+  host: string;
+
+  /** Neo4j Bolt protocol port (default: 7687) */
+  port: number;
+
+  /** Neo4j username for authentication */
+  username: string;
+
+  /** Neo4j password for authentication */
+  password: string;
+
+  /** Maximum connection pool size (default: 50) */
+  maxConnectionPoolSize?: number;
+
+  /** Connection acquisition timeout in ms (default: 30000) */
+  connectionAcquisitionTimeout?: number;
+
+  /** Optional retry configuration for transient failures */
+  retry?: RetryConfig;
+}
+
+// =============================================================================
+// Graph Node Types
+// =============================================================================
+
+/**
+ * Base interface for all graph nodes
+ *
+ * All node types extend this interface to ensure consistent
+ * identification and metadata across the graph.
+ */
+export interface BaseNode {
+  /** Unique identifier for the node within Neo4j */
+  id: string;
+
+  /** Neo4j node labels (e.g., ['Repository'], ['File', 'SourceCode']) */
+  labels: string[];
+}
+
+/**
+ * Repository node representing an indexed code repository
+ *
+ * Maps to Neo4j label: `Repository`
+ */
+export interface RepositoryNode extends BaseNode {
+  /** Repository name (e.g., 'PersonalKnowledgeMCP') */
+  name: string;
+
+  /** Full repository URL */
+  url: string;
+
+  /** ISO timestamp of last indexing operation */
+  lastIndexed: string;
+
+  /** Repository indexing status */
+  status: "pending" | "indexing" | "ready" | "error";
+}
+
+/**
+ * File node representing a source code or documentation file
+ *
+ * Maps to Neo4j label: `File`
+ */
+export interface FileNode extends BaseNode {
+  /** File path relative to repository root */
+  path: string;
+
+  /** File extension (e.g., 'ts', 'md', 'py') */
+  extension: string;
+
+  /** SHA256 content hash for change detection */
+  hash: string;
+
+  /** Repository name this file belongs to */
+  repository: string;
+}
+
+/**
+ * Function node representing a function or method definition
+ *
+ * Maps to Neo4j label: `Function`
+ */
+export interface FunctionNode extends BaseNode {
+  /** Function name */
+  name: string;
+
+  /** Function signature (e.g., 'async search(query: string): Promise<Result>') */
+  signature: string;
+
+  /** Line number where function definition starts */
+  startLine: number;
+
+  /** Line number where function definition ends */
+  endLine: number;
+
+  /** File path where this function is defined */
+  filePath: string;
+
+  /** Repository name */
+  repository: string;
+}
+
+/**
+ * Type of class-like entity in the codebase
+ */
+export type ClassEntityType = "class" | "interface" | "enum" | "type";
+
+/**
+ * Class node representing a class, interface, or enum definition
+ *
+ * Maps to Neo4j label: `Class`
+ */
+export interface ClassNode extends BaseNode {
+  /** Class/interface/enum name */
+  name: string;
+
+  /** Type of entity */
+  type: ClassEntityType;
+
+  /** File path where this is defined */
+  filePath: string;
+
+  /** Line number where definition starts */
+  startLine: number;
+
+  /** Line number where definition ends */
+  endLine: number;
+
+  /** Repository name */
+  repository: string;
+}
+
+/**
+ * Type of module import
+ */
+export type ModuleType = "npm" | "local" | "builtin";
+
+/**
+ * Module node representing an ES module or package
+ *
+ * Maps to Neo4j label: `Module`
+ */
+export interface ModuleNode extends BaseNode {
+  /** Module name (package name or relative path) */
+  name: string;
+
+  /** Module type */
+  type: ModuleType;
+
+  /** Version for npm packages (optional) */
+  version?: string;
+}
+
+/**
+ * Chunk node representing a reference to a ChromaDB vector chunk
+ *
+ * This node type bridges the graph database with the vector database,
+ * enabling combined queries across both stores.
+ *
+ * Maps to Neo4j label: `Chunk`
+ */
+export interface ChunkNode extends BaseNode {
+  /** ChromaDB document ID for this chunk */
+  chromaId: string;
+
+  /** Index of this chunk within the file (0-based) */
+  chunkIndex: number;
+
+  /** File path this chunk belongs to */
+  filePath: string;
+
+  /** Repository name */
+  repository: string;
+}
+
+/**
+ * Concept node representing a semantic concept or topic
+ *
+ * Used for tagging code entities with semantic meaning and
+ * enabling concept-based queries.
+ *
+ * Maps to Neo4j label: `Concept`
+ */
+export interface ConceptNode extends BaseNode {
+  /** Concept name (e.g., 'authentication', 'caching', 'error-handling') */
+  name: string;
+
+  /** Human-readable description of the concept */
+  description?: string;
+
+  /** Confidence score for auto-extracted concepts (0-1) */
+  confidence?: number;
+}
+
+/**
+ * Union type of all graph node types
+ */
+export type GraphNode =
+  | RepositoryNode
+  | FileNode
+  | FunctionNode
+  | ClassNode
+  | ModuleNode
+  | ChunkNode
+  | ConceptNode;
+
+// =============================================================================
+// Relationship Types
+// =============================================================================
+
+/**
+ * Enumeration of all relationship types in the knowledge graph
+ *
+ * @see ADR-0002 for relationship semantics and usage patterns
+ */
+export enum RelationshipType {
+  /** Repository contains a file */
+  CONTAINS = "CONTAINS",
+
+  /** File defines a function, class, or other entity */
+  DEFINES = "DEFINES",
+
+  /** File imports a module */
+  IMPORTS = "IMPORTS",
+
+  /** Function calls another function */
+  CALLS = "CALLS",
+
+  /** Class implements an interface */
+  IMPLEMENTS = "IMPLEMENTS",
+
+  /** Class extends another class */
+  EXTENDS = "EXTENDS",
+
+  /** File references another file (e.g., documentation link) */
+  REFERENCES = "REFERENCES",
+
+  /** File has an associated vector chunk */
+  HAS_CHUNK = "HAS_CHUNK",
+
+  /** Concept is related to another concept */
+  RELATED_TO = "RELATED_TO",
+
+  /** Entity is tagged with a concept */
+  TAGGED_WITH = "TAGGED_WITH",
+}
+
+/**
+ * Base interface for all graph relationships
+ */
+export interface BaseRelationship {
+  /** Unique identifier for the relationship */
+  id: string;
+
+  /** Relationship type */
+  type: RelationshipType;
+
+  /** ID of the source node */
+  fromNodeId: string;
+
+  /** ID of the target node */
+  toNodeId: string;
+}
+
+/**
+ * Import type for IMPORTS relationship
+ */
+export type ImportType = "named" | "default" | "namespace" | "side-effect";
+
+/**
+ * Properties for IMPORTS relationship
+ */
+export interface ImportsRelationshipProps {
+  /** Type of import statement */
+  importType: ImportType;
+
+  /** Imported symbols (for named imports) */
+  importedSymbols?: string[];
+}
+
+/**
+ * Properties for CALLS relationship
+ */
+export interface CallsRelationshipProps {
+  /** Number of times this call appears in the caller */
+  callCount: number;
+
+  /** Whether this is an async/await call */
+  isAsync: boolean;
+}
+
+/**
+ * Properties for DEFINES relationship
+ */
+export interface DefinesRelationshipProps {
+  /** Line number where definition starts */
+  startLine: number;
+
+  /** Line number where definition ends */
+  endLine: number;
+}
+
+/**
+ * Properties for REFERENCES relationship
+ */
+export interface ReferencesRelationshipProps {
+  /** Link text used in the reference */
+  linkText?: string;
+
+  /** Surrounding context of the reference */
+  context?: string;
+}
+
+/**
+ * Properties for HAS_CHUNK relationship
+ */
+export interface HasChunkRelationshipProps {
+  /** Index of the chunk within the file */
+  chunkIndex: number;
+}
+
+/**
+ * Properties for RELATED_TO relationship (concept to concept)
+ */
+export interface RelatedToRelationshipProps {
+  /** Similarity score between concepts (0-1) */
+  similarity: number;
+
+  /** Type of relationship (e.g., 'synonym', 'hypernym', 'related') */
+  relationshipType: string;
+}
+
+/**
+ * Properties for TAGGED_WITH relationship
+ */
+export interface TaggedWithRelationshipProps {
+  /** Confidence score for the tagging (0-1) */
+  confidence: number;
+}
+
+/**
+ * Union type of all relationship property types
+ */
+export type RelationshipProperties =
+  | ImportsRelationshipProps
+  | CallsRelationshipProps
+  | DefinesRelationshipProps
+  | ReferencesRelationshipProps
+  | HasChunkRelationshipProps
+  | RelatedToRelationshipProps
+  | TaggedWithRelationshipProps
+  | Record<string, never>; // For relationships without properties
+
+/**
+ * Generic relationship with typed properties
+ */
+export interface Relationship<
+  P extends RelationshipProperties = RelationshipProperties,
+> extends BaseRelationship {
+  /** Relationship-specific properties */
+  properties: P;
+}
+
+// =============================================================================
+// Query Types
+// =============================================================================
+
+/**
+ * Node type specifier for graph queries
+ */
+export type NodeTypeFilter = "file" | "function" | "class" | "concept" | "chunk" | "module";
+
+/**
+ * Starting point for graph traversal
+ */
+export interface TraversalStartNode {
+  /** Type of the starting node */
+  type: NodeTypeFilter;
+
+  /** Identifier (path for files, name for others) */
+  identifier: string;
+
+  /** Optional repository filter */
+  repository?: string;
+}
+
+/**
+ * Input for graph traversal operations
+ *
+ * @example
+ * ```typescript
+ * const input: GraphTraverseInput = {
+ *   startNode: { type: "function", identifier: "searchService" },
+ *   relationships: [RelationshipType.CALLS, RelationshipType.IMPORTS],
+ *   depth: 2,
+ *   limit: 50,
+ * };
+ * ```
+ */
+export interface GraphTraverseInput {
+  /** Starting point for traversal */
+  startNode: TraversalStartNode;
+
+  /** Relationship types to follow */
+  relationships: RelationshipType[];
+
+  /** Maximum traversal depth (1-5, default: 2) */
+  depth?: number;
+
+  /** Maximum number of results (default: 100) */
+  limit?: number;
+}
+
+/**
+ * Result of a graph traversal operation
+ */
+export interface GraphTraverseResult {
+  /** Nodes found during traversal */
+  nodes: Array<{
+    id: string;
+    type: string;
+    properties: Record<string, unknown>;
+  }>;
+
+  /** Relationships found during traversal */
+  relationships: Array<{
+    from: string;
+    to: string;
+    type: RelationshipType;
+    properties: Record<string, unknown>;
+  }>;
+
+  /** Query metadata */
+  metadata: {
+    nodesCount: number;
+    relationshipsCount: number;
+    queryTimeMs: number;
+  };
+}
+
+/**
+ * Direction for dependency analysis
+ */
+export type DependencyDirection = "dependsOn" | "dependedOnBy" | "both";
+
+/**
+ * Input for dependency analysis operations
+ */
+export interface GraphDependenciesInput {
+  /** Target entity to analyze */
+  target: {
+    type: "file" | "function" | "class";
+    identifier: string;
+    repository: string;
+  };
+
+  /** Direction of dependency analysis */
+  direction: DependencyDirection;
+
+  /** Include transitive dependencies */
+  transitive?: boolean;
+
+  /** Maximum depth for transitive analysis (default: 3) */
+  maxDepth?: number;
+}
+
+/**
+ * Information about a single dependency
+ */
+export interface DependencyInfo {
+  /** Type of the dependent entity */
+  type: "file" | "function" | "class" | "module";
+
+  /** Entity identifier */
+  identifier: string;
+
+  /** Repository name */
+  repository: string;
+
+  /** Relationship type connecting to target */
+  relationshipType: RelationshipType;
+
+  /** Depth from the target (1 = direct, 2+ = transitive) */
+  depth: number;
+}
+
+/**
+ * Result of dependency analysis
+ */
+export interface GraphDependenciesResult {
+  /** Direct dependencies */
+  direct: DependencyInfo[];
+
+  /** Transitive dependencies (if requested) */
+  transitive?: DependencyInfo[];
+
+  /** Impact score (0-1, how many things depend on this) */
+  impactScore: number;
+
+  /** Query metadata */
+  metadata: {
+    directCount: number;
+    transitiveCount: number;
+    queryTimeMs: number;
+  };
+}
+
+/**
+ * Context types to include in RAG enhancement
+ */
+export type ContextType = "imports" | "callers" | "callees" | "siblings" | "documentation";
+
+/**
+ * Input for graph context expansion (RAG enhancement)
+ */
+export interface GraphContextInput {
+  /** Seed nodes from semantic search or explicit files */
+  seeds: Array<{
+    type: "file" | "chunk" | "function";
+    identifier: string;
+    repository?: string;
+  }>;
+
+  /** Types of context to include */
+  includeContext: ContextType[];
+
+  /** Maximum context items (default: 20) */
+  limit?: number;
+}
+
+/**
+ * A single context item in the result
+ */
+export interface ContextItem {
+  /** Entity type */
+  type: string;
+
+  /** File path or identifier */
+  path: string;
+
+  /** Repository name */
+  repository: string;
+
+  /** Relevance score (0-1) */
+  relevance: number;
+
+  /** Reason for inclusion */
+  reason: string;
+}
+
+/**
+ * Result of graph context expansion
+ */
+export interface GraphContextResult {
+  /** Context items found */
+  context: ContextItem[];
+
+  /** Query metadata */
+  metadata: {
+    seedsProcessed: number;
+    contextItemsFound: number;
+    queryTimeMs: number;
+  };
+}
+
+// =============================================================================
+// Client Interface
+// =============================================================================
+
+/**
+ * Client interface for interacting with Neo4j graph storage
+ *
+ * This is the primary interface for all graph storage operations.
+ * Implementation will be provided in a separate issue.
+ *
+ * @see Issue #143 for Neo4j Storage Client implementation
+ */
+export interface Neo4jStorageClient {
+  /**
+   * Connect to the Neo4j database
+   */
+  connect(): Promise<void>;
+
+  /**
+   * Disconnect from the Neo4j database
+   */
+  disconnect(): Promise<void>;
+
+  /**
+   * Check if the connection is healthy
+   */
+  healthCheck(): Promise<boolean>;
+
+  /**
+   * Execute a Cypher query
+   *
+   * @param cypher - Cypher query string
+   * @param params - Query parameters
+   * @returns Query results
+   */
+  runQuery<T>(cypher: string, params?: Record<string, unknown>): Promise<T[]>;
+
+  /**
+   * Create or update a node
+   *
+   * @param node - Node data to create or update
+   * @returns The created/updated node
+   */
+  upsertNode<N extends GraphNode>(node: Omit<N, "id"> & { id?: string }): Promise<N>;
+
+  /**
+   * Delete a node by ID
+   *
+   * @param nodeId - ID of the node to delete
+   * @returns true if deleted, false if not found
+   */
+  deleteNode(nodeId: string): Promise<boolean>;
+
+  /**
+   * Create a relationship between nodes
+   *
+   * @param fromNodeId - Source node ID
+   * @param toNodeId - Target node ID
+   * @param type - Relationship type
+   * @param properties - Relationship properties
+   * @returns The created relationship
+   */
+  createRelationship<P extends RelationshipProperties>(
+    fromNodeId: string,
+    toNodeId: string,
+    type: RelationshipType,
+    properties?: P
+  ): Promise<Relationship<P>>;
+
+  /**
+   * Delete a relationship by ID
+   *
+   * @param relationshipId - ID of the relationship to delete
+   * @returns true if deleted, false if not found
+   */
+  deleteRelationship(relationshipId: string): Promise<boolean>;
+
+  /**
+   * Traverse the graph from a starting node
+   *
+   * @param input - Traversal parameters
+   * @returns Traversal results
+   */
+  traverse(input: GraphTraverseInput): Promise<GraphTraverseResult>;
+
+  /**
+   * Analyze dependencies for a target entity
+   *
+   * @param input - Dependency analysis parameters
+   * @returns Dependency analysis results
+   */
+  analyzeDependencies(input: GraphDependenciesInput): Promise<GraphDependenciesResult>;
+
+  /**
+   * Get related context for RAG enhancement
+   *
+   * @param input - Context expansion parameters
+   * @returns Context items
+   */
+  getContext(input: GraphContextInput): Promise<GraphContextResult>;
+}


### PR DESCRIPTION
## Summary

Creates the foundational directory structure and base files for the knowledge graph module, following existing codebase patterns established in `src/storage/`, `src/providers/`, and `src/services/`.

### Files Created

| File | Purpose | Lines |
|------|---------|-------|
| `src/graph/types.ts` | Type definitions for nodes, relationships, queries, and client interface | ~500 |
| `src/graph/errors.ts` | Error class hierarchy with 10+ specialized error types | ~460 |
| `src/graph/index.ts` | Barrel exports following module patterns | ~120 |

### Type Definitions (from ADR-0002)

**Node Types:**
- `RepositoryNode` - Indexed code repository
- `FileNode` - Source code or documentation file
- `FunctionNode` - Function or method definition
- `ClassNode` - Class, interface, or enum definition
- `ModuleNode` - ES module or package
- `ChunkNode` - Vector store chunk reference (bridges ChromaDB)
- `ConceptNode` - Semantic concept or topic

**Relationship Types:**
- `CONTAINS`, `DEFINES`, `IMPORTS`, `CALLS`, `IMPLEMENTS`, `EXTENDS`, `REFERENCES`, `HAS_CHUNK`, `RELATED_TO`, `TAGGED_WITH`

**Query Interfaces:**
- `GraphTraverseInput/Result` - Graph traversal operations
- `GraphDependenciesInput/Result` - Dependency analysis
- `GraphContextInput/Result` - RAG context expansion

### Error Hierarchy

- `GraphError` (base)
  - `GraphConnectionError` (retryable)
  - `GraphAuthenticationError`
  - `GraphQueryError`
  - `GraphQueryTimeoutError` (retryable)
  - `NodeNotFoundError`
  - `NodeConstraintError`
  - `RelationshipError`
  - `RelationshipNotFoundError`
  - `GraphSchemaError`
  - `TraversalLimitError`

## Test Plan

- [x] TypeScript type checking passes (`bun run typecheck`)
- [x] All 1987 existing tests continue to pass
- [x] Module structure follows codebase patterns
- [x] All types align with ADR-0002 data model design

## Related Issues

- Closes #142
- Parent Epic: #138
- Enables: #143 (Neo4j Storage Client), #144 (Graph Service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)