### PR TITLE
fix(providers): apply code review recommendations from PR #198

### DIFF
--- a/src/providers/EmbeddingProviderFactory.ts
+++ b/src/providers/EmbeddingProviderFactory.ts
@@ -305,6 +305,23 @@ export class EmbeddingProviderFactory {
     if (!baseUrl) {
       const host = Bun.env["OLLAMA_HOST"] || "localhost";
       const port = Bun.env["OLLAMA_PORT"] || "11434";
+
+      // Validate port is numeric
+      if (!/^\d+$/.test(port)) {
+        throw new EmbeddingValidationError(
+          `Invalid OLLAMA_PORT: ${port}. Must be a numeric port number.`,
+          "port"
+        );
+      }
+
+      // Validate host does not contain URL special characters
+      if (/[/:@#?]/.test(host)) {
+        throw new EmbeddingValidationError(
+          `Invalid OLLAMA_HOST: ${host}. Must be a valid hostname without URL special characters.`,
+          "host"
+        );
+      }
+
       baseUrl = `http://${host}:${port}`;
     }
 

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -4,17 +4,19 @@
  * Provides a unified interface for instantiating embedding providers
  * based on configuration, with automatic environment variable handling.
  *
+ * This module provides backward-compatible function API by delegating
+ * to the class-based EmbeddingProviderFactory.
+ *
  * @see EmbeddingProviderFactory for the class-based factory pattern
  */
 
 import type { EmbeddingProvider, EmbeddingProviderConfig } from "./types.js";
-import { OpenAIEmbeddingProvider, type OpenAIProviderConfig } from "./openai-embedding.js";
-import {
-  TransformersJsEmbeddingProvider,
-  type TransformersJsProviderConfig,
-} from "./transformersjs-embedding.js";
-import { OllamaEmbeddingProvider, type OllamaProviderConfig } from "./ollama-embedding.js";
-import { EmbeddingValidationError } from "./errors.js";
+import { EmbeddingProviderFactory } from "./EmbeddingProviderFactory.js";
+
+/**
+ * Singleton factory instance for delegation
+ */
+const factory = new EmbeddingProviderFactory();
 
 /**
  * Create an embedding provider from configuration
@@ -46,110 +48,5 @@ import { EmbeddingValidationError } from "./errors.js";
  * ```
  */
 export function createEmbeddingProvider(config: EmbeddingProviderConfig): EmbeddingProvider {
-  const providerType = config.provider.toLowerCase();
-
-  switch (providerType) {
-    case "openai":
-      return createOpenAIProvider(config);
-
-    case "transformersjs":
-    case "transformers":
-    case "local":
-      return createTransformersJsProvider(config);
-
-    case "ollama":
-      return createOllamaProvider(config);
-
-    default:
-      throw new EmbeddingValidationError(
-        `Unsupported provider: ${config.provider}. Supported providers: openai, transformersjs, ollama`,
-        "provider"
-      );
-  }
-}
-
-/**
- * Create an OpenAI embedding provider
- *
- * Reads API key from OPENAI_API_KEY environment variable.
- * Optionally reads OPENAI_ORGANIZATION and OPENAI_BASE_URL.
- *
- * @param config - Base provider configuration
- * @returns Initialized OpenAI provider
- * @throws {EmbeddingValidationError} If OPENAI_API_KEY is missing
- */
-function createOpenAIProvider(config: EmbeddingProviderConfig): OpenAIEmbeddingProvider {
-  // Read API key from environment
-  const apiKey = Bun.env["OPENAI_API_KEY"];
-
-  if (!apiKey) {
-    throw new EmbeddingValidationError(
-      "OPENAI_API_KEY environment variable is required for OpenAI provider",
-      "apiKey"
-    );
-  }
-
-  // Build OpenAI-specific configuration
-  const openaiConfig: OpenAIProviderConfig = {
-    ...config,
-    apiKey,
-    organization: Bun.env["OPENAI_ORGANIZATION"],
-    baseURL: Bun.env["OPENAI_BASE_URL"],
-  };
-
-  return new OpenAIEmbeddingProvider(openaiConfig);
-}
-
-/**
- * Create a Transformers.js embedding provider
- *
- * Uses local HuggingFace models via Transformers.js for offline embedding generation.
- * Optionally reads TRANSFORMERS_CACHE for custom cache directory.
- *
- * @param config - Base provider configuration
- * @returns Initialized Transformers.js provider
- */
-function createTransformersJsProvider(
-  config: EmbeddingProviderConfig
-): TransformersJsEmbeddingProvider {
-  const transformersConfig: TransformersJsProviderConfig = {
-    ...config,
-    modelPath: (config.options?.["modelPath"] as string) || "Xenova/all-MiniLM-L6-v2",
-    cacheDir: Bun.env["TRANSFORMERS_CACHE"] || undefined,
-    quantized: (config.options?.["quantized"] as boolean) || false,
-  };
-
-  return new TransformersJsEmbeddingProvider(transformersConfig);
-}
-
-/**
- * Create an Ollama embedding provider
- *
- * Connects to a local Ollama server for GPU-accelerated embedding generation.
- * Reads configuration from environment variables:
- * - OLLAMA_BASE_URL: Full URL (takes precedence)
- * - OLLAMA_HOST: Host name (default: localhost)
- * - OLLAMA_PORT: Port number (default: 11434)
- *
- * @param config - Base provider configuration
- * @returns Initialized Ollama provider
- */
-function createOllamaProvider(config: EmbeddingProviderConfig): OllamaEmbeddingProvider {
-  // Build base URL from environment variables
-  let baseUrl = Bun.env["OLLAMA_BASE_URL"];
-
-  if (!baseUrl) {
-    const host = Bun.env["OLLAMA_HOST"] || "localhost";
-    const port = Bun.env["OLLAMA_PORT"] || "11434";
-    baseUrl = `http://${host}:${port}`;
-  }
-
-  const ollamaConfig: OllamaProviderConfig = {
-    ...config,
-    modelName: (config.options?.["modelName"] as string) || "nomic-embed-text",
-    baseUrl,
-    keepAlive: (config.options?.["keepAlive"] as string) || "5m",
-  };
-
-  return new OllamaEmbeddingProvider(ollamaConfig);
+  return factory.createProvider(config);
 }

--- a/tests/unit/providers/EmbeddingProviderFactory.test.ts
+++ b/tests/unit/providers/EmbeddingProviderFactory.test.ts
@@ -364,5 +364,42 @@ describe("EmbeddingProviderFactory", () => {
       const provider = factory.createProvider(config);
       expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
     });
+
+    test("throws on non-numeric OLLAMA_PORT", () => {
+      delete Bun.env["OLLAMA_BASE_URL"];
+      Bun.env["OLLAMA_PORT"] = "not-a-number";
+
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "ollama",
+        model: "nomic-embed-text",
+        dimensions: 768,
+        batchSize: 32,
+        maxRetries: 3,
+        timeoutMs: 30000,
+      };
+
+      expect(() => factory.createProvider(config)).toThrow(EmbeddingValidationError);
+      expect(() => factory.createProvider(config)).toThrow("Must be a numeric port number");
+    });
+
+    test("throws on OLLAMA_HOST with URL special characters", () => {
+      delete Bun.env["OLLAMA_BASE_URL"];
+      Bun.env["OLLAMA_HOST"] = "evil.com/malicious#";
+      Bun.env["OLLAMA_PORT"] = "11434";
+
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "ollama",
+        model: "nomic-embed-text",
+        dimensions: 768,
+        batchSize: 32,
+        maxRetries: 3,
+        timeoutMs: 30000,
+      };
+
+      expect(() => factory.createProvider(config)).toThrow(EmbeddingValidationError);
+      expect(() => factory.createProvider(config)).toThrow("Must be a valid hostname");
+    });
   });
 });

--- a/tests/unit/providers/ollama-embedding.test.ts
+++ b/tests/unit/providers/ollama-embedding.test.ts
@@ -167,6 +167,35 @@ describe("OllamaEmbeddingProvider", () => {
       expect(() => new OllamaEmbeddingProvider(config)).toThrow("Invalid base URL");
     });
 
+    test("throws on non-http/https URL scheme", () => {
+      const config: OllamaProviderConfig = {
+        ...DEFAULT_CONFIG,
+        baseUrl: "file:///etc/passwd",
+      };
+
+      expect(() => new OllamaEmbeddingProvider(config)).toThrow(EmbeddingValidationError);
+      expect(() => new OllamaEmbeddingProvider(config)).toThrow("Only http and https are allowed");
+    });
+
+    test("throws on javascript URL scheme", () => {
+      const config: OllamaProviderConfig = {
+        ...DEFAULT_CONFIG,
+        baseUrl: "javascript:alert(1)",
+      };
+
+      expect(() => new OllamaEmbeddingProvider(config)).toThrow(EmbeddingValidationError);
+    });
+
+    test("accepts https URL scheme", () => {
+      const config: OllamaProviderConfig = {
+        ...DEFAULT_CONFIG,
+        baseUrl: "https://ollama.example.com:443",
+      };
+
+      const provider = new OllamaEmbeddingProvider(config);
+      expect(provider).toBeDefined();
+    });
+
     test("accepts valid custom base URL", () => {
       const config: OllamaProviderConfig = {
         ...DEFAULT_CONFIG,


### PR DESCRIPTION
## Summary

This PR applies all code review recommendations from PR #198 that were identified but not committed before merge.

### Fixes Applied

| # | Severity | File | Change |
|---|----------|------|--------|
| 1 | Medium | `src/providers/ollama-embedding.ts` | Added URL scheme validation - restricts baseUrl to http/https protocols only |
| 2 | Medium | `src/providers/ollama-embedding.ts` | Added jitter to exponential backoff - prevents thundering herd with 0-50% random jitter |
| 3 | Low | `src/providers/ollama-embedding.ts` | Changed to use EmbeddingTimeoutError instead of generic EmbeddingError for timeout scenarios |
| 4 | Low | `src/providers/EmbeddingProviderFactory.ts` | Added validation for OLLAMA_HOST (no URL special chars) and OLLAMA_PORT (numeric only) |
| 5 | Low | `src/providers/factory.ts` | Consolidated factory - now delegates to EmbeddingProviderFactory, eliminating code duplication |

### Security Improvements

- **URL Scheme Validation**: The Ollama provider now validates that `baseUrl` uses only `http:` or `https:` protocols. This prevents potential security issues from malicious URL schemes like `file://`, `javascript:`, or `ftp://`.

- **Input Validation**: Added validation for `OLLAMA_HOST` and `OLLAMA_PORT` environment variables to prevent URL injection attacks through malformed environment values.

### Performance Improvements

- **Jitter in Backoff**: Added random jitter (0-50% of base delay) to exponential backoff to prevent thundering herd problems when multiple clients retry simultaneously.

### Code Quality Improvements

- **Factory Consolidation**: The `factory.ts` module now delegates to `EmbeddingProviderFactory`, eliminating code duplication and ensuring consistent behavior between the function API and class-based API.

- **Semantic Error Types**: Timeout errors now use `EmbeddingTimeoutError` instead of generic `EmbeddingError` for better error handling and categorization.

## Test plan

- [x] All 218 provider unit tests pass
- [x] TypeScript type checking passes (`bun run typecheck`)
- [x] ESLint passes via lint-staged
- [x] New tests for URL scheme validation
- [x] New tests for HOST/PORT validation
- [x] CI/CD pipeline passes

## Related

- Follow-up to PR #198
- Addresses code review feedback from master-code-reviewer agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)