### PR TITLE
docs: update DEFAULT_INSTANCE default from public to private

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -335,8 +335,8 @@ AUTH_TRACK_TOKEN_USAGE=true
 
 # Default instance for unauthenticated requests (stdio transport)
 # Options: private, work, public
-# Default: public (safest for local/LAN deployments)
-DEFAULT_INSTANCE=public
+# Default: private (aligns with CLI default, both use port 8000)
+DEFAULT_INSTANCE=private
 
 # Require authentication for default instance access
 # Set to true for internet-hosted deployments

--- a/docs/configuration-reference.md
+++ b/docs/configuration-reference.md
@@ -269,7 +269,7 @@ The Personal Knowledge MCP supports multiple isolated instances for different se
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `DEFAULT_INSTANCE` | No | `public` | Default instance for unauthenticated requests |
+| `DEFAULT_INSTANCE` | No | `private` | Default instance for unauthenticated requests |
 | `REQUIRE_AUTH_FOR_DEFAULT_INSTANCE` | No | `false` | Require authentication for default instance |
 
 ### Private Instance (Port 8000)

--- a/src/config/instance-config.ts
+++ b/src/config/instance-config.ts
@@ -172,7 +172,7 @@ function loadInstanceConfigFromEnv(
  * Load multi-instance configuration from environment variables
  *
  * Environment variables:
- * - DEFAULT_INSTANCE: Default instance for unauthenticated requests (default: "public")
+ * - DEFAULT_INSTANCE: Default instance for unauthenticated requests (default: "private")
  * - REQUIRE_AUTH_FOR_DEFAULT_INSTANCE: Require auth for default instance (default: false)
  * - INSTANCE_{NAME}_CHROMADB_HOST: ChromaDB host for instance
  * - INSTANCE_{NAME}_CHROMADB_PORT: ChromaDB port for instance


### PR DESCRIPTION
## Summary

- Aligns documentation with the code change from PR #482 that changed `DEFAULT_INSTANCE` default from `"public"` to `"private"`

## Changes

| File | Change |
|------|--------|
| `docs/configuration-reference.md` | Updated default value in Multi-Instance Configuration table |
| `.env.example` | Updated value and comment rationale |
| `src/config/instance-config.ts` | Updated JSDoc annotation |

## What was NOT changed (intentionally)

- `OIDC_DEFAULT_INSTANCE_ACCESS` still defaults to `public` (separate concept for OIDC user access)
- Token CLI `--instances` flag default (separate concern)
- Test fixtures that explicitly construct configs with `defaultInstance: "public"`

## Related

- PR #482 (merged): Changed the actual code default

🤖 Generated with [Claude Code](https://claude.com/claude-code)