### PR TITLE
feat(search): implement provider-aware query embedding (#168)

### DIFF
--- a/src/cli/utils/dependency-init.ts
+++ b/src/cli/utils/dependency-init.ts
@@ -228,7 +228,12 @@ export async function initializeDependencies(
     logger.debug("Repository metadata service initialized");
 
     // Step 6: Initialize search service
-    const searchService = new SearchServiceImpl(embeddingProvider, chromaClient, repositoryService);
+    const searchService = new SearchServiceImpl(
+      embeddingProvider,
+      embeddingProviderFactory,
+      chromaClient,
+      repositoryService
+    );
     logger.debug("Search service initialized");
 
     // Step 7: Initialize ingestion service components

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import "dotenv/config";
 import { PersonalKnowledgeMCPServer } from "./mcp/server.js";
 import { SearchServiceImpl } from "./services/search-service.js";
 import { createEmbeddingProvider } from "./providers/factory.js";
+import { embeddingProviderFactory } from "./providers/EmbeddingProviderFactory.js";
 import { RepositoryMetadataStoreImpl } from "./repositories/metadata-store.js";
 import { initializeLogger, getComponentLogger, type LogLevel } from "./logging/index.js";
 import {
@@ -206,7 +207,12 @@ async function main(): Promise<void> {
 
     // Step 5: Initialize search service
     logger.info("Initializing search service");
-    const searchService = new SearchServiceImpl(embeddingProvider, chromaClient, repositoryService);
+    const searchService = new SearchServiceImpl(
+      embeddingProvider,
+      embeddingProviderFactory,
+      chromaClient,
+      repositoryService
+    );
     logger.info("Search service initialized");
 
     // Step 6: Create MCP server

--- a/src/services/errors.ts
+++ b/src/services/errors.ts
@@ -83,3 +83,36 @@ export class SearchOperationError extends SearchError {
     this.cause = cause;
   }
 }
+
+/**
+ * Thrown when embedding dimensions don't match between provider and collection
+ * Not retryable - indicates configuration mismatch
+ */
+export class DimensionMismatchError extends SearchError {
+  constructor(
+    public readonly repositoryName: string,
+    public readonly expectedDimensions: number,
+    public readonly actualDimensions: number
+  ) {
+    super(
+      `Dimension mismatch for repository '${repositoryName}': expected ${expectedDimensions}, got ${actualDimensions}`,
+      false
+    );
+  }
+}
+
+/**
+ * Thrown when required embedding provider is not available
+ * Not retryable - provider must be configured
+ */
+export class ProviderUnavailableError extends SearchError {
+  constructor(
+    public readonly providerId: string,
+    public readonly reason?: string
+  ) {
+    super(
+      `Embedding provider '${providerId}' is not available${reason ? `: ${reason}` : ""}`,
+      false
+    );
+  }
+}

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -14,7 +14,11 @@ import type { CloneResult, FileInfo, FileChunk } from "../ingestion/types.js";
 import type { FileScanner } from "../ingestion/file-scanner.js";
 import type { FileChunker } from "../ingestion/file-chunker.js";
 import type { EmbeddingProvider } from "../providers/types.js";
-import type { ChromaStorageClient, DocumentInput } from "../storage/types.js";
+import type {
+  ChromaStorageClient,
+  DocumentInput,
+  CollectionEmbeddingMetadata,
+} from "../storage/types.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../repositories/types.js";
 import { getComponentLogger } from "../logging/index.js";
 import type {
@@ -268,7 +272,14 @@ export class IngestionService {
       }
 
       try {
-        await this.storageClient.getOrCreateCollection(collectionName);
+        // Build embedding metadata for provider-aware search
+        const embeddingMetadata: CollectionEmbeddingMetadata = {
+          "app:embedding_provider": this.embeddingProvider.providerId,
+          "app:embedding_model": this.embeddingProvider.modelId,
+          "app:embedding_dimensions": this.embeddingProvider.dimensions,
+        };
+
+        await this.storageClient.getOrCreateCollection(collectionName, embeddingMetadata);
       } catch (err) {
         throw new CollectionCreationError(collectionName, err);
       }

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -2,15 +2,23 @@
  * SearchService implementation for semantic search operations
  *
  * This module provides the core business logic for searching indexed repositories
- * using vector similarity search via ChromaDB.
+ * using vector similarity search via ChromaDB. It supports multi-provider search
+ * where repositories indexed with different embedding providers are searched
+ * using their respective providers for accurate similarity matching.
  */
 
 import { z } from "zod";
 import type { Logger } from "pino";
-import type { EmbeddingProvider } from "../providers/types.js";
+import type { EmbeddingProvider, EmbeddingProviderConfig } from "../providers/types.js";
 import type { ChromaStorageClient, SimilarityResult } from "../storage/types.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../repositories/types.js";
-import type { SearchService, SearchQuery, SearchResponse, SearchResult } from "./types.js";
+import type {
+  SearchService,
+  SearchQuery,
+  SearchResponse,
+  SearchResult,
+  SearchWarning,
+} from "./types.js";
 import { SearchQuerySchema, type ValidatedSearchQuery } from "./validation.js";
 import {
   SearchValidationError,
@@ -18,11 +26,75 @@ import {
   RepositoryNotReadyError,
   NoRepositoriesAvailableError,
   SearchOperationError,
+  DimensionMismatchError,
+  ProviderUnavailableError,
 } from "./errors.js";
 import { getComponentLogger } from "../logging/index.js";
 
 /**
+ * Interface for creating embedding providers on-demand
+ * Used for multi-provider search to create providers dynamically
+ */
+interface EmbeddingProviderFactory {
+  createProvider(config: EmbeddingProviderConfig): EmbeddingProvider;
+}
+
+/**
+ * Group of repositories that share the same embedding provider
+ */
+interface ProviderGroup {
+  /** Provider identifier (e.g., "openai", "transformersjs") */
+  providerId: string;
+
+  /** Embedding model ID */
+  modelId: string;
+
+  /** Expected embedding dimensions */
+  dimensions: number;
+
+  /** Repositories in this group */
+  repositories: RepositoryInfo[];
+}
+
+/**
+ * Search results from a single provider group
+ */
+interface ProviderSearchResult {
+  /** Provider group that produced these results */
+  group: ProviderGroup;
+
+  /** Raw similarity results */
+  results: SimilarityResult[];
+
+  /** Time spent generating embedding in ms */
+  embeddingTimeMs: number;
+
+  /** Time spent in vector search in ms */
+  searchTimeMs: number;
+}
+
+/**
  * Implementation of SearchService using ChromaDB for vector similarity search
+ *
+ * This implementation supports multi-provider search, where repositories indexed
+ * with different embedding providers (e.g., OpenAI, Transformers.js, Ollama)
+ * are queried using their respective providers for accurate similarity matching.
+ *
+ * @example
+ * ```typescript
+ * const searchService = new SearchServiceImpl(
+ *   defaultProvider,
+ *   embeddingProviderFactory,
+ *   storageClient,
+ *   repositoryService
+ * );
+ *
+ * const response = await searchService.search({
+ *   query: "authentication middleware",
+ *   limit: 10,
+ *   threshold: 0.7,
+ * });
+ * ```
  */
 export class SearchServiceImpl implements SearchService {
   /**
@@ -34,8 +106,15 @@ export class SearchServiceImpl implements SearchService {
 
   private _logger: Logger | null = null;
 
+  /**
+   * Cache of created providers to avoid recreating for same provider/model combo
+   * Key format: "{providerId}:{modelId}:{dimensions}"
+   */
+  private readonly providerCache = new Map<string, EmbeddingProvider>();
+
   constructor(
-    private readonly embeddingProvider: EmbeddingProvider,
+    private readonly defaultEmbeddingProvider: EmbeddingProvider,
+    private readonly embeddingProviderFactory: EmbeddingProviderFactory,
     private readonly storageClient: ChromaStorageClient,
     private readonly repositoryService: RepositoryMetadataService
   ) {}
@@ -52,9 +131,19 @@ export class SearchServiceImpl implements SearchService {
 
   /**
    * Execute semantic search query across indexed repositories
+   *
+   * For multi-provider search:
+   * 1. Groups repositories by their embedding provider
+   * 2. Generates query embeddings with each provider
+   * 3. Searches each group's collections
+   * 4. Merges and sorts results by similarity
+   *
+   * @param query - Search parameters including query text and filters
+   * @returns Search results with ranked chunks and performance metadata
    */
   async search(query: SearchQuery): Promise<SearchResponse> {
     const startTime = performance.now();
+    const warnings: SearchWarning[] = [];
 
     try {
       // 1. Validate input
@@ -67,61 +156,66 @@ export class SearchServiceImpl implements SearchService {
         throw new NoRepositoriesAvailableError();
       }
 
-      // 3. Generate query embedding
-      const embeddingStart = performance.now();
-      const embedding = await this.embeddingProvider.generateEmbedding(validated.query);
-      const embeddingTime = performance.now() - embeddingStart;
+      // 3. Group repositories by embedding provider
+      const providerGroups = this.groupRepositoriesByProvider(targetRepos, warnings);
 
-      // Validate embedding dimensions match provider specification
-      if (embedding.length !== this.embeddingProvider.dimensions) {
-        throw new SearchOperationError(
-          `Embedding dimension mismatch: expected ${this.embeddingProvider.dimensions}, got ${embedding.length}`,
-          false // Not retryable - indicates provider configuration error
+      this.logger.info("Grouped repositories by provider", {
+        total_repos: targetRepos.length,
+        provider_groups: providerGroups.length,
+        groups: providerGroups.map((g) => ({
+          provider: g.providerId,
+          model: g.modelId,
+          dimensions: g.dimensions,
+          repo_count: g.repositories.length,
+        })),
+      });
+
+      // 4. Search each provider group
+      const allResults: ProviderSearchResult[] = [];
+      let totalEmbeddingTime = 0;
+      let totalSearchTime = 0;
+
+      for (const group of providerGroups) {
+        const result = await this.searchProviderGroup(
+          group,
+          validated.query,
+          validated.limit ?? 10,
+          validated.threshold ?? 0.7,
+          warnings
         );
+
+        if (result) {
+          allResults.push(result);
+          totalEmbeddingTime += result.embeddingTimeMs;
+          totalSearchTime += result.searchTimeMs;
+        }
       }
 
-      this.logger.info("Generated query embedding", {
-        query_length: validated.query.length,
-        embedding_dim: embedding.length,
-        duration_ms: Math.round(embeddingTime),
-      });
+      // 5. Merge and sort results from all providers
+      const mergedResults = this.mergeResults(allResults, validated.limit ?? 10);
 
-      // 4. Execute vector similarity search
-      const searchStart = performance.now();
-      const collections = targetRepos.map((r) => r.collectionName);
-      const rawResults = await this.storageClient.similaritySearch({
-        embedding,
-        collections,
-        limit: validated.limit ?? 10,
-        threshold: validated.threshold ?? 0.7,
-      });
-      const searchTime = performance.now() - searchStart;
+      // 6. Format results
+      const formattedResults = this.formatResults(mergedResults);
 
-      this.logger.info("Completed vector search", {
-        collections_searched: collections.length,
-        raw_results: rawResults.length,
-        duration_ms: Math.round(searchTime),
-      });
-
-      // 5. Format results
-      const results = this.formatResults(rawResults);
-
-      // 6. Assemble response with metadata
+      // 7. Assemble response with metadata
       const totalTime = performance.now() - startTime;
       const response: SearchResponse = {
-        results,
+        results: formattedResults,
         metadata: {
-          total_matches: results.length,
+          total_matches: formattedResults.length,
           query_time_ms: Math.round(totalTime),
-          embedding_time_ms: Math.round(embeddingTime),
-          search_time_ms: Math.round(searchTime),
+          embedding_time_ms: Math.round(totalEmbeddingTime),
+          search_time_ms: Math.round(totalSearchTime),
           repositories_searched: targetRepos.map((r) => r.name),
+          warnings: warnings.length > 0 ? warnings : undefined,
         },
       };
 
       this.logger.info("Search completed successfully", {
-        total_results: results.length,
+        total_results: formattedResults.length,
         total_time_ms: response.metadata.query_time_ms,
+        provider_groups_searched: providerGroups.length,
+        warnings_count: warnings.length,
         repositories: response.metadata.repositories_searched,
       });
 
@@ -135,7 +229,9 @@ export class SearchServiceImpl implements SearchService {
         error instanceof RepositoryNotFoundError ||
         error instanceof RepositoryNotReadyError ||
         error instanceof NoRepositoriesAvailableError ||
-        error instanceof SearchOperationError
+        error instanceof SearchOperationError ||
+        error instanceof DimensionMismatchError ||
+        error instanceof ProviderUnavailableError
       ) {
         this.logger.error("Search failed with known error", {
           error_type: error.constructor.name,
@@ -217,6 +313,231 @@ export class SearchServiceImpl implements SearchService {
 
       return readyRepos;
     }
+  }
+
+  /**
+   * Group repositories by their embedding provider
+   *
+   * Repositories are grouped by provider ID, model ID, and dimensions.
+   * Repositories without embedding provider metadata use the default provider.
+   *
+   * @param repos - Repositories to group
+   * @param warnings - Array to collect warnings about missing metadata
+   * @returns Array of provider groups
+   */
+  private groupRepositoriesByProvider(
+    repos: RepositoryInfo[],
+    warnings: SearchWarning[]
+  ): ProviderGroup[] {
+    const groups = new Map<string, ProviderGroup>();
+
+    for (const repo of repos) {
+      // Use repository's embedding provider or fall back to default
+      const providerId = repo.embeddingProvider ?? this.defaultEmbeddingProvider.providerId;
+      const modelId = repo.embeddingModel ?? this.defaultEmbeddingProvider.modelId;
+      const dimensions = repo.embeddingDimensions ?? this.defaultEmbeddingProvider.dimensions;
+
+      // Generate warning if using default provider due to missing metadata
+      if (!repo.embeddingProvider) {
+        warnings.push({
+          type: "missing_metadata",
+          repository: repo.name,
+          message: `Repository '${repo.name}' has no embedding provider metadata. Using default provider '${providerId}'.`,
+        });
+      }
+
+      // Group key includes provider, model, and dimensions for uniqueness
+      const groupKey = `${providerId}:${modelId}:${dimensions}`;
+
+      if (!groups.has(groupKey)) {
+        groups.set(groupKey, {
+          providerId,
+          modelId,
+          dimensions,
+          repositories: [],
+        });
+      }
+
+      groups.get(groupKey)!.repositories.push(repo);
+    }
+
+    return Array.from(groups.values());
+  }
+
+  /**
+   * Get or create an embedding provider for a provider group
+   *
+   * Uses caching to avoid creating duplicate providers for the same
+   * provider/model/dimensions combination.
+   *
+   * @param group - Provider group to get provider for
+   * @returns Embedding provider instance
+   * @throws {ProviderUnavailableError} If provider cannot be created
+   */
+  private getOrCreateProvider(group: ProviderGroup): EmbeddingProvider {
+    const cacheKey = `${group.providerId}:${group.modelId}:${group.dimensions}`;
+
+    // Check cache first
+    const cached = this.providerCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Check if this matches the default provider
+    if (
+      group.providerId === this.defaultEmbeddingProvider.providerId &&
+      group.modelId === this.defaultEmbeddingProvider.modelId &&
+      group.dimensions === this.defaultEmbeddingProvider.dimensions
+    ) {
+      this.providerCache.set(cacheKey, this.defaultEmbeddingProvider);
+      return this.defaultEmbeddingProvider;
+    }
+
+    // Create new provider via factory
+    try {
+      const config: EmbeddingProviderConfig = {
+        provider: group.providerId,
+        model: group.modelId,
+        dimensions: group.dimensions,
+        batchSize: 100, // Default batch size
+        maxRetries: 3,
+        timeoutMs: 30000,
+      };
+
+      const provider = this.embeddingProviderFactory.createProvider(config);
+      this.providerCache.set(cacheKey, provider);
+
+      this.logger.debug("Created new embedding provider", {
+        provider: group.providerId,
+        model: group.modelId,
+        dimensions: group.dimensions,
+      });
+
+      return provider;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new ProviderUnavailableError(group.providerId, message);
+    }
+  }
+
+  /**
+   * Search a single provider group
+   *
+   * Generates query embedding with the group's provider and searches
+   * all repositories in the group.
+   *
+   * @param group - Provider group to search
+   * @param queryText - Query text to embed
+   * @param limit - Maximum results per search
+   * @param threshold - Minimum similarity threshold
+   * @param warnings - Array to collect warnings
+   * @returns Search results or null if provider unavailable
+   */
+  private async searchProviderGroup(
+    group: ProviderGroup,
+    queryText: string,
+    limit: number,
+    threshold: number,
+    warnings: SearchWarning[]
+  ): Promise<ProviderSearchResult | null> {
+    try {
+      // Get or create provider for this group
+      const provider = this.getOrCreateProvider(group);
+
+      // Generate query embedding
+      const embeddingStart = performance.now();
+      const embedding = await provider.generateEmbedding(queryText);
+      const embeddingTime = performance.now() - embeddingStart;
+
+      // Validate embedding dimensions
+      if (embedding.length !== group.dimensions) {
+        throw new DimensionMismatchError(
+          group.repositories.map((r) => r.name).join(", "),
+          group.dimensions,
+          embedding.length
+        );
+      }
+
+      this.logger.debug("Generated query embedding for provider group", {
+        provider: group.providerId,
+        model: group.modelId,
+        embedding_dim: embedding.length,
+        duration_ms: Math.round(embeddingTime),
+        repo_count: group.repositories.length,
+      });
+
+      // Execute vector similarity search
+      const searchStart = performance.now();
+      const collections = group.repositories.map((r) => r.collectionName);
+      const results = await this.storageClient.similaritySearch({
+        embedding,
+        collections,
+        limit,
+        threshold,
+      });
+      const searchTime = performance.now() - searchStart;
+
+      this.logger.debug("Completed vector search for provider group", {
+        provider: group.providerId,
+        collections_searched: collections.length,
+        raw_results: results.length,
+        duration_ms: Math.round(searchTime),
+      });
+
+      return {
+        group,
+        results,
+        embeddingTimeMs: embeddingTime,
+        searchTimeMs: searchTime,
+      };
+    } catch (error) {
+      // If it's a dimension mismatch or provider unavailable, rethrow
+      if (error instanceof DimensionMismatchError || error instanceof ProviderUnavailableError) {
+        throw error;
+      }
+
+      // For other errors, log warning and continue with other groups
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn("Failed to search provider group", {
+        provider: group.providerId,
+        error: message,
+      });
+
+      // Add warning for each repository in the failed group
+      for (const repo of group.repositories) {
+        warnings.push({
+          type: "provider_mismatch",
+          repository: repo.name,
+          message: `Failed to search repository '${repo.name}' with provider '${group.providerId}': ${message}`,
+        });
+      }
+
+      return null;
+    }
+  }
+
+  /**
+   * Merge and sort results from multiple provider groups
+   *
+   * Combines results from all provider groups and sorts by similarity
+   * score in descending order, then limits to the requested number.
+   *
+   * @param providerResults - Results from each provider group
+   * @param limit - Maximum results to return
+   * @returns Merged and sorted similarity results
+   */
+  private mergeResults(providerResults: ProviderSearchResult[], limit: number): SimilarityResult[] {
+    // Flatten all results
+    const allResults: SimilarityResult[] = [];
+    for (const pr of providerResults) {
+      allResults.push(...pr.results);
+    }
+
+    // Sort by similarity descending
+    allResults.sort((a, b) => b.similarity - a.similarity);
+
+    // Limit results
+    return allResults.slice(0, limit);
   }
 
   /**

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -50,6 +50,20 @@ export interface SearchResult {
 }
 
 /**
+ * Warning generated during provider-aware search operations
+ */
+export interface SearchWarning {
+  /** Type of warning encountered */
+  type: "provider_mismatch" | "dimension_mismatch" | "missing_metadata";
+
+  /** Repository that triggered the warning */
+  repository: string;
+
+  /** Human-readable warning message */
+  message: string;
+}
+
+/**
  * Search response with results and diagnostic metadata
  */
 export interface SearchResponse {
@@ -72,6 +86,9 @@ export interface SearchResponse {
 
     /** List of repository names that were searched */
     repositories_searched: string[];
+
+    /** Warnings generated during search (e.g., provider mismatches) */
+    warnings?: SearchWarning[];
   };
 }
 

--- a/tests/services/ingestion-service.test.ts
+++ b/tests/services/ingestion-service.test.ts
@@ -31,7 +31,12 @@ import {
 } from "../../src/services/ingestion-errors.js";
 import type { IndexProgress } from "../../src/services/ingestion-types.js";
 import type { EmbeddingProvider } from "../../src/providers/types.js";
-import type { ChromaStorageClient, DocumentInput } from "../../src/storage/types.js";
+import type {
+  ChromaStorageClient,
+  DocumentInput,
+  ParsedEmbeddingMetadata,
+  CollectionEmbeddingMetadata,
+} from "../../src/storage/types.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../../src/repositories/types.js";
 import type { CloneResult, FileInfo, FileChunk } from "../../src/ingestion/types.js";
 import { initializeLogger, resetLogger } from "../../src/logging/index.js";
@@ -204,7 +209,10 @@ class MockChromaStorageClient implements ChromaStorageClient {
     return true;
   }
 
-  async getOrCreateCollection(name: string): Promise<any> {
+  async getOrCreateCollection(
+    name: string,
+    _embeddingMetadata?: CollectionEmbeddingMetadata
+  ): Promise<any> {
     if (this.shouldFailCreate) {
       throw new Error("Failed to create collection");
     }
@@ -243,6 +251,10 @@ class MockChromaStorageClient implements ChromaStorageClient {
 
   async getDocumentsByMetadata(): Promise<any[]> {
     return [];
+  }
+
+  async getCollectionEmbeddingMetadata(): Promise<ParsedEmbeddingMetadata | null> {
+    return null;
   }
 
   async deleteDocumentsByFilePrefix(): Promise<number> {


### PR DESCRIPTION
## Summary

- Implements multi-provider search support in SearchService for accurate semantic search across repositories indexed with different embedding providers
- Adds infrastructure to store and retrieve embedding provider metadata from ChromaDB collections
- Groups repositories by provider and generates query embeddings using the correct provider per group
- Merges results from multiple provider searches, sorted by similarity score

## Changes

### New Types & Interfaces
- `CollectionEmbeddingMetadata` - Storage format for embedding provider info in ChromaDB
- `ParsedEmbeddingMetadata` - Application-friendly parsed metadata
- `SearchWarning` - Structured warnings for missing metadata or provider issues
- `ProviderGroup` - Internal grouping structure for multi-provider search
- `EmbeddingProviderFactory` interface for dynamic provider creation

### New Error Types
- `DimensionMismatchError` - When embedding dimensions don't match collection expectations
- `ProviderUnavailableError` - When a required provider cannot be created

### SearchService Enhancements
- `groupRepositoriesByProvider()` - Groups repositories by their embedding provider/model/dimensions
- `getOrCreateProvider()` - Provider caching and on-demand creation
- `searchProviderGroup()` - Executes search for a single provider group
- `mergeResults()` - Combines and sorts results from multiple provider groups

### Storage Layer
- `getOrCreateCollection()` now accepts optional embedding metadata
- `getCollectionEmbeddingMetadata()` retrieves stored provider info

## Test plan

- [x] Run `bun run typecheck` - passes
- [x] Run `bun test tests/services/search-service.test.ts` - all 30 tests pass
- [x] Run `bun test tests/services/ingestion-service.test.ts` - all 37 tests pass
- [ ] CI/CD pipeline (automated)

## Acceptance Criteria

- [x] Store embedding provider in collection metadata
- [x] On search, determine which provider(s) are needed
- [x] Embed query with appropriate provider(s)
- [x] Handle multi-provider searches
- [x] Warn if querying with different provider
- [x] Validate dimension compatibility

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)