### PR TITLE
fix(config): change DEFAULT_INSTANCE default from "public" to "private"

### DIFF
--- a/src/config/instance-config.ts
+++ b/src/config/instance-config.ts
@@ -186,7 +186,10 @@ export function loadInstanceConfig(): MultiInstanceConfig {
   const env = Bun.env;
 
   // Load default instance setting
-  const defaultInstanceRaw = env[ENV_KEYS.DEFAULT_INSTANCE] || "public";
+  // Default to "private" to align with CLI behavior (both use port 8000).
+  // Previously defaulted to "public" (port 8002), causing a mismatch where
+  // CLI indexed data to private instance but MCP searched public instance.
+  const defaultInstanceRaw = env[ENV_KEYS.DEFAULT_INSTANCE] || "private";
   const defaultInstanceResult = InstanceAccessSchema.safeParse(defaultInstanceRaw);
 
   if (!defaultInstanceResult.success) {

--- a/tests/unit/config/instance-config.test.ts
+++ b/tests/unit/config/instance-config.test.ts
@@ -91,7 +91,7 @@ describe("Instance Configuration", () => {
       it("should load default configuration when no env vars are set", () => {
         const config = loadInstanceConfig();
 
-        expect(config.defaultInstance).toBe("public");
+        expect(config.defaultInstance).toBe("private");
         expect(config.requireAuthForDefaultInstance).toBe(false);
       });
 
@@ -265,6 +265,7 @@ describe("Instance Configuration", () => {
     it("should filter out disabled instances", () => {
       Bun.env["INSTANCE_PRIVATE_ENABLED"] = "false";
       Bun.env["INSTANCE_WORK_ENABLED"] = "false";
+      Bun.env["DEFAULT_INSTANCE"] = "public";
 
       const config = loadInstanceConfig();
       const enabled = getEnabledInstances(config);


### PR DESCRIPTION
## Summary

- **Fix MCP semantic_search returning 0 results** for repositories indexed via CLI by aligning the default ChromaDB instance between CLI and MCP server
- The MCP server defaulted to `DEFAULT_INSTANCE="public"` (port 8002) while the CLI indexed to `CHROMADB_PORT=8000` (private instance), causing the MCP server to query a different ChromaDB instance than where data was stored
- Changed default from `"public"` to `"private"` so both CLI and MCP server use port 8000 out of the box
- Users who need multi-instance routing can still override via the `DEFAULT_INSTANCE` env var

## Root Cause

The CLI (`dependency-init.ts`) uses `CHROMADB_PORT` directly (defaults to 8000), while the MCP server (`instance-config.ts`) uses instance routing via `DEFAULT_INSTANCE` (previously defaulted to `"public"` = port 8002). This design mismatch meant data indexed by `bun run cli index` was invisible to `semantic_search` MCP tool calls.

## Changes

| File | Change |
|------|--------|
| `src/config/instance-config.ts` | Default `DEFAULT_INSTANCE` from `"public"` to `"private"` |
| `tests/unit/config/instance-config.test.ts` | Update test expectations to match new default |

## Test Plan

- [x] `bun run typecheck` — passes
- [x] Instance-config unit tests — 34 pass, 0 fail
- [x] Full test suite — exit code 0
- [x] `bun run build` — clean build
- [ ] Manual: restart MCP server and verify `semantic_search` returns results for CLI-indexed repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)