### PR TITLE
docs: add graph tools documentation and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2025 Seth Bibler
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/graph-tools.md
+++ b/docs/graph-tools.md
@@ -1,0 +1,423 @@
+# Graph Tools - Personal Knowledge MCP
+
+This guide documents the graph-based MCP tools that enable code dependency analysis and impact assessment using the knowledge graph backed by Neo4j.
+
+## Overview
+
+The Personal Knowledge MCP provides two graph-based tools that complement semantic search with structural code analysis:
+
+| Tool | Purpose | Primary Use Case |
+|------|---------|------------------|
+| `get_dependencies` | Query what a code entity depends on | Understanding code structure, pre-change analysis |
+| `get_dependents` | Query what depends on a code entity | Impact analysis, refactoring risk assessment |
+
+### Graph vs. Semantic Search
+
+| Capability | Semantic Search | Graph Tools |
+|------------|-----------------|-------------|
+| Find similar code | Yes | No |
+| Find code by concept | Yes | No |
+| Trace import chains | No | Yes |
+| Identify callers/callees | No | Yes |
+| Impact analysis | No | Yes |
+| Dependency depth traversal | No | Yes |
+
+**Best Practice**: Use semantic search to *find* relevant code, then use graph tools to *understand* its relationships and impact.
+
+## Prerequisites
+
+Before using graph tools, ensure:
+
+1. **Neo4j is running**: The knowledge graph requires Neo4j Community Edition
+   ```bash
+   docker-compose up -d neo4j
+   ```
+
+2. **Repository is indexed with AST parsing**: Graph data requires code analysis beyond simple text indexing
+   ```bash
+   pk-mcp index <repository-url>
+   ```
+
+3. **GraphService is enabled**: The MCP server must be configured with Neo4j connection
+   ```bash
+   # Required environment variables
+   NEO4J_URI=bolt://localhost:7687
+   NEO4J_USER=neo4j
+   NEO4J_PASSWORD=your-password
+   ```
+
+## MCP Tools Reference
+
+### get_dependencies
+
+**Purpose**: Get all dependencies of a file, function, or class. Returns what the entity imports, calls, or extends.
+
+**When to use**:
+- Understanding what a piece of code relies on before making changes
+- Exploring the codebase structure
+- Identifying external dependencies
+- Planning migrations or upgrades
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `entity_type` | string | Yes | - | Type of entity: `"file"`, `"function"`, or `"class"` |
+| `entity_path` | string | Yes | - | Path or identifier of the entity |
+| `repository` | string | Yes | - | Repository name to scope the query |
+| `depth` | integer | No | 1 | Depth of transitive dependencies (1-5) |
+| `relationship_types` | array | No | all | Filter: `["imports", "calls", "extends", "implements", "references"]` |
+
+#### Entity Path Format
+
+- **Files**: Relative path from repository root (e.g., `"src/auth/middleware.ts"`)
+- **Functions/Classes**: Name or fully qualified name
+  - Simple: `"AuthMiddleware"`
+  - Qualified: `"src/auth/middleware.ts::AuthMiddleware"`
+
+#### Example Requests
+
+**Get direct imports of a file**:
+```json
+{
+  "entity_type": "file",
+  "entity_path": "src/services/auth.ts",
+  "repository": "my-api"
+}
+```
+
+**Get transitive dependencies (2 levels deep)**:
+```json
+{
+  "entity_type": "file",
+  "entity_path": "src/services/auth.ts",
+  "repository": "my-api",
+  "depth": 2
+}
+```
+
+**Get only import relationships**:
+```json
+{
+  "entity_type": "file",
+  "entity_path": "src/services/auth.ts",
+  "repository": "my-api",
+  "relationship_types": ["imports"]
+}
+```
+
+**Get dependencies of a specific class**:
+```json
+{
+  "entity_type": "class",
+  "entity_path": "AuthService",
+  "repository": "my-api",
+  "depth": 2,
+  "relationship_types": ["extends", "implements"]
+}
+```
+
+#### Response Format
+
+```json
+{
+  "entity": {
+    "type": "file",
+    "path": "src/services/auth.ts",
+    "repository": "my-api"
+  },
+  "dependencies": [
+    {
+      "type": "file",
+      "path": "src/utils/jwt.ts",
+      "relationship": "imports",
+      "depth": 1,
+      "metadata": {
+        "line_number": 3
+      }
+    },
+    {
+      "type": "package",
+      "path": "jsonwebtoken",
+      "relationship": "imports",
+      "depth": 1,
+      "metadata": {
+        "external": true
+      }
+    }
+  ],
+  "metadata": {
+    "total_count": 2,
+    "query_time_ms": 45,
+    "max_depth_reached": 1
+  }
+}
+```
+
+---
+
+### get_dependents
+
+**Purpose**: Get all code that depends on a file, function, or class. Returns what imports, calls, or extends the entity.
+
+**When to use**:
+- Impact analysis before refactoring
+- Understanding the blast radius of a change
+- Identifying critical shared code
+- Planning deprecation of APIs or functions
+
+#### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `entity_type` | string | Yes | - | Type of entity: `"file"`, `"function"`, `"class"`, or `"package"` |
+| `entity_path` | string | Yes | - | Path or identifier of the entity |
+| `repository` | string | No | all | Repository name (omit to search all repositories) |
+| `depth` | integer | No | 1 | Depth of transitive dependents (1-5) |
+| `include_cross_repo` | boolean | No | false | Include dependents from other repositories |
+
+#### Key Differences from get_dependencies
+
+1. **Repository is optional**: Omit to search all indexed repositories
+2. **Supports "package" entity type**: For package-level impact analysis
+3. **Cross-repository search**: Find dependents across your entire codebase
+4. **Impact analysis metrics**: Response includes severity assessment
+
+#### Example Requests
+
+**Find all files that import a utility**:
+```json
+{
+  "entity_type": "file",
+  "entity_path": "src/utils/validation.ts",
+  "repository": "my-api"
+}
+```
+
+**Impact analysis across all repositories**:
+```json
+{
+  "entity_type": "function",
+  "entity_path": "validateToken",
+  "include_cross_repo": true
+}
+```
+
+**Find all callers of a function (2 levels deep)**:
+```json
+{
+  "entity_type": "function",
+  "entity_path": "src/auth/middleware.ts::authenticate",
+  "repository": "my-api",
+  "depth": 2
+}
+```
+
+**Package-level impact analysis**:
+```json
+{
+  "entity_type": "package",
+  "entity_path": "src/shared/utils",
+  "repository": "my-api"
+}
+```
+
+#### Response Format
+
+```json
+{
+  "entity": {
+    "type": "function",
+    "path": "validateToken",
+    "repository": "my-api"
+  },
+  "dependents": [
+    {
+      "type": "file",
+      "path": "src/middleware/auth.ts",
+      "repository": "my-api",
+      "relationship": "calls",
+      "depth": 1,
+      "metadata": {
+        "line_number": 42
+      }
+    },
+    {
+      "type": "file",
+      "path": "src/routes/protected.ts",
+      "repository": "my-api",
+      "relationship": "calls",
+      "depth": 2,
+      "metadata": {}
+    }
+  ],
+  "impact_analysis": {
+    "direct_impact_count": 1,
+    "transitive_impact_count": 1,
+    "impact_score": 0.35
+  },
+  "metadata": {
+    "total_count": 2,
+    "query_time_ms": 67,
+    "repositories_searched": ["my-api"]
+  }
+}
+```
+
+#### Understanding Impact Analysis
+
+The `impact_analysis` object helps assess refactoring risk:
+
+| Field | Description | Interpretation |
+|-------|-------------|----------------|
+| `direct_impact_count` | Files/entities that directly depend on this entity | Immediate change required |
+| `transitive_impact_count` | Entities affected through dependency chains | Potential cascade effects |
+| `impact_score` | Normalized score (0.0-1.0) | Higher = more risk |
+
+**Impact Score Guidelines**:
+- `0.0 - 0.2`: Low impact, safe to refactor
+- `0.2 - 0.5`: Moderate impact, plan carefully
+- `0.5 - 0.8`: High impact, comprehensive testing needed
+- `0.8 - 1.0`: Critical impact, consider incremental changes
+
+---
+
+## Usage Examples
+
+### Example 1: Pre-Refactoring Analysis
+
+Before renaming a utility function:
+
+```
+Claude, I want to rename the validateEmail function in src/utils/validation.ts.
+Can you show me what depends on it?
+```
+
+Claude would use:
+```json
+{
+  "entity_type": "function",
+  "entity_path": "src/utils/validation.ts::validateEmail",
+  "repository": "my-api",
+  "depth": 2
+}
+```
+
+### Example 2: Understanding New Code
+
+When exploring unfamiliar code:
+
+```
+Claude, I'm looking at src/services/payment.ts. What external services
+and internal modules does it depend on?
+```
+
+Claude would use:
+```json
+{
+  "entity_type": "file",
+  "entity_path": "src/services/payment.ts",
+  "repository": "my-api",
+  "depth": 1,
+  "relationship_types": ["imports"]
+}
+```
+
+### Example 3: Deprecation Planning
+
+Planning to deprecate an old API:
+
+```
+Claude, we want to deprecate the legacy authentication middleware.
+What's the impact across all our repositories?
+```
+
+Claude would use:
+```json
+{
+  "entity_type": "file",
+  "entity_path": "src/middleware/legacy-auth.ts",
+  "include_cross_repo": true,
+  "depth": 3
+}
+```
+
+### Example 4: Architecture Overview
+
+Understanding module boundaries:
+
+```
+Claude, show me all the dependencies of our core domain module
+to check for unwanted coupling.
+```
+
+Claude would use:
+```json
+{
+  "entity_type": "file",
+  "entity_path": "src/domain/index.ts",
+  "repository": "my-api",
+  "depth": 1
+}
+```
+
+---
+
+## Performance
+
+Graph tools are optimized for fast response times:
+
+| Query Type | Target Latency |
+|------------|----------------|
+| Direct dependencies (depth=1) | < 100ms |
+| Transitive queries (depth=2-3) | < 300ms |
+| Cross-repository queries | < 500ms |
+| Full module graph | < 1000ms |
+
+---
+
+## Troubleshooting
+
+### "Entity not found" Error
+
+**Cause**: The entity path doesn't match any indexed code.
+
+**Solutions**:
+1. Verify the path is relative to repository root
+2. Check that the repository is indexed: `pk-mcp status`
+3. For functions/classes, try the fully qualified name
+
+### "No graph data available" Error
+
+**Cause**: Neo4j is not running or not configured.
+
+**Solutions**:
+1. Start Neo4j: `docker-compose up -d neo4j`
+2. Verify connection: `docker-compose logs neo4j`
+3. Check environment variables: `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`
+
+### Empty Results
+
+**Cause**: The entity exists but has no relationships of the requested type.
+
+**Solutions**:
+1. Try without `relationship_types` filter to see all relationships
+2. Increase `depth` to find transitive dependencies
+3. For `get_dependents`, try `include_cross_repo: true`
+
+### Slow Queries
+
+**Cause**: Deep traversal or large result sets.
+
+**Solutions**:
+1. Reduce `depth` parameter
+2. Add `relationship_types` filter
+3. Scope to a specific repository instead of all
+
+---
+
+## Related Documentation
+
+- [Knowledge Graph PRD](pm/knowledge-graph-PRD.md) - Full product requirements
+- [Knowledge Graph Architecture](architecture/adr/0002-knowledge-graph-architecture.md) - Technical design
+- [MCP Integration Guide](MCP_INTEGRATION_GUIDE.md) - General MCP setup


### PR DESCRIPTION
## Summary

- Create comprehensive `docs/graph-tools.md` with full tool reference, usage examples, and troubleshooting guide for `get_dependencies` and `get_dependents` MCP tools
- Update `README.md` with graph tools in MCP Tools section, updated architecture diagram showing Neo4j and Graph Service
- Add Phase 2 Stack section documenting Neo4j and graph tools
- Add usage examples for dependency and impact analysis
- Update code statistics with current cloc output
- Add MIT License for Seth Bibler

## Test plan

- [x] Typecheck passes (`bun run typecheck`)
- [ ] Verify documentation renders correctly in GitHub
- [ ] Verify architecture diagram renders in mermaid
- [ ] Confirm all internal links work (e.g., `docs/graph-tools.md`)

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)