### PR TITLE
feat: add paragraph-level overlap to DocumentChunker (#469)

### DIFF
--- a/src/documents/DocumentChunker.ts
+++ b/src/documents/DocumentChunker.ts
@@ -342,7 +342,10 @@ export class DocumentChunker extends FileChunker {
    * Chunk document by paragraph boundaries.
    *
    * Splits content at double-newline boundaries and groups paragraphs
-   * into chunks respecting the token limit. Falls back to line-level
+   * into chunks respecting the token limit. When `overlapTokens > 0`,
+   * the last N whole paragraphs fitting within the overlap budget are
+   * carried from the flushed group into the next group for semantic
+   * continuity across chunk boundaries. Falls back to line-level
    * splitting for individual paragraphs that exceed the token limit.
    * Character offsets are tracked for section heading lookup.
    *
@@ -369,6 +372,7 @@ export class DocumentChunker extends FileChunker {
     const positions: ChunkPositionData[] = [];
     let currentParagraphs: ParagraphBlock[] = [];
     let currentTokens = 0;
+    let overlapCount = 0; // Track how many leading paragraphs are overlap from previous group
     const fileInfo = this.createDocumentFileInfo(extractionResult, filePath);
 
     for (const paragraph of paragraphs) {
@@ -385,6 +389,7 @@ export class DocumentChunker extends FileChunker {
           });
           positions.push({ charOffset: paragraph.charOffset });
         }
+        overlapCount = 0;
         continue;
       }
 
@@ -393,12 +398,16 @@ export class DocumentChunker extends FileChunker {
         allChunks.push(
           this.createChunkFromParagraphs(currentParagraphs, filePath, source, fileInfo)
         );
-        positions.push({ charOffset: currentParagraphs[0]!.charOffset });
+        // Use the first non-overlap paragraph's offset for section heading lookup,
+        // falling back to the first paragraph if the group is entirely overlap
+        const posIndex = Math.min(overlapCount, currentParagraphs.length - 1);
+        positions.push({ charOffset: currentParagraphs[posIndex]!.charOffset });
 
         // Seed next group with overlap paragraphs from the tail of the flushed group
         const overlapParas = this.getOverlapParagraphs(currentParagraphs, this.overlapTokens);
         currentParagraphs = [...overlapParas];
         currentTokens = overlapParas.reduce((sum, p) => sum + estimateTokens(p.content), 0);
+        overlapCount = overlapParas.length;
       }
 
       currentParagraphs.push(paragraph);
@@ -408,7 +417,8 @@ export class DocumentChunker extends FileChunker {
     // Flush remaining paragraphs
     if (currentParagraphs.length > 0) {
       allChunks.push(this.createChunkFromParagraphs(currentParagraphs, filePath, source, fileInfo));
-      positions.push({ charOffset: currentParagraphs[0]!.charOffset });
+      const posIndex = Math.min(overlapCount, currentParagraphs.length - 1);
+      positions.push({ charOffset: currentParagraphs[posIndex]!.charOffset });
     }
 
     // Fix chunk indices and totalChunks

--- a/tests/unit/documents/DocumentChunker.test.ts
+++ b/tests/unit/documents/DocumentChunker.test.ts
@@ -792,7 +792,7 @@ describe("DocumentChunker", () => {
       }
     });
 
-    test("overlap respects overlapTokens budget", () => {
+    test("overlap includes at least one paragraph even when it exceeds budget", () => {
       // Each paragraph ~91 tokens. With overlapTokens=50, the "at least one"
       // rule still includes one paragraph. With maxChunkTokens=200, two fit
       // (91+91=182 < 200) but three don't (273 > 200).
@@ -820,6 +820,36 @@ describe("DocumentChunker", () => {
       }
     });
 
+    test("overlap budget constrains number of overlap paragraphs", () => {
+      // Use short paragraphs (~8 chars → ~2 tokens each) to test real budget
+      // constraints. With overlapTokens=5, two ~2-token paragraphs fit (4 ≤ 5)
+      // but three don't (6 > 5).
+      const shortParas = Array.from({ length: 10 }, (_, i) => `Para ${i + 1}.`);
+      const content = shortParas.join("\n\n");
+      // Each paragraph ~2 tokens, maxChunkTokens=8 fits ~4 paragraphs per chunk
+      const chunker = createChunker({
+        maxChunkTokens: 8,
+        overlapTokens: 5,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+      const result = createMockExtractionResult({ content });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      expect(chunks.length).toBeGreaterThan(1);
+
+      // With ~2 tokens per paragraph and overlap budget of 5, at most 2 paragraphs
+      // should be carried as overlap (2*2=4 ≤ 5, but 3*2=6 > 5)
+      for (let i = 1; i < chunks.length; i++) {
+        const paras = chunks[i]!.content.split("\n\n");
+        // Overlap paragraphs from the previous chunk
+        const prevParas = chunks[i - 1]!.content.split("\n\n");
+        const overlapParas = paras.filter((p) => prevParas.includes(p));
+        expect(overlapParas.length).toBeLessThanOrEqual(2);
+        expect(overlapParas.length).toBeGreaterThanOrEqual(1);
+      }
+    });
+
     test("single-paragraph groups still produce overlap", () => {
       // maxChunkTokens=120: fits one ~91-token paragraph but not two
       // overlapTokens=100: enough to carry the single paragraph forward
@@ -836,6 +866,29 @@ describe("DocumentChunker", () => {
       expect(chunks.length).toBeGreaterThan(1);
 
       // Each chunk after the first should contain the previous chunk's paragraph
+      for (let i = 0; i < chunks.length - 1; i++) {
+        const currentParagraphs = chunks[i]!.content.split("\n\n");
+        const lastParagraph = currentParagraphs[currentParagraphs.length - 1]!;
+        expect(chunks[i + 1]!.content).toContain(lastParagraph);
+      }
+    });
+
+    test("at least one overlap paragraph included even with tiny overlapTokens budget", () => {
+      // With overlapTokens=1 and paragraphs at ~91 tokens each,
+      // the "at least one" rule should still include one paragraph
+      const chunker = createChunker({
+        maxChunkTokens: 120,
+        overlapTokens: 1,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+      const content = generateLargeDocumentContent(4);
+      const result = createMockExtractionResult({ content });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      expect(chunks.length).toBeGreaterThan(1);
+
+      // Each chunk after the first should still contain overlap
       for (let i = 0; i < chunks.length - 1; i++) {
         const currentParagraphs = chunks[i]!.content.split("\n\n");
         const lastParagraph = currentParagraphs[currentParagraphs.length - 1]!;


### PR DESCRIPTION
## Summary

- Adds whole-paragraph overlap between consecutive paragraph-boundary chunks in `DocumentChunker.chunkByParagraphs()`, analogous to `FileChunker`'s `getOverlapLines` for line-level chunks
- When `overlapTokens > 0`, the last N paragraphs (fitting within the overlap budget) from a flushed group are carried into the next group for semantic continuity across chunk boundaries
- Adds `getOverlapParagraphs()` private method following the same algorithm pattern as `getOverlapLines` (iterate backwards, include at least one if possible)

## Changes

### `src/documents/DocumentChunker.ts`
- Added `private readonly overlapTokens: number` field (read from config + env var, same pattern as `maxTokens`)
- Added `getOverlapParagraphs()` private method — takes whole paragraphs from the tail of a flushed group until the overlap token budget is reached
- Modified `chunkByParagraphs()` flush logic to seed the next group with overlap paragraphs instead of starting fresh
- Updated class JSDoc to document overlap behavior

### `tests/unit/documents/DocumentChunker.test.ts`
- Added `describe("Paragraph overlap behavior")` block with 4 tests:
  1. Consecutive chunks include overlap from previous chunk
  2. No overlap when `overlapTokens` is 0
  3. Overlap respects the `overlapTokens` budget
  4. Single-paragraph groups still produce overlap

## Design Decision

Uses whole-paragraph overlap (not partial) because the paragraph-boundary chunking mode exists specifically to keep paragraphs intact. Partial paragraph overlap would violate that contract and confuse section heading resolution.

`overlapTokens` is stored as a local field in `DocumentChunker` (Option B from the plan) rather than exposing it via a protected getter on `FileChunker`, consistent with the existing `maxTokens` pattern and avoiding parent class changes.

## Test plan

- [x] `bun test tests/unit/documents/DocumentChunker.test.ts` — 56 tests pass, 100% coverage on changed files
- [x] `bun run typecheck` — clean
- [x] `bun test tests/unit/` — 2720 pass (26 pre-existing Roslyn failures unrelated)
- [x] `bun run build` — clean

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)