### PR TITLE
feat: add sentence/word boundary fallbacks for chunking (#366)

### DIFF
--- a/src/documents/DocumentChunker.ts
+++ b/src/documents/DocumentChunker.ts
@@ -62,7 +62,11 @@ interface ChunkPositionData {
  * - **Section heading context**: Attaches nearest section heading to each chunk
  * - **Document metadata**: Preserves document type, title, and author in chunk metadata
  *
- * Falls back to FileChunker's line-level splitting when paragraphs exceed token limits.
+ * When paragraphs exceed token limits, falls back through a hierarchy:
+ * **Paragraph > Sentence > Word > (oversized word in own chunk)**.
+ * Sentence boundaries use punctuation followed by whitespace; word boundaries
+ * use whitespace splitting. Single words exceeding the token limit are emitted
+ * as their own chunk (never broken mid-word).
  *
  * When `overlapTokens > 0`, paragraph-boundary chunking carries the last N whole
  * paragraphs (fitting within the overlap budget) from the flushed group into the
@@ -345,8 +349,8 @@ export class DocumentChunker extends FileChunker {
    * into chunks respecting the token limit. When `overlapTokens > 0`,
    * the last N whole paragraphs fitting within the overlap budget are
    * carried from the flushed group into the next group for semantic
-   * continuity across chunk boundaries. Falls back to line-level
-   * splitting for individual paragraphs that exceed the token limit.
+   * continuity across chunk boundaries. Falls back through sentence
+   * and word boundaries for individual paragraphs that exceed the token limit.
    * Character offsets are tracked for section heading lookup.
    *
    * @param content - Full document content
@@ -378,17 +382,11 @@ export class DocumentChunker extends FileChunker {
     for (const paragraph of paragraphs) {
       const paragraphTokens = estimateTokens(paragraph.content);
 
-      // If single paragraph exceeds limit, chunk it with line-level splitting
+      // If single paragraph exceeds limit, chunk it with sentence/word fallbacks
       if (paragraphTokens > this.maxTokens && currentParagraphs.length === 0) {
-        const lineChunks = this.chunkFile(paragraph.content, fileInfo, source);
-        for (const chunk of lineChunks) {
-          allChunks.push({
-            ...chunk,
-            startLine: paragraph.startLine + chunk.startLine - 1,
-            endLine: paragraph.startLine + chunk.endLine - 1,
-          });
-          positions.push({ charOffset: paragraph.charOffset });
-        }
+        const subResult = this.chunkOversizedParagraph(paragraph, fileInfo, source, filePath);
+        allChunks.push(...subResult.chunks);
+        positions.push(...subResult.positions);
         overlapCount = 0;
         continue;
       }
@@ -532,6 +530,221 @@ export class DocumentChunker extends FileChunker {
     }
 
     return overlap;
+  }
+
+  /**
+   * Split text into sentences at punctuation boundaries.
+   *
+   * Uses a lookbehind regex to split after sentence-ending punctuation
+   * (`.`, `!`, `?`) followed by whitespace. Keeps punctuation attached
+   * to the preceding sentence. Imperfect for abbreviations and decimals,
+   * but acceptable for document chunking purposes.
+   *
+   * @param text - Text to split into sentences
+   * @returns Array of sentences (at least one element)
+   */
+  private splitIntoSentences(text: string): string[] {
+    const sentences = text.split(/(?<=[.!?])\s+/).filter((s) => s.length > 0);
+    return sentences.length > 0 ? sentences : [text];
+  }
+
+  /**
+   * Split text into words on whitespace boundaries.
+   *
+   * @param text - Text to split into words
+   * @returns Array of words (empty strings filtered out)
+   */
+  private splitIntoWords(text: string): string[] {
+    return text.split(/\s+/).filter((w) => w.length > 0);
+  }
+
+  /**
+   * Chunk an oversized paragraph using sentence and word boundary fallbacks.
+   *
+   * Fallback hierarchy:
+   * 1. If paragraph has internal newlines, try line-level splitting first
+   * 2. Split into sentences and group into chunks respecting maxTokens
+   * 3. For sentences exceeding maxTokens, split by words
+   * 4. Single words exceeding maxTokens get their own chunk (never broken mid-word)
+   *
+   * @param paragraph - The oversized paragraph block
+   * @param fileInfo - FileInfo for metadata
+   * @param source - Repository or source name
+   * @param filePath - Relative file path
+   * @returns Chunks and their position data
+   */
+  private chunkOversizedParagraph(
+    paragraph: ParagraphBlock,
+    fileInfo: FileInfo,
+    source: string,
+    filePath: string
+  ): { chunks: FileChunk[]; positions: ChunkPositionData[] } {
+    // If paragraph has internal newlines, try line-level splitting first
+    if (paragraph.content.includes("\n")) {
+      const lineChunks = this.chunkFile(paragraph.content, fileInfo, source);
+      // Check if line-level produced reasonable chunks (all within limit)
+      const allWithinLimit = lineChunks.every(
+        (chunk) => estimateTokens(chunk.content) <= this.maxTokens
+      );
+      if (allWithinLimit) {
+        const chunks = lineChunks.map((chunk) => ({
+          ...chunk,
+          startLine: paragraph.startLine + chunk.startLine - 1,
+          endLine: paragraph.startLine + chunk.endLine - 1,
+        }));
+        const positions = chunks.map(() => ({ charOffset: paragraph.charOffset }));
+        return { chunks, positions };
+      }
+    }
+
+    // Sentence-level splitting
+    const sentences = this.splitIntoSentences(paragraph.content);
+    const resultChunks: FileChunk[] = [];
+    const resultPositions: ChunkPositionData[] = [];
+    let currentParts: string[] = [];
+    let currentTokens = 0;
+
+    const flushCurrent = (): void => {
+      if (currentParts.length === 0) return;
+      const content = currentParts.join(" ");
+      resultChunks.push({
+        id: createChunkId(source, filePath, resultChunks.length),
+        repository: source,
+        filePath,
+        content,
+        chunkIndex: resultChunks.length,
+        totalChunks: 0, // Updated later
+        startLine: paragraph.startLine,
+        endLine: paragraph.endLine,
+        metadata: {
+          extension: fileInfo.extension,
+          language: detectLanguage(filePath),
+          fileSizeBytes: fileInfo.sizeBytes,
+          contentHash: computeContentHash(content),
+          fileModifiedAt: fileInfo.modifiedAt,
+        },
+      });
+      resultPositions.push({ charOffset: paragraph.charOffset });
+      currentParts = [];
+      currentTokens = 0;
+    };
+
+    for (const sentence of sentences) {
+      const sentenceTokens = estimateTokens(sentence);
+
+      // If sentence itself exceeds limit, split by words
+      if (sentenceTokens > this.maxTokens) {
+        flushCurrent();
+        const wordChunks = this.chunkByWords(sentence, paragraph, fileInfo, source, filePath);
+        resultChunks.push(...wordChunks.chunks);
+        resultPositions.push(...wordChunks.positions);
+        continue;
+      }
+
+      // If adding this sentence would exceed limit, flush first
+      if (currentTokens + sentenceTokens > this.maxTokens && currentParts.length > 0) {
+        flushCurrent();
+      }
+
+      currentParts.push(sentence);
+      currentTokens += sentenceTokens;
+    }
+
+    flushCurrent();
+
+    return { chunks: resultChunks, positions: resultPositions };
+  }
+
+  /**
+   * Chunk text by word boundaries when sentence-level splitting is insufficient.
+   *
+   * Groups words into chunks respecting maxTokens. Single words exceeding
+   * the limit are emitted as their own chunk (never broken mid-word).
+   *
+   * @param text - Text to chunk by words
+   * @param paragraph - Source paragraph for position data
+   * @param fileInfo - FileInfo for metadata
+   * @param source - Repository or source name
+   * @param filePath - Relative file path
+   * @returns Chunks and their position data
+   */
+  private chunkByWords(
+    text: string,
+    paragraph: ParagraphBlock,
+    fileInfo: FileInfo,
+    source: string,
+    filePath: string
+  ): { chunks: FileChunk[]; positions: ChunkPositionData[] } {
+    const words = this.splitIntoWords(text);
+    const resultChunks: FileChunk[] = [];
+    const resultPositions: ChunkPositionData[] = [];
+    let currentWords: string[] = [];
+    let currentTokens = 0;
+
+    const flushWords = (): void => {
+      if (currentWords.length === 0) return;
+      const content = currentWords.join(" ");
+      resultChunks.push({
+        id: createChunkId(source, filePath, resultChunks.length),
+        repository: source,
+        filePath,
+        content,
+        chunkIndex: resultChunks.length,
+        totalChunks: 0,
+        startLine: paragraph.startLine,
+        endLine: paragraph.endLine,
+        metadata: {
+          extension: fileInfo.extension,
+          language: detectLanguage(filePath),
+          fileSizeBytes: fileInfo.sizeBytes,
+          contentHash: computeContentHash(content),
+          fileModifiedAt: fileInfo.modifiedAt,
+        },
+      });
+      resultPositions.push({ charOffset: paragraph.charOffset });
+      currentWords = [];
+      currentTokens = 0;
+    };
+
+    for (const word of words) {
+      const wordTokens = estimateTokens(word);
+
+      // Single word exceeds limit - emit as its own chunk
+      if (wordTokens > this.maxTokens) {
+        flushWords();
+        const content = word;
+        resultChunks.push({
+          id: createChunkId(source, filePath, resultChunks.length),
+          repository: source,
+          filePath,
+          content,
+          chunkIndex: resultChunks.length,
+          totalChunks: 0,
+          startLine: paragraph.startLine,
+          endLine: paragraph.endLine,
+          metadata: {
+            extension: fileInfo.extension,
+            language: detectLanguage(filePath),
+            fileSizeBytes: fileInfo.sizeBytes,
+            contentHash: computeContentHash(content),
+            fileModifiedAt: fileInfo.modifiedAt,
+          },
+        });
+        resultPositions.push({ charOffset: paragraph.charOffset });
+        continue;
+      }
+
+      if (currentTokens + wordTokens > this.maxTokens && currentWords.length > 0) {
+        flushWords();
+      }
+
+      currentWords.push(word);
+      currentTokens += wordTokens;
+    }
+
+    flushWords();
+
+    return { chunks: resultChunks, positions: resultPositions };
   }
 
   /**

--- a/tests/fixtures/documents/document-chunk-fixtures.ts
+++ b/tests/fixtures/documents/document-chunk-fixtures.ts
@@ -72,6 +72,49 @@ The architecture follows a layered approach with clear separation of concerns. E
 This is the conclusion section. It wraps up the discussion and provides actionable recommendations based on the analysis presented in the previous sections.`;
 
 /**
+ * Long prose paragraph with multiple sentences and no internal newlines.
+ *
+ * ~300 tokens (1200+ characters). Simulates dense prose from PDFs/DOCX
+ * where paragraph boundaries don't contain `\n` characters.
+ */
+export const LONG_PROSE_PARAGRAPH =
+  "The architecture of modern distributed systems requires careful consideration of multiple factors including consistency, availability, and partition tolerance. " +
+  "When designing microservices, engineers must evaluate the trade-offs between synchronous and asynchronous communication patterns to ensure optimal performance. " +
+  "Database selection plays a critical role in determining system behavior under load, with relational databases offering strong consistency guarantees while NoSQL alternatives provide horizontal scalability. " +
+  "Caching strategies must be implemented at multiple levels of the stack, from application-level memoization to distributed caches like Redis and Memcached. " +
+  "Monitoring and observability are essential concerns that should be addressed from the earliest stages of development rather than retrofitted after deployment. " +
+  "Security considerations including authentication, authorization, and encryption must be woven into the fabric of the system rather than treated as an afterthought.";
+
+/**
+ * Long single sentence without sentence-ending punctuation boundaries.
+ *
+ * ~200 tokens (800+ characters). Forces word-level splitting when
+ * sentence boundary detection finds no split points.
+ */
+export const LONG_SINGLE_SENTENCE =
+  "The comprehensive analysis of distributed computing paradigms across " +
+  "heterogeneous cloud environments with varying network topologies and " +
+  "diverse workload characteristics including batch processing and " +
+  "real-time streaming and interactive query execution and machine " +
+  "learning inference and data transformation pipelines and event-driven " +
+  "architectures and serverless functions and container orchestration " +
+  "and service mesh configurations and API gateway routing and load " +
+  "balancing algorithms and circuit breaker patterns and retry mechanisms " +
+  "and timeout configurations and connection pooling strategies and " +
+  "thread management approaches and memory allocation techniques and " +
+  "garbage collection tuning and JIT compilation optimization and " +
+  "native code generation and cross-compilation toolchains reveals " +
+  "fundamental constraints on system performance";
+
+/**
+ * Very long single word (~3000 characters).
+ *
+ * Forces the word-level fallback to emit an oversized chunk
+ * since words are never broken mid-character.
+ */
+export const VERY_LONG_WORD = "supercalifragilisticexpialidocious".repeat(90);
+
+/**
  * Large document content that will produce multiple chunks.
  *
  * Generates content with many paragraphs, each ~200 characters (~50 tokens).

--- a/tests/unit/documents/DocumentChunker.test.ts
+++ b/tests/unit/documents/DocumentChunker.test.ts
@@ -9,9 +9,13 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { DocumentChunker } from "../../../src/documents/DocumentChunker.js";
 import type { DocumentChunkerConfig, SectionInfo } from "../../../src/documents/types.js";
 import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
+import { estimateTokens } from "../../../src/ingestion/chunk-utils.js";
 import {
   SMALL_DOCUMENT_CONTENT,
   PARAGRAPH_DOCUMENT_CONTENT,
+  LONG_PROSE_PARAGRAPH,
+  LONG_SINGLE_SENTENCE,
+  VERY_LONG_WORD,
   createMockExtractionResult,
   createMultiPageExtractionResult,
   createSectionedExtractionResult,
@@ -217,21 +221,165 @@ describe("DocumentChunker", () => {
       expect(chunks[0]!.content).toBe(content);
     });
 
-    test("falls back to line-level for oversized paragraphs", () => {
+    test("falls back to sentence splitting for oversized paragraphs", () => {
       const chunker = createChunker({
-        maxChunkTokens: 50,
-        overlapTokens: 5,
+        maxChunkTokens: 100,
+        overlapTokens: 0,
         respectParagraphs: true,
         respectPageBoundaries: false,
       });
 
-      // Single long paragraph that exceeds 50 tokens
-      const longParagraph = Array.from({ length: 80 }, (_, i) => `word${i}`).join(" ");
-      const result = createMockExtractionResult({ content: longParagraph });
+      // LONG_PROSE_PARAGRAPH is ~300 tokens, no internal newlines, has sentence boundaries
+      const result = createMockExtractionResult({ content: LONG_PROSE_PARAGRAPH });
       const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
 
-      // Should split the oversized paragraph at line boundaries
-      expect(chunks.length).toBeGreaterThanOrEqual(1);
+      // Should produce multiple chunks split at sentence boundaries
+      expect(chunks.length).toBeGreaterThan(1);
+
+      // Each chunk should respect the token limit
+      for (const chunk of chunks) {
+        expect(estimateTokens(chunk.content)).toBeLessThanOrEqual(100);
+      }
+
+      // Reassembled content should contain all original sentences
+      const reassembled = chunks.map((c) => c.content).join(" ");
+      expect(reassembled).toContain("architecture of modern distributed");
+      expect(reassembled).toContain("Security considerations");
+    });
+
+    test("falls back to word-level for oversized sentences", () => {
+      const chunker = createChunker({
+        maxChunkTokens: 50,
+        overlapTokens: 0,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+
+      // LONG_SINGLE_SENTENCE has no sentence-ending punctuation boundaries, ~200 tokens
+      const result = createMockExtractionResult({ content: LONG_SINGLE_SENTENCE });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      // Should produce multiple chunks split at word boundaries
+      expect(chunks.length).toBeGreaterThan(1);
+
+      // Each chunk should respect the token limit
+      for (const chunk of chunks) {
+        expect(estimateTokens(chunk.content)).toBeLessThanOrEqual(50);
+      }
+
+      // No chunk should break mid-word
+      for (const chunk of chunks) {
+        const words = chunk.content.split(/\s+/);
+        for (const word of words) {
+          // Each word should be a complete word from the original text
+          expect(LONG_SINGLE_SENTENCE).toContain(word);
+        }
+      }
+    });
+
+    test("never breaks mid-word even for very long words", () => {
+      const chunker = createChunker({
+        maxChunkTokens: 50,
+        overlapTokens: 0,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+
+      // VERY_LONG_WORD is ~3000 chars, a single word that exceeds token limits
+      const result = createMockExtractionResult({ content: VERY_LONG_WORD });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      // Should emit the word as a single oversized chunk rather than breaking it
+      expect(chunks.length).toBe(1);
+      expect(chunks[0]!.content).toBe(VERY_LONG_WORD);
+    });
+
+    test("sentence-boundary fallback respects token limit", () => {
+      const chunker = createChunker({
+        maxChunkTokens: 80,
+        overlapTokens: 0,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+
+      const result = createMockExtractionResult({ content: LONG_PROSE_PARAGRAPH });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      // Every chunk must be within the token limit
+      for (const chunk of chunks) {
+        expect(estimateTokens(chunk.content)).toBeLessThanOrEqual(80);
+      }
+    });
+
+    test("mixed sentence sizes group correctly", () => {
+      const chunker = createChunker({
+        maxChunkTokens: 40,
+        overlapTokens: 0,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+
+      // Mix of short and medium sentences totaling ~100 tokens with 40 token limit
+      const content =
+        "Short one. Another short sentence here. " +
+        "This is a medium length sentence that adds significantly more tokens to the overall mix. " +
+        "Tiny. " +
+        "This is yet another medium sentence that should definitely push us past the boundary limit. " +
+        "The final concluding sentence wraps everything up nicely here.";
+
+      const result = createMockExtractionResult({ content });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(estimateTokens(chunk.content)).toBeLessThanOrEqual(40);
+      }
+    });
+
+    test("multi-line oversized paragraph still uses line-level splitting", () => {
+      const chunker = createChunker({
+        maxChunkTokens: 50,
+        overlapTokens: 0,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+
+      // Multi-line paragraph with internal \n characters (not \n\n) - 80+ tokens
+      const lines = Array.from({ length: 20 }, (_, i) => `Line ${i}: content for line ${i}`);
+      const multiLineParagraph = lines.join("\n");
+      const result = createMockExtractionResult({ content: multiLineParagraph });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      // Should split successfully using line-level splitting
+      expect(chunks.length).toBeGreaterThan(1);
+      for (const chunk of chunks) {
+        expect(estimateTokens(chunk.content)).toBeLessThanOrEqual(50);
+      }
+    });
+
+    test("sentence splitting handles common edge cases", () => {
+      const chunker = createChunker({
+        maxChunkTokens: 40,
+        overlapTokens: 0,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+
+      // Content with abbreviation-like periods (Dr., Mr.) and decimals (3.14)
+      // These will cause imperfect splits, but no content should be lost
+      const content =
+        "Dr. Smith analyzed the data showing 3.14 as the ratio. " +
+        "The results were significant. " +
+        "Mr. Jones confirmed the findings in his independent review. " +
+        "The conclusion was unanimous.";
+
+      const result = createMockExtractionResult({ content });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      // Should produce chunks without losing content
+      const reassembled = chunks.map((c) => c.content).join(" ");
+      expect(reassembled).toContain("3.14");
+      expect(reassembled).toContain("conclusion was unanimous");
     });
 
     test("groups multiple small paragraphs into one chunk", () => {


### PR DESCRIPTION
## Summary

- **Adds sentence-boundary splitting** as intermediate fallback when a single paragraph exceeds the token limit but has no internal newlines (common in PDFs/DOCX prose)
- **Adds word-boundary splitting** as final fallback when individual sentences still exceed the token limit
- **Never breaks mid-word** — oversized single words are emitted as their own chunk rather than being truncated

The chunking fallback hierarchy is now: **Paragraph > Sentence > Word > (oversized word in own chunk)**.

Previously, the `DocumentChunker` fell back to `FileChunker.chunkFile()` (line-level splitting) for oversized paragraphs. For dense prose text without `\n` characters, this produced a single oversized chunk since there were no line boundaries to split on.

### Changes

| File | Changes |
|------|---------|
| `src/documents/DocumentChunker.ts` | Added `splitIntoSentences()`, `splitIntoWords()`, `chunkOversizedParagraph()`, `chunkByWords()` methods; updated `chunkByParagraphs()` fallback; updated class JSDoc |
| `tests/fixtures/documents/document-chunk-fixtures.ts` | Added `LONG_PROSE_PARAGRAPH`, `LONG_SINGLE_SENTENCE`, `VERY_LONG_WORD` fixtures |
| `tests/unit/documents/DocumentChunker.test.ts` | Updated 1 existing test, added 6 new tests for sentence/word splitting |

Closes #366

## Test plan

- [x] `bun run typecheck` — passes with no errors
- [x] `bun test tests/unit/documents/DocumentChunker.test.ts` — all 70 tests pass
- [x] `bun run build` — clean build
- [x] Sentence-boundary fallback splits dense prose into token-limited chunks
- [x] Word-boundary fallback handles long sentences without punctuation
- [x] Very long single words emitted as own chunk (never broken mid-word)
- [x] Mixed sentence sizes group correctly within token budget
- [x] Multi-line oversized paragraphs still use line-level splitting first
- [x] Edge cases (abbreviations, decimals) don't lose content

🤖 Generated with [Claude Code](https://claude.com/claude-code)