### PR TITLE
feat(providers): add getCapabilities() to EmbeddingProvider interface

### DIFF
--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -22,7 +22,7 @@
  */
 
 // Type definitions
-export type { EmbeddingProvider, EmbeddingProviderConfig } from "./types.js";
+export type { EmbeddingProvider, EmbeddingProviderConfig, ProviderCapabilities } from "./types.js";
 
 // Error classes
 export {

--- a/src/providers/openai-embedding.ts
+++ b/src/providers/openai-embedding.ts
@@ -6,7 +6,7 @@
  */
 
 import OpenAI from "openai";
-import type { EmbeddingProvider, EmbeddingProviderConfig } from "./types.js";
+import type { EmbeddingProvider, EmbeddingProviderConfig, ProviderCapabilities } from "./types.js";
 import {
   EmbeddingError,
   EmbeddingAuthenticationError,
@@ -153,6 +153,24 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
       // Health check never throws - just returns false
       return false;
     }
+  }
+
+  /**
+   * Get provider capabilities and limitations
+   *
+   * Returns information about OpenAI API constraints and characteristics.
+   * OpenAI is an API-based provider requiring network connectivity.
+   *
+   * @returns Provider capabilities for OpenAI embeddings
+   */
+  getCapabilities(): ProviderCapabilities {
+    return {
+      maxBatchSize: this.config.batchSize,
+      maxTokensPerText: 8191, // OpenAI text-embedding-3-* limit
+      supportsGPU: false, // API-based, GPU handled server-side
+      requiresNetwork: true, // Requires internet connectivity
+      estimatedLatencyMs: 200, // Typical API latency
+    };
   }
 
   /**

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -6,6 +6,74 @@
  */
 
 /**
+ * Capabilities and limitations of an embedding provider
+ *
+ * Describes the operational characteristics and constraints of an embedding provider.
+ * This information helps callers make informed decisions about batching strategies,
+ * deployment options, and provider selection based on requirements.
+ *
+ * @example
+ * ```typescript
+ * const caps = provider.getCapabilities();
+ * if (caps.requiresNetwork && !isOnline) {
+ *   throw new Error("Network required for this provider");
+ * }
+ * const batchSize = Math.min(texts.length, caps.maxBatchSize);
+ * ```
+ */
+export interface ProviderCapabilities {
+  /**
+   * Maximum number of texts that can be embedded in a single API call
+   *
+   * For API-based providers, this is typically limited by the service.
+   * For local providers, this may be limited by memory or compute resources.
+   *
+   * @example 100 (OpenAI), 32 (typical local model)
+   */
+  maxBatchSize: number;
+
+  /**
+   * Maximum tokens per input text
+   *
+   * Texts exceeding this limit may be truncated or rejected depending
+   * on the provider's behavior. This is an approximate limit.
+   *
+   * @example 8191 (OpenAI text-embedding-3-*), 512 (typical local model)
+   */
+  maxTokensPerText: number;
+
+  /**
+   * Whether this provider supports GPU acceleration
+   *
+   * True for local providers that can utilize GPU hardware.
+   * False for API-based providers (GPU is handled server-side).
+   *
+   * @example false (OpenAI), true (Transformers.js with WebGPU)
+   */
+  supportsGPU: boolean;
+
+  /**
+   * Whether this provider requires network connectivity
+   *
+   * True for API-based providers that call external services.
+   * False for local providers that run entirely on the local machine.
+   *
+   * @example true (OpenAI), false (Transformers.js)
+   */
+  requiresNetwork: boolean;
+
+  /**
+   * Estimated latency in milliseconds for single-text embedding
+   *
+   * This is an approximate value for typical conditions. Actual latency
+   * may vary based on network conditions, text length, and system load.
+   *
+   * @example 200 (OpenAI API), 50 (local GPU), 500 (local CPU)
+   */
+  estimatedLatencyMs: number;
+}
+
+/**
  * Configuration for embedding provider instances
  *
  * This configuration is used to initialize an embedding provider with the
@@ -158,4 +226,22 @@ export interface EmbeddingProvider {
    * ```
    */
   healthCheck(): Promise<boolean>;
+
+  /**
+   * Get provider capabilities and limitations
+   *
+   * Returns information about batch limits, network requirements, GPU support,
+   * and performance characteristics. This helps callers make informed decisions
+   * about provider selection, batching strategies, and deployment options.
+   *
+   * @returns Provider capabilities object describing operational characteristics
+   *
+   * @example
+   * ```typescript
+   * const caps = provider.getCapabilities();
+   * console.log(`Max batch size: ${caps.maxBatchSize}`);
+   * console.log(`Requires network: ${caps.requiresNetwork}`);
+   * ```
+   */
+  getCapabilities(): ProviderCapabilities;
 }

--- a/tests/integration/search-service.integration.test.ts
+++ b/tests/integration/search-service.integration.test.ts
@@ -47,6 +47,16 @@ class MockEmbeddingProvider implements EmbeddingProvider {
     return true;
   }
 
+  getCapabilities() {
+    return {
+      maxBatchSize: 100,
+      maxTokensPerText: 8191,
+      supportsGPU: false,
+      requiresNetwork: false,
+      estimatedLatencyMs: 10,
+    };
+  }
+
   private hashString(str: string): number {
     let hash = 0;
     for (let i = 0; i < str.length; i++) {

--- a/tests/services/incremental-update-pipeline.test.ts
+++ b/tests/services/incremental-update-pipeline.test.ts
@@ -46,6 +46,13 @@ describe("IncrementalUpdatePipeline", () => {
         texts.map(() => new Array(1536).fill(0.1) as number[])
       ),
       healthCheck: mock(async () => true),
+      getCapabilities: () => ({
+        maxBatchSize: 100,
+        maxTokensPerText: 8191,
+        supportsGPU: false,
+        requiresNetwork: false,
+        estimatedLatencyMs: 10,
+      }),
     };
 
     // Create mock storage client

--- a/tests/services/ingestion-service.test.ts
+++ b/tests/services/ingestion-service.test.ts
@@ -176,6 +176,16 @@ class MockEmbeddingProvider implements EmbeddingProvider {
     return !this.shouldFail;
   }
 
+  getCapabilities() {
+    return {
+      maxBatchSize: 100,
+      maxTokensPerText: 8191,
+      supportsGPU: false,
+      requiresNetwork: false,
+      estimatedLatencyMs: 10,
+    };
+  }
+
   setShouldFail(shouldFail: boolean, error?: Error) {
     this.shouldFail = shouldFail;
     this.failureError = error || null;

--- a/tests/services/search-service.test.ts
+++ b/tests/services/search-service.test.ts
@@ -51,6 +51,16 @@ class MockEmbeddingProvider implements EmbeddingProvider {
     return !this.shouldFail;
   }
 
+  getCapabilities() {
+    return {
+      maxBatchSize: 100,
+      maxTokensPerText: 8191,
+      supportsGPU: false,
+      requiresNetwork: false,
+      estimatedLatencyMs: 10,
+    };
+  }
+
   setShouldFail(shouldFail: boolean, error?: Error) {
     this.shouldFail = shouldFail;
     this.failureError = error || null;

--- a/tests/unit/providers/openai-embedding.test.ts
+++ b/tests/unit/providers/openai-embedding.test.ts
@@ -572,4 +572,47 @@ describe("OpenAIEmbeddingProvider", () => {
       expect(isHealthy).toBe(false);
     });
   });
+
+  describe("getCapabilities", () => {
+    test("returns provider capabilities", () => {
+      const provider = new OpenAIEmbeddingProvider(config);
+      const capabilities = provider.getCapabilities();
+
+      expect(capabilities.maxBatchSize).toBe(config.batchSize);
+      expect(capabilities.maxTokensPerText).toBe(8191);
+      expect(capabilities.supportsGPU).toBe(false);
+      expect(capabilities.requiresNetwork).toBe(true);
+      expect(capabilities.estimatedLatencyMs).toBeGreaterThan(0);
+    });
+
+    test("reflects configured batch size", () => {
+      const smallBatchConfig = { ...TEST_CONFIGS.smallBatch };
+      const provider = new OpenAIEmbeddingProvider(smallBatchConfig);
+      const capabilities = provider.getCapabilities();
+
+      expect(capabilities.maxBatchSize).toBe(10);
+    });
+
+    test("indicates OpenAI is a network-dependent provider", () => {
+      const provider = new OpenAIEmbeddingProvider(config);
+      const capabilities = provider.getCapabilities();
+
+      // OpenAI requires network and does not support local GPU
+      expect(capabilities.requiresNetwork).toBe(true);
+      expect(capabilities.supportsGPU).toBe(false);
+    });
+
+    test("returns consistent values across multiple calls", () => {
+      const provider = new OpenAIEmbeddingProvider(config);
+
+      const caps1 = provider.getCapabilities();
+      const caps2 = provider.getCapabilities();
+
+      expect(caps1.maxBatchSize).toBe(caps2.maxBatchSize);
+      expect(caps1.maxTokensPerText).toBe(caps2.maxTokensPerText);
+      expect(caps1.supportsGPU).toBe(caps2.supportsGPU);
+      expect(caps1.requiresNetwork).toBe(caps2.requiresNetwork);
+      expect(caps1.estimatedLatencyMs).toBe(caps2.estimatedLatencyMs);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Add `ProviderCapabilities` interface describing provider constraints and characteristics
- Add `getCapabilities()` method to `EmbeddingProvider` interface
- Implement `getCapabilities()` in `OpenAIEmbeddingProvider`
- Update mock providers in test files to implement the new method
- Add unit tests for the new method

This is the foundational work for Epic #140 (Local Embeddings Provider). The interface changes are additive and backward-compatible.

## Test Plan

- [x] All 50 OpenAI embedding provider unit tests pass
- [x] All 134 services tests pass (mocks updated)
- [x] New `getCapabilities()` tests verify correct values
- [x] TypeScript type checking passes

## Related Issues

Closes #160

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)