### PR TITLE
fix(pipeline): fall back to DEFAULT_EXTENSIONS when empty (#453)

### DIFF
--- a/src/ingestion/default-extensions.ts
+++ b/src/ingestion/default-extensions.ts
@@ -1,0 +1,45 @@
+/**
+ * Default file extensions for repository indexing.
+ *
+ * Shared constant used by FileScanner (initial indexing) and
+ * IncrementalUpdatePipeline (incremental updates) to ensure
+ * consistent file filtering across both code paths.
+ *
+ * @module ingestion/default-extensions
+ */
+
+/**
+ * Default file extensions to include in scans.
+ *
+ * Covers common source code, documentation, and configuration files.
+ * Used as fallback when no custom extensions are specified or when
+ * repository metadata has an empty includeExtensions array.
+ */
+export const DEFAULT_EXTENSIONS = [
+  // JavaScript/TypeScript
+  ".js",
+  ".ts",
+  ".jsx",
+  ".tsx",
+  // C#
+  ".cs",
+  // Python
+  ".py",
+  // Other languages
+  ".java",
+  ".go",
+  ".rs",
+  // C/C++
+  ".cpp",
+  ".c",
+  ".h",
+  // Documentation
+  ".md",
+  ".txt",
+  ".rst",
+  // Configuration
+  ".json",
+  ".yaml",
+  ".yml",
+  ".toml",
+] as const;

--- a/src/ingestion/file-scanner.ts
+++ b/src/ingestion/file-scanner.ts
@@ -16,6 +16,7 @@ import type pino from "pino";
 import { getComponentLogger } from "../logging/index.js";
 import type { ScanOptions, FileInfo, FileScannerConfig } from "./types.js";
 import { ValidationError, FileScanError } from "./errors.js";
+import { DEFAULT_EXTENSIONS } from "./default-extensions.js";
 
 /**
  * Scans repository directories to identify files for indexing.
@@ -52,40 +53,6 @@ import { ValidationError, FileScanError } from "./errors.js";
 export class FileScanner {
   private readonly logger: pino.Logger;
   private readonly config: Required<FileScannerConfig>;
-
-  /**
-   * Default file extensions to include in scans.
-   *
-   * Covers common source code, documentation, and configuration files.
-   */
-  private readonly DEFAULT_EXTENSIONS = [
-    // JavaScript/TypeScript
-    ".js",
-    ".ts",
-    ".jsx",
-    ".tsx",
-    // C#
-    ".cs",
-    // Python
-    ".py",
-    // Other languages
-    ".java",
-    ".go",
-    ".rs",
-    // C/C++
-    ".cpp",
-    ".c",
-    ".h",
-    // Documentation
-    ".md",
-    ".txt",
-    ".rst",
-    // Configuration
-    ".json",
-    ".yaml",
-    ".yml",
-    ".toml",
-  ] as const;
 
   /**
    * Default patterns to exclude from scans.
@@ -177,7 +144,7 @@ export class FileScanner {
       const gitignore = await this.loadGitignore(normalizedRepoPath);
 
       // 3. Determine extensions and exclusions
-      const extensions = options.includeExtensions ?? [...this.DEFAULT_EXTENSIONS];
+      const extensions = options.includeExtensions ?? [...DEFAULT_EXTENSIONS];
       const exclusions = [...this.DEFAULT_EXCLUSIONS, ...(options.excludePatterns ?? [])];
 
       // 4. Execute glob scan

--- a/src/ingestion/index.ts
+++ b/src/ingestion/index.ts
@@ -9,6 +9,7 @@
 export { RepositoryCloner } from "./repository-cloner.js";
 export { FileScanner } from "./file-scanner.js";
 export { FileChunker } from "./file-chunker.js";
+export { DEFAULT_EXTENSIONS } from "./default-extensions.js";
 export { detectLanguage, SUPPORTED_LANGUAGES } from "./language-detector.js";
 export type { ProgrammingLanguage } from "./language-detector.js";
 export type {

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -271,6 +271,11 @@ export class IncrementalUpdateCoordinator {
           "No changes detected - repository is up-to-date"
         );
 
+        logger.debug(
+          { repository: repositoryName, localPath: repo.localPath },
+          "Skipping git pull - no changes detected. Local clone was not updated."
+        );
+
         // Note: inProgressFlagSet remains true, so the finally block will clear the
         // updateInProgress flag. This ensures consistent cleanup even for early returns.
         return {

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -21,6 +21,7 @@ import type {
 } from "../storage/types.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../repositories/types.js";
 import { getComponentLogger } from "../logging/index.js";
+import { DEFAULT_EXTENSIONS } from "../ingestion/default-extensions.js";
 import type {
   IndexOptions,
   IndexProgress,
@@ -892,7 +893,9 @@ export class IngestionService {
       indexDurationMs: params.stats.durationMs,
       status: params.stats.filesFailed > 0 ? "error" : "ready",
       errorMessage: params.errorMessage,
-      includeExtensions: params.options.includeExtensions || [],
+      includeExtensions: params.options.includeExtensions?.length
+        ? params.options.includeExtensions
+        : [...DEFAULT_EXTENSIONS],
       excludePatterns: params.options.excludePatterns || [],
       // Embedding provider metadata
       embeddingProvider: this.embeddingProvider.providerId,

--- a/tests/services/incremental-update-coordinator.test.ts
+++ b/tests/services/incremental-update-coordinator.test.ts
@@ -516,6 +516,29 @@ describe("IncrementalUpdateCoordinator", () => {
     });
   });
 
+  describe("empty includeExtensions handling", () => {
+    it("should pass empty includeExtensions to pipeline (pipeline handles fallback)", async () => {
+      // Simulate a repository with empty includeExtensions (the bug scenario)
+      const repoWithEmptyExtensions: RepositoryInfo = {
+        ...testRepo,
+        includeExtensions: [],
+      };
+      mockRepositoryService.getRepository = mock(async () => repoWithEmptyExtensions);
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("updated");
+
+      // Verify pipeline was called with the empty array (pipeline handles fallback internally)
+      expect(mockUpdatePipeline.processChanges).toHaveBeenCalledWith(
+        comparison.files,
+        expect.objectContaining({
+          includeExtensions: [],
+        })
+      );
+    });
+  });
+
   describe("error handling", () => {
     it("should re-throw GitHub API errors", async () => {
       const apiError = new Error("GitHub API error");

--- a/tests/unit/ingestion/default-extensions.test.ts
+++ b/tests/unit/ingestion/default-extensions.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for DEFAULT_EXTENSIONS shared constant
+ *
+ * @module tests/unit/ingestion/default-extensions
+ */
+
+import { describe, it, expect } from "bun:test";
+import { DEFAULT_EXTENSIONS } from "../../../src/ingestion/default-extensions.js";
+
+describe("DEFAULT_EXTENSIONS", () => {
+  it("should be a non-empty array", () => {
+    expect(Array.isArray(DEFAULT_EXTENSIONS)).toBe(true);
+    expect(DEFAULT_EXTENSIONS.length).toBeGreaterThan(0);
+  });
+
+  it("should contain exactly 19 extensions", () => {
+    expect(DEFAULT_EXTENSIONS).toHaveLength(19);
+  });
+
+  it("should contain all expected JavaScript/TypeScript extensions", () => {
+    expect(DEFAULT_EXTENSIONS).toContain(".js");
+    expect(DEFAULT_EXTENSIONS).toContain(".ts");
+    expect(DEFAULT_EXTENSIONS).toContain(".jsx");
+    expect(DEFAULT_EXTENSIONS).toContain(".tsx");
+  });
+
+  it("should contain C# extension", () => {
+    expect(DEFAULT_EXTENSIONS).toContain(".cs");
+  });
+
+  it("should contain Python extension", () => {
+    expect(DEFAULT_EXTENSIONS).toContain(".py");
+  });
+
+  it("should contain Java, Go, and Rust extensions", () => {
+    expect(DEFAULT_EXTENSIONS).toContain(".java");
+    expect(DEFAULT_EXTENSIONS).toContain(".go");
+    expect(DEFAULT_EXTENSIONS).toContain(".rs");
+  });
+
+  it("should contain C/C++ extensions", () => {
+    expect(DEFAULT_EXTENSIONS).toContain(".cpp");
+    expect(DEFAULT_EXTENSIONS).toContain(".c");
+    expect(DEFAULT_EXTENSIONS).toContain(".h");
+  });
+
+  it("should contain documentation extensions", () => {
+    expect(DEFAULT_EXTENSIONS).toContain(".md");
+    expect(DEFAULT_EXTENSIONS).toContain(".txt");
+    expect(DEFAULT_EXTENSIONS).toContain(".rst");
+  });
+
+  it("should contain configuration extensions", () => {
+    expect(DEFAULT_EXTENSIONS).toContain(".json");
+    expect(DEFAULT_EXTENSIONS).toContain(".yaml");
+    expect(DEFAULT_EXTENSIONS).toContain(".yml");
+    expect(DEFAULT_EXTENSIONS).toContain(".toml");
+  });
+
+  it("should have all extensions starting with a dot", () => {
+    for (const ext of DEFAULT_EXTENSIONS) {
+      expect(ext).toMatch(/^\./);
+    }
+  });
+
+  it("should have all extensions in lowercase", () => {
+    for (const ext of DEFAULT_EXTENSIONS) {
+      expect(ext).toBe(ext.toLowerCase() as typeof ext);
+    }
+  });
+
+  it("should be importable from barrel export", async () => {
+    const { DEFAULT_EXTENSIONS: barrelExport } = await import("../../../src/ingestion/index.js");
+    expect(barrelExport).toBe(DEFAULT_EXTENSIONS);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #453 - Incremental updates were completely non-functional because every repository stored `includeExtensions: []` in metadata, and `[].includes(anything)` always returns `false`, causing the pipeline's file filter to reject ALL files.

- **Extract shared `DEFAULT_EXTENSIONS` constant** from `FileScanner` into `src/ingestion/default-extensions.ts` for reuse across initial indexing and incremental updates
- **Fix `shouldProcessFile` in pipeline** to fall back to `DEFAULT_EXTENSIONS` when `includeExtensions` is empty, with a warning log when fallback is triggered
- **Fix metadata persistence in `ingestion-service.ts`** to store actual default extensions instead of `[]` when none specified, preventing the issue for newly indexed repositories
- **Add debug log** in coordinator for no-changes early return path (skipped git pull)
- **Add comprehensive tests** for empty extensions fallback behavior across pipeline, coordinator, and shared constant

## Test plan

- [x] `bun run typecheck` - no type errors
- [x] `bun test` - all 3479 tests pass (0 failures) across 134 files
- [x] `bun run build` - clean build
- [x] New test: empty `includeExtensions` falls back to defaults and processes files
- [x] New test: non-default extensions still filtered when falling back
- [x] New test: explicit `includeExtensions` still respected when provided
- [x] New test: coordinator passes empty extensions to pipeline
- [x] New test: shared constant has expected 19 extensions

## Files changed (9 files, ~258 additions, ~38 deletions)

| File | Change |
|------|--------|
| `src/ingestion/default-extensions.ts` | **New** - Shared DEFAULT_EXTENSIONS constant |
| `src/ingestion/index.ts` | Add barrel export |
| `src/ingestion/file-scanner.ts` | Use shared constant, remove private member |
| `src/services/incremental-update-pipeline.ts` | Fall back to defaults when empty |
| `src/services/ingestion-service.ts` | Store actual extensions in metadata |
| `src/services/incremental-update-coordinator.ts` | Add debug log for no-changes path |
| `tests/unit/ingestion/default-extensions.test.ts` | **New** - Test shared constant |
| `tests/services/incremental-update-pipeline.test.ts` | Add 3 empty extensions tests |
| `tests/services/incremental-update-coordinator.test.ts` | Add empty extensions test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)