### PR TITLE
feat(db): add watched_folders table migration for Phase 6

### DIFF
--- a/docs/architecture/database-schema.md
+++ b/docs/architecture/database-schema.md
@@ -67,10 +67,11 @@ SELECT EXISTS(
 | `enabled` | BOOLEAN | NOT NULL | `true` | Whether watching is active |
 | `include_patterns` | TEXT[] | - | NULL | Glob patterns to include (e.g., `['*.pdf', '*.docx']`) |
 | `exclude_patterns` | TEXT[] | - | NULL | Glob patterns to exclude (e.g., `['.git/*', '*.tmp']`) |
-| `debounce_ms` | INTEGER | NOT NULL | `2000` | Debounce delay in milliseconds |
+| `debounce_ms` | INTEGER | NOT NULL, CHECK (100-300000) | `2000` | Debounce delay in milliseconds (100ms-5min) |
 | `created_at` | TIMESTAMP WITH TIME ZONE | NOT NULL | `CURRENT_TIMESTAMP` | When folder was registered |
 | `last_scan_at` | TIMESTAMP WITH TIME ZONE | - | NULL | Last full scan timestamp |
-| `file_count` | INTEGER | - | `0` | Cached count of tracked files |
+| `file_count` | INTEGER | CHECK (>= 0) | `0` | Cached count of tracked files |
+| `updated_at` | TIMESTAMP WITH TIME ZONE | - | NULL | When configuration was last modified |
 
 **Indexes**:
 

--- a/init-scripts/002-phase6-watched-folders.sql
+++ b/init-scripts/002-phase6-watched-folders.sql
@@ -36,7 +36,8 @@ CREATE TABLE IF NOT EXISTS watched_folders (
 
     -- Debounce delay in milliseconds before processing file changes
     -- Prevents rapid re-processing when files are being actively modified
-    debounce_ms INTEGER NOT NULL DEFAULT 2000,
+    -- Valid range: 100ms minimum (practical debounce) to 300000ms (5 minutes max)
+    debounce_ms INTEGER NOT NULL DEFAULT 2000 CHECK (debounce_ms >= 100 AND debounce_ms <= 300000),
 
     -- Timestamp when this folder configuration was created
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -47,7 +48,11 @@ CREATE TABLE IF NOT EXISTS watched_folders (
 
     -- Cached count of files currently tracked in this folder
     -- Updated during scans, not a live count
-    file_count INTEGER DEFAULT 0
+    file_count INTEGER DEFAULT 0 CHECK (file_count >= 0),
+
+    -- Timestamp when this configuration was last modified
+    -- Updated by application code on any configuration change (name, patterns, enabled, etc.)
+    updated_at TIMESTAMP WITH TIME ZONE
 );
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

- Create PostgreSQL migration (`002-phase6-watched-folders.sql`) for the `watched_folders` table that stores configuration for the folder watching feature
- Add comprehensive database schema documentation (`docs/architecture/database-schema.md`) covering all PostgreSQL tables
- Schema matches PRD Section 5.4 specification exactly with TIMESTAMP WITH TIME ZONE for consistency

## Changes

### Migration File (`init-scripts/002-phase6-watched-folders.sql`)
- `watched_folders` table with all PRD-specified columns:
  - UUID primary key with `gen_random_uuid()` default
  - Unique path constraint for folder deduplication
  - `TEXT[]` arrays for include/exclude glob patterns
  - Debounce configuration (default 2000ms)
  - Timestamps for creation and last scan tracking
- Partial index on `enabled` column for query optimization
- Schema version tracking via `_schema_info` table
- Fully idempotent (safe to run multiple times)

### Documentation (`docs/architecture/database-schema.md`)
- Table specifications with column descriptions
- Index rationale and usage patterns
- SQL usage examples for common operations
- Migration strategy and naming conventions
- PostgreSQL data type reference (arrays, UUIDs, timestamps)

## Test Plan

- [ ] Start fresh PostgreSQL container: `docker compose --profile default up -d postgres`
- [ ] Verify table exists: `docker exec pk-mcp-postgres psql -U pk_mcp -d personal_knowledge -c "\d watched_folders"`
- [ ] Verify schema version tracked: `docker exec pk-mcp-postgres psql -U pk_mcp -d personal_knowledge -c "SELECT * FROM _schema_info;"`
- [ ] Test idempotency by re-running migration manually
- [ ] Test basic CRUD operations with sample data

## Related Issues

Closes #281

**Epic**: #248 (M4: Folder Watching)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)