### PR TITLE
fix(documents): add code review NOTE comments for PR #478

### DIFF
--- a/src/documents/extractors/ImageMetadataExtractor.ts
+++ b/src/documents/extractors/ImageMetadataExtractor.ts
@@ -293,6 +293,10 @@ export class ImageMetadataExtractor implements DocumentExtractor<ImageMetadata> 
       const timeoutId = setTimeout(() => {
         if (settled) return;
         settled = true;
+        // NOTE: In-flight sharp operations continue in background after timeout.
+        // Neither sharp nor the JS runtime provides a cancellation mechanism for
+        // native image processing. Consider worker threads for isolation if this
+        // becomes a production issue.
         reject(
           new ExtractionTimeoutError(
             `Image extraction timed out after ${this.config.timeoutMs}ms`,

--- a/tests/unit/documents/extractors.test.ts
+++ b/tests/unit/documents/extractors.test.ts
@@ -1360,6 +1360,8 @@ describe("ImageMetadataExtractor", () => {
         // Uses a very short timeout (1ms) to exercise the timeout path.
         // Due to JS event loop mechanics, sharp may complete before the timeout fires.
         // This test validates that both outcomes are handled correctly.
+        // NOTE: This test is non-deterministic. For reliable timeout coverage,
+        // a mock-based approach injecting a delayed sharp response is recommended.
         const extractor = new ImageMetadataExtractor({ timeoutMs: 1 });
         const filePath = path.join(IMAGES_DIR, "photo.jpg");
 


### PR DESCRIPTION
## Summary

- Adds NOTE comment to `extractWithTimeout()` documenting that in-flight sharp operations continue in background after timeout (consistent with DocxExtractor pattern)
- Adds NOTE comment to timeout test documenting its non-deterministic nature and recommending mock-based approach for reliable coverage

These are the 2 required changes from the [code review on PR #478](https://github.com/sethships/PersonalKnowledgeMCP/pull/478#issuecomment-3994480388) that were applied after the PR was merged.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test tests/unit/documents/extractors.test.ts` — 115/115 pass
- [x] Comment-only changes, no behavior modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)