### PR TITLE
perf(graph): optimize getContext with batched UNWIND queries

### DIFF
--- a/tests/helpers/neo4j-mock.ts
+++ b/tests/helpers/neo4j-mock.ts
@@ -425,8 +425,16 @@ export const mockRecordFactories = {
   /**
    * Create a record for context retrieval
    */
-  contextResult: (contextNode: MockNode, reason: string): MockRecord => {
-    return new MockRecord(["context", "reason"], [contextNode, reason]);
+  contextResult: (
+    contextNode: MockNode,
+    reason: string,
+    seedId: string = "default-seed",
+    seedRepo: string | null = null
+  ): MockRecord => {
+    return new MockRecord(
+      ["seedId", "seedRepo", "context", "reason"],
+      [seedId, seedRepo, contextNode, reason]
+    );
   },
 };
 


### PR DESCRIPTION
## Summary

- Reduces database round trips from O(N×M) to O(M) by using UNWIND to process all seeds in a single query per context type
- Adds `buildBatchedContextQuery()` method to generate optimized Cypher queries
- Refactors `getContext()` to use batched queries with a seedsParam array
- Adds `queriesExecuted` and `contextTypesRequested` metrics for observability
- Implements early exit when result limit is reached

## Performance Impact

| Scenario | Before | After |
|----------|--------|-------|
| 5 seeds × 4 context types | 20 queries | 4 queries |
| 10 seeds × 5 context types | 50 queries | 5 queries |

## Test Plan

- [x] All existing Neo4jClient tests pass (70 tests)
- [x] Full test suite passes (2195 tests)
- [x] TypeScript type checking passes
- [ ] Manual testing with real Neo4j instance (optional)

Closes #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)