### PR TITLE
fix(storage): add retry logic to ChromaDB collection operations

### DIFF
--- a/src/storage/chroma-client.ts
+++ b/src/storage/chroma-client.ts
@@ -273,7 +273,11 @@ export class ChromaStorageClientImpl implements ChromaStorageClient {
 
     try {
       // Check if collection exists by listing all collections
-      const collections = await this.client!.listCollectionsAndMetadata();
+      // Use retry wrapper for transient network failures
+      const collections = await this.withRetryWrapper(
+        () => this.client!.listCollectionsAndMetadata(),
+        "ChromaDB list collections"
+      );
       const exists = collections.some((col) => col.name === name);
 
       if (!exists) {
@@ -342,10 +346,15 @@ export class ChromaStorageClientImpl implements ChromaStorageClient {
       }
 
       // Get or create collection with cosine similarity metric and embedding metadata
-      const collection = await this.client!.getOrCreateCollection({
-        name,
-        metadata,
-      });
+      // Use retry wrapper for transient network failures
+      const collection = await this.withRetryWrapper(
+        () =>
+          this.client!.getOrCreateCollection({
+            name,
+            metadata,
+          }),
+        "ChromaDB get or create collection"
+      );
 
       // Cache the collection handle
       this.collections.set(name, collection);
@@ -375,7 +384,11 @@ export class ChromaStorageClientImpl implements ChromaStorageClient {
     this.ensureConnected();
 
     try {
-      await this.client!.deleteCollection({ name });
+      // Use retry wrapper for transient network failures
+      await this.withRetryWrapper(
+        () => this.client!.deleteCollection({ name }),
+        "ChromaDB delete collection"
+      );
 
       // Remove from cache
       this.collections.delete(name);
@@ -401,7 +414,11 @@ export class ChromaStorageClientImpl implements ChromaStorageClient {
 
     try {
       // Use listCollectionsAndMetadata() to get name, id, and metadata
-      const collections = await this.client!.listCollectionsAndMetadata();
+      // Use retry wrapper for transient network failures
+      const collections = await this.withRetryWrapper(
+        () => this.client!.listCollectionsAndMetadata(),
+        "ChromaDB list collections"
+      );
 
       return collections.map((collection) => {
         return {
@@ -1228,7 +1245,11 @@ export class ChromaStorageClientImpl implements ChromaStorageClient {
 
     try {
       // List all collections to check if the target exists and get its metadata
-      const collections = await this.client!.listCollectionsAndMetadata();
+      // Use retry wrapper for transient network failures
+      const collections = await this.withRetryWrapper(
+        () => this.client!.listCollectionsAndMetadata(),
+        "ChromaDB list collections for metadata"
+      );
       const collectionInfo = collections.find((col) => col.name === name);
 
       if (!collectionInfo) {


### PR DESCRIPTION
## Summary

Add `withRetryWrapper` to ChromaDB collection operations to handle transient network failures that cause false "Collection not found" errors during incremental updates.

### Root Cause (Issue #444)

The `getCollectionIfExists` method called `listCollectionsAndMetadata()` without retry logic. When this API call experienced a transient failure, the collection appeared to not exist, causing `CollectionNotFoundError` even though the collection was valid.

**Error flow:**
1. `processModifiedFile` → `deleteDocumentsByFilePrefix` → `getDocumentsByMetadata` → `getCollectionIfExists`
2. `getCollectionIfExists` calls `listCollectionsAndMetadata()` WITHOUT retry
3. Transient failure → empty/error response → `CollectionNotFoundError`

### Changes

- **`getCollectionIfExists`**: Added retry wrapper - this is the primary fix for issue #444
- **`getOrCreateCollection`**: Added retry wrapper for consistency
- **`listCollections`**: Added retry wrapper for consistency
- **`deleteCollection`**: Added retry wrapper for consistency
- **`getCollectionEmbeddingMetadata`**: Added retry wrapper for consistency

### Testing

- Added `setListCollectionsTransientFailures()`, `setGetOrCreateCollectionTransientFailures()`, and `setDeleteCollectionTransientFailures()` to MockChromaClient to simulate transient failures
- Added new test cases for retry behavior in all affected methods
- All 2544 unit tests pass
- All existing tests continue to pass

## Test Plan

- [x] TypeScript type check passes (`bun run typecheck`)
- [x] Unit tests pass (`bun test tests/unit`)
- [x] Build succeeds (`bun run build`)
- [ ] Manual verification: Run `bun run cli update <repository>` and verify no "Collection not found" errors for modified files

Fixes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)