### PR TITLE
feat: add TableContentIndexer for ChromaDB table content indexing

### DIFF
--- a/src/documents/TableContentIndexer.ts
+++ b/src/documents/TableContentIndexer.ts
@@ -1,0 +1,432 @@
+/**
+ * Table content indexer for ChromaDB.
+ *
+ * Converts structured {@link TableExtractionResult} arrays into
+ * {@link DocumentChunk} arrays suitable for embedding and storage
+ * in ChromaDB. Uses Markdown formatting for table content and
+ * handles large-table splitting with header repetition.
+ *
+ * This is a standalone utility with no dependencies on services,
+ * storage, or embedding providers. Callers (e.g., the future
+ * document ingestion pipeline) are responsible for embedding
+ * and storing the returned chunks.
+ *
+ * @module documents/TableContentIndexer
+ */
+
+import type pino from "pino";
+import { getComponentLogger } from "../logging/index.js";
+import { estimateTokens, computeContentHash } from "../ingestion/chunk-utils.js";
+import { TableFormatter } from "./TableFormatter.js";
+import type {
+  TableExtractionResult,
+  DocumentChunk,
+  DocumentChunkMetadata,
+  DocumentType,
+} from "./types.js";
+
+/**
+ * Configuration options for {@link TableContentIndexer}.
+ *
+ * @example
+ * ```typescript
+ * const config: TableIndexerConfig = {
+ *   maxChunkTokens: 800,
+ * };
+ * ```
+ */
+export interface TableIndexerConfig {
+  /**
+   * Maximum tokens per table chunk.
+   *
+   * Tables exceeding this limit are split by row groups,
+   * with the header row(s) repeated in each sub-chunk.
+   *
+   * @default 500
+   */
+  maxChunkTokens?: number;
+}
+
+/**
+ * Contextual information about the source document.
+ *
+ * Provides the metadata needed to build {@link DocumentChunk} objects
+ * with proper IDs, file paths, and document-level metadata.
+ *
+ * @example
+ * ```typescript
+ * const context: TableIndexerContext = {
+ *   repository: "my-docs",
+ *   filePath: "reports/quarterly.pdf",
+ *   extension: ".pdf",
+ *   fileSizeBytes: 1048576,
+ *   fileModifiedAt: new Date("2025-01-15"),
+ *   documentType: "pdf",
+ *   documentTitle: "Q4 Report",
+ * };
+ * ```
+ */
+export interface TableIndexerContext {
+  /** Repository or source name (must not contain ':'). */
+  repository: string;
+
+  /** File path relative to repository root. */
+  filePath: string;
+
+  /** File extension including leading dot (e.g., ".pdf"). */
+  extension: string;
+
+  /** Original file size in bytes. */
+  fileSizeBytes: number;
+
+  /** File modification timestamp. */
+  fileModifiedAt: Date;
+
+  /** Document type of the source file. */
+  documentType: DocumentType;
+
+  /** Document title from extraction metadata. */
+  documentTitle?: string;
+
+  /** Document author from extraction metadata. */
+  documentAuthor?: string;
+}
+
+/** Default maximum tokens per table chunk. */
+const DEFAULT_MAX_CHUNK_TOKENS = 500;
+
+/**
+ * Converts extracted tables into ChromaDB-ready document chunks.
+ *
+ * For each table in the input array:
+ * 1. Formats the table to Markdown via {@link TableFormatter.toMarkdown}
+ * 2. Optionally prepends the table caption
+ * 3. If the result fits within `maxChunkTokens`, produces a single chunk
+ * 4. If it exceeds the limit, splits by row groups with header repetition
+ *
+ * Chunk IDs follow the format: `{repository}:{filePath}:table-{tableIndex}:{subChunkIndex}`
+ *
+ * @example
+ * ```typescript
+ * const indexer = new TableContentIndexer({ maxChunkTokens: 500 });
+ * const chunks = indexer.indexTables(tables, context);
+ * // chunks are ready for embedding and ChromaDB storage
+ * ```
+ */
+export class TableContentIndexer {
+  private readonly logger: pino.Logger;
+  private readonly maxChunkTokens: number;
+
+  /**
+   * Create a new TableContentIndexer instance.
+   *
+   * @param config - Optional configuration overrides
+   */
+  constructor(config?: TableIndexerConfig) {
+    this.logger = getComponentLogger("documents:table-indexer");
+    this.maxChunkTokens = config?.maxChunkTokens ?? DEFAULT_MAX_CHUNK_TOKENS;
+
+    this.logger.debug({ maxChunkTokens: this.maxChunkTokens }, "TableContentIndexer initialized");
+  }
+
+  /**
+   * Convert extracted tables into document chunks for ChromaDB indexing.
+   *
+   * @param tables - Table extraction results from PDF or DOCX extractors
+   * @param context - Source document context for metadata
+   * @returns Array of document chunks ready for embedding
+   */
+  indexTables(tables: TableExtractionResult[], context: TableIndexerContext): DocumentChunk[] {
+    if (tables.length === 0) {
+      this.logger.debug({ filePath: context.filePath }, "No tables to index");
+      return [];
+    }
+
+    const startTime = Date.now();
+    const allChunks: DocumentChunk[] = [];
+
+    for (const tableResult of tables) {
+      const tableChunks = this.indexSingleTable(tableResult, context);
+      allChunks.push(...tableChunks);
+    }
+
+    const duration = Date.now() - startTime;
+    this.logger.info(
+      {
+        metric: "table_indexer.duration_ms",
+        value: duration,
+        filePath: context.filePath,
+        tableCount: tables.length,
+        chunkCount: allChunks.length,
+      },
+      "Table indexing complete"
+    );
+
+    return allChunks;
+  }
+
+  /**
+   * Index a single table into one or more chunks.
+   *
+   * @param tableResult - Single table extraction result
+   * @param context - Source document context
+   * @returns Array of chunks for this table
+   */
+  private indexSingleTable(
+    tableResult: TableExtractionResult,
+    context: TableIndexerContext
+  ): DocumentChunk[] {
+    const { table } = tableResult;
+
+    // Format to markdown
+    const markdown = TableFormatter.toMarkdown(table);
+    if (markdown.length === 0) {
+      this.logger.debug(
+        { tableIndex: tableResult.tableIndex, filePath: context.filePath },
+        "Skipping empty table"
+      );
+      return [];
+    }
+
+    // Prepend caption if available
+    const fullContent = table.caption ? `**Table: ${table.caption}**\n\n${markdown}` : markdown;
+
+    // Count data rows (non-header rows)
+    const dataRowCount = table.rows.filter((r) => !r.isHeader).length;
+
+    // Check if it fits in a single chunk
+    const tokens = estimateTokens(fullContent);
+    if (tokens <= this.maxChunkTokens) {
+      const chunk = this.buildChunk(
+        fullContent,
+        tableResult,
+        context,
+        dataRowCount,
+        0, // subChunkIndex
+        1 // totalSubChunks
+      );
+      return [chunk];
+    }
+
+    // Split large table by row groups
+    return this.splitLargeTable(tableResult, context, dataRowCount);
+  }
+
+  /**
+   * Split a large table into multiple chunks with header repetition.
+   *
+   * Extracts header rows from the table, then groups data rows
+   * until the token budget is reached. Each sub-chunk includes
+   * the header rows for independent comprehension.
+   *
+   * @param tableResult - Table extraction result
+   * @param context - Source document context
+   * @param dataRowCount - Total number of data rows
+   * @returns Array of sub-chunks
+   */
+  private splitLargeTable(
+    tableResult: TableExtractionResult,
+    context: TableIndexerContext,
+    dataRowCount: number
+  ): DocumentChunk[] {
+    const { table } = tableResult;
+    const headerRows = table.rows.filter((r) => r.isHeader);
+    const dataRows = table.rows.filter((r) => !r.isHeader);
+
+    // Build header markdown (used as prefix for each sub-chunk)
+    const headerTable = {
+      rows: headerRows,
+      columnCount: table.columnCount,
+    };
+    const headerMarkdown = headerRows.length > 0 ? TableFormatter.toMarkdown(headerTable) : "";
+
+    // Build caption prefix
+    const captionPrefix = table.caption ? `**Table: ${table.caption}**\n\n` : "";
+
+    // Calculate token budget for data rows in each chunk
+    const headerTokens = estimateTokens(captionPrefix + headerMarkdown);
+    // Reserve at least 1 token for a separator line between header and data
+    const separatorTokens = headerMarkdown.length > 0 ? estimateTokens("\n") : 0;
+    const dataTokenBudget = Math.max(1, this.maxChunkTokens - headerTokens - separatorTokens);
+
+    // Group data rows into sub-chunks
+    const subChunks: DocumentChunk[] = [];
+    let currentDataRows: typeof dataRows = [];
+    let currentTokens = 0;
+
+    for (const row of dataRows) {
+      // Build a temporary single-row table to estimate tokens
+      const rowTable = {
+        rows: [row],
+        columnCount: table.columnCount,
+      };
+      const rowMarkdown = TableFormatter.toMarkdown(rowTable);
+      const rowTokens = estimateTokens(rowMarkdown);
+
+      // Flush current group if adding this row would exceed budget
+      if (currentDataRows.length > 0 && currentTokens + rowTokens > dataTokenBudget) {
+        subChunks.push(
+          this.buildSubChunk(
+            headerRows,
+            currentDataRows,
+            table.columnCount,
+            table.caption,
+            tableResult,
+            context,
+            dataRowCount,
+            subChunks.length
+          )
+        );
+        currentDataRows = [];
+        currentTokens = 0;
+      }
+
+      currentDataRows.push(row);
+      currentTokens += rowTokens;
+    }
+
+    // Flush remaining rows
+    if (currentDataRows.length > 0) {
+      subChunks.push(
+        this.buildSubChunk(
+          headerRows,
+          currentDataRows,
+          table.columnCount,
+          table.caption,
+          tableResult,
+          context,
+          dataRowCount,
+          subChunks.length
+        )
+      );
+    }
+
+    // Fix totalChunks in all sub-chunks
+    const totalSubChunks = subChunks.length;
+    return subChunks.map((chunk, index) => ({
+      ...chunk,
+      id: this.buildChunkId(context.repository, context.filePath, tableResult.tableIndex, index),
+      chunkIndex: index,
+      totalChunks: totalSubChunks,
+    }));
+  }
+
+  /**
+   * Build a sub-chunk from header rows and a group of data rows.
+   *
+   * @param headerRows - Header rows to prepend
+   * @param dataRows - Data rows for this sub-chunk
+   * @param columnCount - Number of columns
+   * @param caption - Optional table caption
+   * @param tableResult - Original table extraction result
+   * @param context - Source document context
+   * @param dataRowCount - Total data rows across all sub-chunks
+   * @param subChunkIndex - Index of this sub-chunk
+   * @returns Document chunk
+   */
+  private buildSubChunk(
+    headerRows: typeof tableResult.table.rows,
+    dataRows: typeof tableResult.table.rows,
+    columnCount: number,
+    caption: string | undefined,
+    tableResult: TableExtractionResult,
+    context: TableIndexerContext,
+    dataRowCount: number,
+    subChunkIndex: number
+  ): DocumentChunk {
+    const subTable = {
+      rows: [...headerRows, ...dataRows],
+      columnCount,
+      caption,
+    };
+    const markdown = TableFormatter.toMarkdown(subTable);
+    const fullContent = caption ? `**Table: ${caption}**\n\n${markdown}` : markdown;
+
+    return this.buildChunk(
+      fullContent,
+      tableResult,
+      context,
+      dataRowCount,
+      subChunkIndex,
+      0 // placeholder - will be corrected in splitLargeTable
+    );
+  }
+
+  /**
+   * Build a single document chunk with table metadata.
+   *
+   * @param content - Markdown content for the chunk
+   * @param tableResult - Source table extraction result
+   * @param context - Source document context
+   * @param dataRowCount - Number of data rows in the source table
+   * @param subChunkIndex - Sub-chunk index within this table
+   * @param totalSubChunks - Total sub-chunks for this table
+   * @returns Complete document chunk
+   */
+  private buildChunk(
+    content: string,
+    tableResult: TableExtractionResult,
+    context: TableIndexerContext,
+    dataRowCount: number,
+    subChunkIndex: number,
+    totalSubChunks: number
+  ): DocumentChunk {
+    const contentLines = content.split("\n");
+
+    const metadata: DocumentChunkMetadata = {
+      extension: context.extension,
+      language: "unknown",
+      fileSizeBytes: context.fileSizeBytes,
+      contentHash: computeContentHash(content),
+      fileModifiedAt: context.fileModifiedAt,
+      documentType: context.documentType,
+      pageNumber: tableResult.pageNumber,
+      documentTitle: context.documentTitle,
+      documentAuthor: context.documentAuthor,
+      isTable: true,
+      tableIndex: tableResult.tableIndex,
+      tableCaption: tableResult.table.caption,
+      tableColumnCount: tableResult.table.columnCount,
+      tableRowCount: dataRowCount,
+      tableSourceType: tableResult.sourceType,
+      tableConfidence: tableResult.confidence,
+    };
+
+    return {
+      id: this.buildChunkId(
+        context.repository,
+        context.filePath,
+        tableResult.tableIndex,
+        subChunkIndex
+      ),
+      repository: context.repository,
+      filePath: context.filePath,
+      content,
+      chunkIndex: subChunkIndex,
+      totalChunks: totalSubChunks,
+      startLine: 1,
+      endLine: contentLines.length,
+      metadata,
+    };
+  }
+
+  /**
+   * Build a chunk ID for table content.
+   *
+   * Format: `{repository}:{filePath}:table-{tableIndex}:{subChunkIndex}`
+   *
+   * @param repository - Repository name
+   * @param filePath - File path
+   * @param tableIndex - Zero-based table index
+   * @param subChunkIndex - Zero-based sub-chunk index
+   * @returns Unique chunk ID
+   */
+  private buildChunkId(
+    repository: string,
+    filePath: string,
+    tableIndex: number,
+    subChunkIndex: number
+  ): string {
+    return `${repository}:${filePath}:table-${tableIndex}:${subChunkIndex}`;
+  }
+}

--- a/src/documents/index.ts
+++ b/src/documents/index.ts
@@ -112,6 +112,10 @@ export type {
 // Table formatter
 export { TableFormatter } from "./TableFormatter.js";
 
+// Table content indexer
+export { TableContentIndexer } from "./TableContentIndexer.js";
+export type { TableIndexerConfig, TableIndexerContext } from "./TableContentIndexer.js";
+
 // Document chunker
 export { DocumentChunker } from "./DocumentChunker.js";
 

--- a/src/documents/types.ts
+++ b/src/documents/types.ts
@@ -578,6 +578,64 @@ export interface DocumentChunkMetadata {
    * @default undefined
    */
   documentAuthor?: string;
+
+  // ── Table-specific metadata ───────────────────────────────────
+
+  /**
+   * Whether this chunk contains table content.
+   *
+   * When true, the chunk was generated from a {@link TableExtractionResult}
+   * rather than from prose text.
+   *
+   * @default undefined
+   */
+  isTable?: boolean;
+
+  /**
+   * Zero-based index of the table within the source document.
+   *
+   * Matches {@link TableExtractionResult.tableIndex}.
+   *
+   * @default undefined
+   */
+  tableIndex?: number;
+
+  /**
+   * Table caption text, if present in the source document.
+   *
+   * @default undefined
+   */
+  tableCaption?: string;
+
+  /**
+   * Number of columns in the source table.
+   *
+   * @default undefined
+   */
+  tableColumnCount?: number;
+
+  /**
+   * Number of data rows in the source table (excluding header rows).
+   *
+   * @default undefined
+   */
+  tableRowCount?: number;
+
+  /**
+   * Source document type that contained the table ("pdf" or "docx").
+   *
+   * @default undefined
+   */
+  tableSourceType?: string;
+
+  /**
+   * Extraction confidence score between 0.0 and 1.0.
+   *
+   * Propagated from {@link TableExtractionResult.confidence}.
+   *
+   * @default undefined
+   */
+  tableConfidence?: number;
 }
 
 /**

--- a/tests/fixtures/documents/table-indexer-fixtures.ts
+++ b/tests/fixtures/documents/table-indexer-fixtures.ts
@@ -1,0 +1,331 @@
+/**
+ * Test fixtures for TableContentIndexer tests.
+ *
+ * Provides builder functions for creating {@link TableExtractionResult}
+ * and {@link TableIndexerContext} objects for testing table-to-chunk
+ * conversion with various table sizes, structures, and metadata.
+ *
+ * @module tests/fixtures/documents/table-indexer-fixtures
+ */
+
+import type {
+  TableExtractionResult,
+  TableRow,
+  TableSourceType,
+} from "../../../src/documents/types.js";
+import type { TableIndexerContext } from "../../../src/documents/TableContentIndexer.js";
+
+// ── Context builders ────────────────────────────────────────────────
+
+/**
+ * Default context for table indexer tests.
+ */
+const DEFAULT_CONTEXT: TableIndexerContext = {
+  repository: "test-docs",
+  filePath: "reports/quarterly.pdf",
+  extension: ".pdf",
+  fileSizeBytes: 102400,
+  fileModifiedAt: new Date("2025-06-15T10:00:00Z"),
+  documentType: "pdf",
+  documentTitle: "Quarterly Report",
+  documentAuthor: "Test Author",
+};
+
+/**
+ * Create a test context with optional overrides.
+ *
+ * @param overrides - Partial overrides for the context
+ * @returns Complete TableIndexerContext
+ */
+export function createTestContext(
+  overrides?: Partial<TableIndexerContext>
+): TableIndexerContext {
+  return { ...DEFAULT_CONTEXT, ...overrides };
+}
+
+/**
+ * Create a DOCX-specific test context.
+ *
+ * @param overrides - Optional additional overrides
+ * @returns Context configured for DOCX documents
+ */
+export function createDocxContext(
+  overrides?: Partial<TableIndexerContext>
+): TableIndexerContext {
+  return createTestContext({
+    filePath: "docs/specification.docx",
+    extension: ".docx",
+    documentType: "docx",
+    documentTitle: "Technical Specification",
+    ...overrides,
+  });
+}
+
+// ── Table builders ──────────────────────────────────────────────────
+
+/**
+ * Create a small 2-column, 2-data-row table.
+ *
+ * Layout:
+ * ```
+ * Name  | Age
+ * Alice | 30
+ * Bob   | 25
+ * ```
+ */
+export function createSmallTable(
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  return {
+    table: {
+      rows: [
+        { cells: [{ content: "Name" }, { content: "Age" }], isHeader: true },
+        { cells: [{ content: "Alice" }, { content: "30" }] },
+        { cells: [{ content: "Bob" }, { content: "25" }] },
+      ],
+      columnCount: 2,
+    },
+    filePath: "/docs/test.pdf",
+    sourceType: "pdf",
+    tableIndex: 0,
+    confidence: 0.95,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a table with a caption.
+ *
+ * @param caption - Caption text
+ * @param overrides - Additional overrides
+ */
+export function createTableWithCaption(
+  caption: string = "Employee Directory",
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  const base = createSmallTable(overrides);
+  return {
+    ...base,
+    table: {
+      ...base.table,
+      caption,
+    },
+  };
+}
+
+/**
+ * Create a large table that will exceed the default 500-token limit.
+ *
+ * Generates a table with the specified number of data rows,
+ * each containing 4 columns of descriptive text.
+ *
+ * @param rowCount - Number of data rows (default 50)
+ * @param overrides - Additional overrides
+ */
+export function createLargeTable(
+  rowCount: number = 50,
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  const headerRow: TableRow = {
+    cells: [
+      { content: "Employee ID" },
+      { content: "Full Name" },
+      { content: "Department" },
+      { content: "Annual Salary" },
+    ],
+    isHeader: true,
+  };
+
+  const dataRows: TableRow[] = [];
+  for (let i = 0; i < rowCount; i++) {
+    dataRows.push({
+      cells: [
+        { content: `EMP-${String(i + 1).padStart(4, "0")}` },
+        { content: `Employee Number ${i + 1} with a longer name` },
+        { content: `Department of Engineering and Research ${i + 1}` },
+        { content: `$${(50000 + i * 1000).toLocaleString()}` },
+      ],
+    });
+  }
+
+  return {
+    table: {
+      rows: [headerRow, ...dataRows],
+      columnCount: 4,
+    },
+    filePath: "/docs/employees.pdf",
+    sourceType: "pdf",
+    tableIndex: 0,
+    confidence: 0.92,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a PDF table with a page number.
+ *
+ * @param pageNumber - 1-based page number
+ * @param tableIndex - 0-based table index
+ * @param overrides - Additional overrides
+ */
+export function createPdfTableWithPage(
+  pageNumber: number = 3,
+  tableIndex: number = 0,
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  return createSmallTable({
+    pageNumber,
+    tableIndex,
+    sourceType: "pdf",
+    ...overrides,
+  });
+}
+
+/**
+ * Create a DOCX table extraction result (no page number).
+ *
+ * @param tableIndex - 0-based table index
+ * @param overrides - Additional overrides
+ */
+export function createDocxTable(
+  tableIndex: number = 0,
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  return createSmallTable({
+    filePath: "/docs/spec.docx",
+    sourceType: "docx",
+    tableIndex,
+    pageNumber: undefined,
+    ...overrides,
+  });
+}
+
+/**
+ * Create a set of multiple tables as if from a single document.
+ *
+ * @param count - Number of tables (default 3)
+ * @param sourceType - Source type (default "pdf")
+ */
+export function createMultipleTableResults(
+  count: number = 3,
+  sourceType: TableSourceType = "pdf"
+): TableExtractionResult[] {
+  const results: TableExtractionResult[] = [];
+
+  for (let i = 0; i < count; i++) {
+    results.push({
+      table: {
+        rows: [
+          {
+            cells: [{ content: `Header ${i}A` }, { content: `Header ${i}B` }],
+            isHeader: true,
+          },
+          {
+            cells: [{ content: `Data ${i}A` }, { content: `Data ${i}B` }],
+          },
+        ],
+        columnCount: 2,
+      },
+      filePath: sourceType === "pdf" ? "/docs/multi.pdf" : "/docs/multi.docx",
+      sourceType,
+      tableIndex: i,
+      pageNumber: sourceType === "pdf" ? i + 1 : undefined,
+      confidence: 0.9 + i * 0.02,
+    });
+  }
+
+  return results;
+}
+
+/**
+ * Create a header-only table (no data rows).
+ */
+export function createHeaderOnlyTable(
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  return {
+    table: {
+      rows: [
+        {
+          cells: [{ content: "Column A" }, { content: "Column B" }, { content: "Column C" }],
+          isHeader: true,
+        },
+      ],
+      columnCount: 3,
+    },
+    filePath: "/docs/empty-data.pdf",
+    sourceType: "pdf",
+    tableIndex: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a table with no header rows.
+ */
+export function createNoHeaderTable(
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  return {
+    table: {
+      rows: [
+        { cells: [{ content: "Value A1" }, { content: "Value B1" }] },
+        { cells: [{ content: "Value A2" }, { content: "Value B2" }] },
+      ],
+      columnCount: 2,
+    },
+    filePath: "/docs/no-header.pdf",
+    sourceType: "pdf",
+    tableIndex: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a single-row (data) table.
+ */
+export function createSingleRowTable(
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  return {
+    table: {
+      rows: [
+        { cells: [{ content: "Name" }, { content: "Value" }], isHeader: true },
+        { cells: [{ content: "Total" }, { content: "42" }] },
+      ],
+      columnCount: 2,
+    },
+    filePath: "/docs/single-row.pdf",
+    sourceType: "pdf",
+    tableIndex: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Create an empty table (no rows at all).
+ */
+export function createEmptyTable(
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  return {
+    table: {
+      rows: [],
+      columnCount: 0,
+    },
+    filePath: "/docs/empty.pdf",
+    sourceType: "pdf",
+    tableIndex: 0,
+    ...overrides,
+  };
+}
+
+/**
+ * Create a table without confidence score.
+ */
+export function createTableWithoutConfidence(
+  overrides?: Partial<TableExtractionResult>
+): TableExtractionResult {
+  const { confidence: _, ...base } = createSmallTable(overrides);
+  return base as TableExtractionResult;
+}

--- a/tests/unit/documents/TableContentIndexer.test.ts
+++ b/tests/unit/documents/TableContentIndexer.test.ts
@@ -1,0 +1,610 @@
+/**
+ * Unit tests for TableContentIndexer.
+ *
+ * Tests table-to-chunk conversion including single tables, large table
+ * splitting, caption handling, metadata propagation, and edge cases.
+ *
+ * @module tests/unit/documents/TableContentIndexer.test
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { TableContentIndexer } from "../../../src/documents/TableContentIndexer.js";
+import { estimateTokens } from "../../../src/ingestion/chunk-utils.js";
+import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
+import {
+  createSmallTable,
+  createTableWithCaption,
+  createLargeTable,
+  createPdfTableWithPage,
+  createDocxTable,
+  createMultipleTableResults,
+  createHeaderOnlyTable,
+  createNoHeaderTable,
+  createSingleRowTable,
+  createEmptyTable,
+  createTableWithoutConfidence,
+  createTestContext,
+  createDocxContext,
+} from "../../fixtures/documents/table-indexer-fixtures.js";
+
+describe("TableContentIndexer", () => {
+  let indexer: TableContentIndexer;
+
+  beforeEach(() => {
+    initializeLogger({ level: "error", format: "json" });
+    indexer = new TableContentIndexer();
+  });
+
+  afterEach(() => {
+    resetLogger();
+  });
+
+  // ── Configuration ─────────────────────────────────────────────────
+
+  describe("configuration", () => {
+    test("uses default maxChunkTokens of 500", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      // Small table should produce exactly one chunk
+      expect(chunks.length).toBe(1);
+    });
+
+    test("respects custom maxChunkTokens", () => {
+      // Very small token limit to force splitting even small tables
+      const tinyIndexer = new TableContentIndexer({ maxChunkTokens: 10 });
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = tinyIndexer.indexTables([table], context);
+
+      // Should produce multiple chunks with such a small limit
+      expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    test("constructs without config", () => {
+      const noConfigIndexer = new TableContentIndexer();
+      expect(noConfigIndexer).toBeDefined();
+    });
+  });
+
+  // ── Single table indexing ─────────────────────────────────────────
+
+  describe("single table indexing", () => {
+    test("produces correct markdown content", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks.length).toBe(1);
+      const content = chunks[0]!.content;
+
+      // Should contain markdown table format
+      expect(content).toContain("| Name | Age |");
+      expect(content).toContain("| --- | --- |");
+      expect(content).toContain("| Alice | 30 |");
+      expect(content).toContain("| Bob | 25 |");
+    });
+
+    test("generates correct chunk ID format", () => {
+      const table = createSmallTable({ tableIndex: 2 });
+      const context = createTestContext({ repository: "my-repo", filePath: "docs/report.pdf" });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.id).toBe("my-repo:docs/report.pdf:table-2:0");
+    });
+
+    test("sets repository and filePath from context", () => {
+      const table = createSmallTable();
+      const context = createTestContext({ repository: "my-repo", filePath: "data/file.pdf" });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.repository).toBe("my-repo");
+      expect(chunks[0]!.filePath).toBe("data/file.pdf");
+    });
+
+    test("sets totalChunks to 1 for single-chunk table", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.totalChunks).toBe(1);
+      expect(chunks[0]!.chunkIndex).toBe(0);
+    });
+
+    test("sets startLine and endLine based on content", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.startLine).toBe(1);
+      expect(chunks[0]!.endLine).toBeGreaterThan(0);
+    });
+  });
+
+  // ── Metadata ──────────────────────────────────────────────────────
+
+  describe("metadata", () => {
+    test("sets isTable to true", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.isTable).toBe(true);
+    });
+
+    test("propagates tableIndex from extraction result", () => {
+      const table = createSmallTable({ tableIndex: 5 });
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.tableIndex).toBe(5);
+    });
+
+    test("propagates tableCaption from table data", () => {
+      const table = createTableWithCaption("Revenue Summary");
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.tableCaption).toBe("Revenue Summary");
+    });
+
+    test("sets tableCaption to undefined when no caption", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.tableCaption).toBeUndefined();
+    });
+
+    test("propagates tableColumnCount", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.tableColumnCount).toBe(2);
+    });
+
+    test("computes tableRowCount excluding headers", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      // Small table has 1 header + 2 data rows
+      expect(chunks[0]!.metadata.tableRowCount).toBe(2);
+    });
+
+    test("propagates tableSourceType", () => {
+      const pdfTable = createSmallTable({ sourceType: "pdf" });
+      const docxTable = createDocxTable();
+      const context = createTestContext();
+
+      const pdfChunks = indexer.indexTables([pdfTable], context);
+      const docxChunks = indexer.indexTables([docxTable], createDocxContext());
+
+      expect(pdfChunks[0]!.metadata.tableSourceType).toBe("pdf");
+      expect(docxChunks[0]!.metadata.tableSourceType).toBe("docx");
+    });
+
+    test("propagates tableConfidence", () => {
+      const table = createSmallTable({ confidence: 0.87 });
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.tableConfidence).toBe(0.87);
+    });
+
+    test("sets tableConfidence to undefined when not provided", () => {
+      const table = createTableWithoutConfidence();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.tableConfidence).toBeUndefined();
+    });
+
+    test("propagates documentType from context", () => {
+      const table = createSmallTable();
+      const context = createTestContext({ documentType: "pdf" });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.documentType).toBe("pdf");
+    });
+
+    test("propagates documentTitle from context", () => {
+      const table = createSmallTable();
+      const context = createTestContext({ documentTitle: "Annual Report 2025" });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.documentTitle).toBe("Annual Report 2025");
+    });
+
+    test("propagates documentAuthor from context", () => {
+      const table = createSmallTable();
+      const context = createTestContext({ documentAuthor: "Jane Smith" });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.documentAuthor).toBe("Jane Smith");
+    });
+
+    test("sets extension from context", () => {
+      const table = createSmallTable();
+      const context = createTestContext({ extension: ".pdf" });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.extension).toBe(".pdf");
+    });
+
+    test("sets language to 'unknown'", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.language).toBe("unknown");
+    });
+
+    test("sets fileSizeBytes from context", () => {
+      const table = createSmallTable();
+      const context = createTestContext({ fileSizeBytes: 999999 });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.fileSizeBytes).toBe(999999);
+    });
+
+    test("computes contentHash from chunk content", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.contentHash).toBeDefined();
+      expect(typeof chunks[0]!.metadata.contentHash).toBe("string");
+      expect(chunks[0]!.metadata.contentHash.length).toBeGreaterThan(0);
+    });
+
+    test("produces different contentHash for different content", () => {
+      const table1 = createSmallTable();
+      const table2 = createSingleRowTable();
+      const context = createTestContext();
+
+      const chunks1 = indexer.indexTables([table1], context);
+      const chunks2 = indexer.indexTables([table2], context);
+
+      expect(chunks1[0]!.metadata.contentHash).not.toBe(chunks2[0]!.metadata.contentHash);
+    });
+
+    test("sets fileModifiedAt from context", () => {
+      const date = new Date("2025-03-01T00:00:00Z");
+      const table = createSmallTable();
+      const context = createTestContext({ fileModifiedAt: date });
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.fileModifiedAt).toEqual(date);
+    });
+  });
+
+  // ── Caption handling ──────────────────────────────────────────────
+
+  describe("caption handling", () => {
+    test("prepends caption as bold text when present", () => {
+      const table = createTableWithCaption("Revenue Summary");
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.content).toMatch(/^\*\*Table: Revenue Summary\*\*/);
+    });
+
+    test("includes blank line between caption and table", () => {
+      const table = createTableWithCaption("Revenue Summary");
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.content).toContain("**Table: Revenue Summary**\n\n|");
+    });
+
+    test("does not prepend caption when absent", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.content).not.toContain("**Table:");
+      expect(chunks[0]!.content).toMatch(/^\|/); // starts with pipe
+    });
+  });
+
+  // ── Page number propagation ───────────────────────────────────────
+
+  describe("page number propagation", () => {
+    test("sets pageNumber for PDF tables", () => {
+      const table = createPdfTableWithPage(5);
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.pageNumber).toBe(5);
+    });
+
+    test("pageNumber is undefined for DOCX tables", () => {
+      const table = createDocxTable();
+      const context = createDocxContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks[0]!.metadata.pageNumber).toBeUndefined();
+    });
+  });
+
+  // ── Large table splitting ─────────────────────────────────────────
+
+  describe("large table splitting", () => {
+    test("splits tables exceeding maxChunkTokens", () => {
+      const table = createLargeTable(50);
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    test("repeats header in each sub-chunk", () => {
+      const table = createLargeTable(50);
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      for (const chunk of chunks) {
+        expect(chunk.content).toContain("| Employee ID |");
+        expect(chunk.content).toContain("| --- |");
+      }
+    });
+
+    test("covers all data rows across sub-chunks", () => {
+      const rowCount = 30;
+      const table = createLargeTable(rowCount);
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      // Collect all non-header data rows from all chunks
+      const allDataLines = new Set<string>();
+      for (const chunk of chunks) {
+        const lines = chunk.content.split("\n");
+        for (const line of lines) {
+          // Skip header row, separator, and caption
+          if (
+            line.startsWith("| Employee ID") ||
+            line.startsWith("| ---") ||
+            line.startsWith("**Table:")
+          ) {
+            continue;
+          }
+          if (line.startsWith("| EMP-")) {
+            allDataLines.add(line);
+          }
+        }
+      }
+
+      expect(allDataLines.size).toBe(rowCount);
+    });
+
+    test("assigns sequential chunkIndex values", () => {
+      const table = createLargeTable(50);
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      for (let i = 0; i < chunks.length; i++) {
+        expect(chunks[i]!.chunkIndex).toBe(i);
+      }
+    });
+
+    test("sets consistent totalChunks across sub-chunks", () => {
+      const table = createLargeTable(50);
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      const totalChunks = chunks[0]!.totalChunks;
+      expect(totalChunks).toBe(chunks.length);
+      for (const chunk of chunks) {
+        expect(chunk.totalChunks).toBe(totalChunks);
+      }
+    });
+
+    test("each sub-chunk respects token limit", () => {
+      const table = createLargeTable(50);
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      for (const chunk of chunks) {
+        const tokens = estimateTokens(chunk.content);
+        // Allow some tolerance since header repetition can add tokens
+        // The splitting algorithm targets maxChunkTokens but may slightly exceed
+        // when a single row plus header exceeds the limit
+        expect(tokens).toBeLessThan(1000); // generous upper bound
+      }
+    });
+
+    test("generates correct sub-chunk IDs", () => {
+      const table = createLargeTable(50, { tableIndex: 1 });
+      const context = createTestContext({ repository: "repo", filePath: "file.pdf" });
+      const chunks = indexer.indexTables([table], context);
+
+      for (let i = 0; i < chunks.length; i++) {
+        expect(chunks[i]!.id).toBe(`repo:file.pdf:table-1:${i}`);
+      }
+    });
+
+    test("preserves caption in each sub-chunk when present", () => {
+      const table = createLargeTable(50);
+      table.table.caption = "Large Employee Table";
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      for (const chunk of chunks) {
+        expect(chunk.content).toContain("**Table: Large Employee Table**");
+      }
+    });
+
+    test("preserves metadata across all sub-chunks", () => {
+      const table = createLargeTable(50, { confidence: 0.88, tableIndex: 3 });
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      for (const chunk of chunks) {
+        expect(chunk.metadata.isTable).toBe(true);
+        expect(chunk.metadata.tableIndex).toBe(3);
+        expect(chunk.metadata.tableConfidence).toBe(0.88);
+        expect(chunk.metadata.tableColumnCount).toBe(4);
+      }
+    });
+  });
+
+  // ── Multiple tables ───────────────────────────────────────────────
+
+  describe("multiple tables", () => {
+    test("produces separate chunks for each table", () => {
+      const tables = createMultipleTableResults(3);
+      const context = createTestContext();
+      const chunks = indexer.indexTables(tables, context);
+
+      // Each small table should produce 1 chunk
+      expect(chunks.length).toBe(3);
+    });
+
+    test("assigns distinct IDs per table", () => {
+      const tables = createMultipleTableResults(3);
+      const context = createTestContext();
+      const chunks = indexer.indexTables(tables, context);
+
+      const ids = chunks.map((c) => c.id);
+      const uniqueIds = new Set(ids);
+      expect(uniqueIds.size).toBe(ids.length);
+    });
+
+    test("table content matches expected table data", () => {
+      const tables = createMultipleTableResults(2);
+      const context = createTestContext();
+      const chunks = indexer.indexTables(tables, context);
+
+      expect(chunks[0]!.content).toContain("Header 0A");
+      expect(chunks[0]!.content).toContain("Data 0A");
+      expect(chunks[1]!.content).toContain("Header 1A");
+      expect(chunks[1]!.content).toContain("Data 1A");
+    });
+
+    test("preserves per-table metadata", () => {
+      const tables = createMultipleTableResults(3, "pdf");
+      const context = createTestContext();
+      const chunks = indexer.indexTables(tables, context);
+
+      for (let i = 0; i < chunks.length; i++) {
+        expect(chunks[i]!.metadata.tableIndex).toBe(i);
+        expect(chunks[i]!.metadata.pageNumber).toBe(i + 1);
+      }
+    });
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    test("returns empty array for empty tables input", () => {
+      const context = createTestContext();
+      const chunks = indexer.indexTables([], context);
+
+      expect(chunks).toEqual([]);
+    });
+
+    test("skips tables with empty rows (produces no chunks)", () => {
+      const table = createEmptyTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks).toEqual([]);
+    });
+
+    test("handles header-only table", () => {
+      const table = createHeaderOnlyTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks.length).toBe(1);
+      expect(chunks[0]!.content).toContain("Column A");
+      expect(chunks[0]!.metadata.tableRowCount).toBe(0); // no data rows
+    });
+
+    test("handles table with no headers", () => {
+      const table = createNoHeaderTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks.length).toBe(1);
+      expect(chunks[0]!.content).toContain("Value A1");
+      expect(chunks[0]!.content).toContain("Value B2");
+      expect(chunks[0]!.metadata.tableRowCount).toBe(2);
+    });
+
+    test("handles single data row table", () => {
+      const table = createSingleRowTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      expect(chunks.length).toBe(1);
+      expect(chunks[0]!.content).toContain("Total");
+      expect(chunks[0]!.content).toContain("42");
+      expect(chunks[0]!.metadata.tableRowCount).toBe(1);
+    });
+
+    test("handles mix of empty and non-empty tables", () => {
+      const tables = [createEmptyTable({ tableIndex: 0 }), createSmallTable({ tableIndex: 1 })];
+      const context = createTestContext();
+      const chunks = indexer.indexTables(tables, context);
+
+      // Only the non-empty table should produce chunks
+      expect(chunks.length).toBe(1);
+      expect(chunks[0]!.metadata.tableIndex).toBe(1);
+    });
+  });
+
+  // ── ChromaDB metadata completeness ────────────────────────────────
+
+  describe("ChromaDB metadata completeness", () => {
+    test("includes all required base metadata fields", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      const meta = chunks[0]!.metadata;
+      expect(meta.extension).toBeDefined();
+      expect(meta.language).toBeDefined();
+      expect(meta.fileSizeBytes).toBeDefined();
+      expect(meta.contentHash).toBeDefined();
+      expect(meta.fileModifiedAt).toBeDefined();
+      expect(meta.documentType).toBeDefined();
+    });
+
+    test("includes all table-specific metadata fields", () => {
+      const table = createTableWithCaption("Test Caption");
+      table.confidence = 0.95;
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      const meta = chunks[0]!.metadata;
+      expect(meta.isTable).toBe(true);
+      expect(meta.tableIndex).toBeDefined();
+      expect(meta.tableCaption).toBe("Test Caption");
+      expect(meta.tableColumnCount).toBeDefined();
+      expect(meta.tableRowCount).toBeDefined();
+      expect(meta.tableSourceType).toBeDefined();
+      expect(meta.tableConfidence).toBe(0.95);
+    });
+
+    test("chunk has all required DocumentChunk fields", () => {
+      const table = createSmallTable();
+      const context = createTestContext();
+      const chunks = indexer.indexTables([table], context);
+
+      const chunk = chunks[0]!;
+      expect(chunk.id).toBeDefined();
+      expect(chunk.repository).toBeDefined();
+      expect(chunk.filePath).toBeDefined();
+      expect(chunk.content).toBeDefined();
+      expect(typeof chunk.chunkIndex).toBe("number");
+      expect(typeof chunk.totalChunks).toBe("number");
+      expect(typeof chunk.startLine).toBe("number");
+      expect(typeof chunk.endLine).toBe("number");
+      expect(chunk.metadata).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Extends `DocumentChunkMetadata`** with 7 optional table-specific fields (`isTable`, `tableIndex`, `tableCaption`, `tableColumnCount`, `tableRowCount`, `tableSourceType`, `tableConfidence`) for filtering and context in ChromaDB
- **Creates `TableContentIndexer` class** — a standalone utility that converts `TableExtractionResult[]` into `DocumentChunk[]` using Markdown formatting, with configurable token limits and automatic large-table splitting with header repetition
- **Adds comprehensive test fixtures** (`table-indexer-fixtures.ts`) with builder functions for small tables, large tables, captions, PDF/DOCX sources, multi-table documents, and edge cases
- **53 unit tests at 100% coverage** covering configuration, metadata propagation, caption handling, page numbers, large table splitting, multiple tables, and edge cases (empty, header-only, no-header, single-row)

Closes #416

## Design Decisions

1. **Markdown format** — `TableFormatter.toMarkdown()` preserves header/data structure, is well-understood by embedding models, and is human-readable in search results
2. **Header repetition** — When splitting large tables, each sub-chunk repeats header row(s) so each chunk is independently meaningful for semantic search
3. **Chunk ID format** — `{repository}:{filePath}:table-{tableIndex}:{subChunkIndex}` distinguishes table chunks from text chunks and enables per-table deletion
4. **Standalone utility** — No dependencies on services/storage/embedding; produces `DocumentChunk[]` for the caller (future ingestion pipeline) to embed and store

## Files Changed

| File | Action | Purpose |
|------|--------|---------|
| `src/documents/types.ts` | Modified | Add 7 optional table fields to `DocumentChunkMetadata` |
| `src/documents/TableContentIndexer.ts` | Created | Core class: tables → `DocumentChunk[]` |
| `src/documents/index.ts` | Modified | Export new class and types |
| `tests/fixtures/documents/table-indexer-fixtures.ts` | Created | Test fixture builders |
| `tests/unit/documents/TableContentIndexer.test.ts` | Created | 53 unit tests (100% coverage) |

## Out of Scope

- DocumentSearchService changes (table-aware search filtering = separate issue)
- Document ingestion pipeline integration (separate issue)
- CLI commands for tables
- MCP tool schema changes

## Test plan

- [x] `bun test tests/unit/documents/TableContentIndexer.test.ts` — 53 tests pass, 100% coverage
- [x] `bun run typecheck` — No type errors
- [x] `bun run build` — Builds without errors
- [x] Full test suite — 4251 pass, 31 pre-existing failures (Roslyn/DocxExtractor, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)