### PR TITLE
fix: apply PR #489 code review fixes (race condition, file rename, JSDoc)

### DIFF
--- a/src/documents/extractors/PdfExtractor.ts
+++ b/src/documents/extractors/PdfExtractor.ts
@@ -10,17 +10,21 @@
 // Import from lib directly to avoid debug mode in index.js.
 // Uses lazy dynamic import() so the binding is interceptable by Bun's mock.module in tests.
 import type pdfParseTypes from "pdf-parse";
-let pdfParse: typeof import("pdf-parse") | undefined;
-async function ensurePdfParse(): Promise<typeof import("pdf-parse")> {
-  if (!pdfParse) {
-    // @ts-expect-error — pdf-parse/lib/pdf-parse.js has no type declarations
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    const m = await import("pdf-parse/lib/pdf-parse.js");
-    // Handle CJS/ESM interop: module may export function directly or as .default
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    pdfParse = (typeof m.default === "function" ? m.default : m) as typeof import("pdf-parse");
+let pdfParsePromise: Promise<typeof import("pdf-parse")> | undefined;
+function ensurePdfParse(): Promise<typeof import("pdf-parse")> {
+  if (!pdfParsePromise) {
+    // Cache the promise (not the resolved value) so concurrent callers share
+    // a single in-flight import instead of racing through the if-check.
+    pdfParsePromise = (async () => {
+      // @ts-expect-error — pdf-parse/lib/pdf-parse.js has no type declarations
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const m = await import("pdf-parse/lib/pdf-parse.js");
+      // Handle CJS/ESM interop: module may export function directly or as .default
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      return (typeof m.default === "function" ? m.default : m) as typeof import("pdf-parse");
+    })();
   }
-  return pdfParse;
+  return pdfParsePromise;
 }
 import { DOCUMENT_EXTENSIONS, DEFAULT_EXTRACTOR_CONFIG } from "../constants.js";
 import { ExtractionError, ExtractionTimeoutError, PasswordProtectedError } from "../errors.js";

--- a/tests/isolated/pdf-extractor-perpage-error.test.ts
+++ b/tests/isolated/pdf-extractor-perpage-error.test.ts
@@ -2,8 +2,8 @@
  * Tests PdfExtractor per-page error resilience.
  *
  * Verifies that individual page failures in getTextContent() are caught by the
- * .catch() handler in the pagerender callback (PdfExtractor.ts:288-290), recording
- * empty content for failed pages without aborting the entire extraction.
+ * .catch() handler in the pagerender callback (inside parsePdfWithTimeout()),
+ * recording empty content for failed pages without aborting the entire extraction.
  *
  * Uses mock.module to intercept pdf-parse before PdfExtractor's dynamic import()
  * resolves, simulating per-page failures without needing a specially crafted PDF.
@@ -11,7 +11,7 @@
  * Placed in tests/isolated/ pattern (separate from extractors.test.ts) because
  * mock.module replaces pdf-parse globally for the process.
  *
- * @module tests/isolated/PdfExtractor.perpage-error
+ * @module tests/isolated/pdf-extractor-perpage-error
  */
 
 import { mock, describe, test, expect, beforeAll } from "bun:test";
@@ -19,6 +19,7 @@ import * as path from "node:path";
 
 // Mock pdf-parse BEFORE importing PdfExtractor so the dynamic import() is intercepted.
 // Simulates a 3-page PDF where page 2's getTextContent() rejects.
+// `void` satisfies ESLint no-floating-promises — mock.module returns a Promise we don't need to await.
 void mock.module("pdf-parse/lib/pdf-parse.js", () => ({
   default: async (
     _buffer: Buffer,


### PR DESCRIPTION
## Summary

Applies code review fixes from PR #489 that were identified but not included before merge.

- **Fix race condition in `ensurePdfParse()`**: Cache the promise instead of the resolved value so concurrent callers share a single in-flight import (async lazy singleton pattern)
- **Rename test file**: `PdfExtractor.perpage-error.test.ts` → `pdf-extractor-perpage-error.test.ts` to follow kebab-case convention in `tests/isolated/`
- **Fix fragile JSDoc**: Replace line number references (`PdfExtractor.ts:288-290`) with code location descriptions (`inside parsePdfWithTimeout()`)
- **Add explanatory comment**: Document why `void` prefix is needed on `mock.module` (ESLint `no-floating-promises`)

Closes #491

## Test plan

- [x] `bun run typecheck` passes
- [x] Isolated PDF test passes (`bun test ./tests/isolated/pdf-extractor-perpage-error.test.ts`)
- [x] `bun run build` succeeds
- [x] Lint-staged hooks pass on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)