### PR TITLE
test: add concurrent-import singleton test for ensurePdfParse()

### DIFF
--- a/src/documents/extractors/DocxExtractor.ts
+++ b/src/documents/extractors/DocxExtractor.ts
@@ -14,7 +14,6 @@ import { DOMParser } from "@xmldom/xmldom";
 import { DOCUMENT_EXTENSIONS, DEFAULT_EXTRACTOR_CONFIG } from "../constants.js";
 import { ExtractionError, ExtractionTimeoutError, UnsupportedFormatError } from "../errors.js";
 import { BaseExtractor } from "./BaseExtractor.js";
-import { getComponentLogger } from "../../logging/index.js";
 import type { DocumentMetadata, ExtractionResult, ExtractorConfig, SectionInfo } from "../types.js";
 import { getComponentLogger } from "../../logging/index.js";
 

--- a/tests/isolated/pdf-extractor-concurrent-import.test.ts
+++ b/tests/isolated/pdf-extractor-concurrent-import.test.ts
@@ -10,6 +10,12 @@
  * for the process, and each isolated file runs in its own Bun worker to
  * guarantee a fresh pdfParsePromise = undefined starting state.
  *
+ * Note: This is a positive singleton test — it confirms concurrent calls share
+ * a single import. It does not prove the singleton is *necessary* (i.e., that
+ * removing it would cause duplicate imports), because that would require
+ * modifying module-private state. The test's secondary value is as a smoke test
+ * confirming concurrent extractions succeed without error.
+ *
  * Fixes #501 — missing singleton test for ensurePdfParse().
  *
  * @module tests/isolated/pdf-extractor-concurrent-import
@@ -41,7 +47,7 @@ void mock.module("pdf-parse/lib/pdf-parse.js", () => {
       numpages: number;
       numrender: number;
       info: Record<string, unknown>;
-      metadata: null;
+      metadata: unknown;
       text: string;
     }> => {
       // Simulate a single-page PDF
@@ -70,9 +76,12 @@ void mock.module("pdf-parse/lib/pdf-parse.js", () => {
   };
 });
 
-// Import AFTER mock.module so the mock is active when PdfExtractor's dynamic import() resolves
-import { PdfExtractor } from "../../src/documents/extractors/PdfExtractor.js";
-import { createTestPdfFiles } from "../fixtures/documents/pdf-fixtures.js";
+// Dynamic imports after mock setup — using await import() (matching extractor-timeout.test.ts
+// pattern) instead of static import to ensure the mock factory is evaluated during this
+// dynamic import, not eagerly cached by the module system. This makes importInvocationCount
+// deterministic: exactly 1 after module resolution.
+const { PdfExtractor } = await import("../../src/documents/extractors/PdfExtractor.js");
+const { createTestPdfFiles } = await import("../fixtures/documents/pdf-fixtures.js");
 
 let fixtureDir: string;
 let pdfFilePath: string;
@@ -96,8 +105,9 @@ describe("PdfExtractor concurrent-import singleton", () => {
   test("concurrent extractions trigger only a single import() of pdf-parse", async () => {
     const extractor = new PdfExtractor({ extractPageInfo: true });
 
-    // Reset counter before the concurrent calls (mock.module factory may have
-    // been evaluated during module-level import resolution above)
+    // The dynamic import above loaded PdfExtractor but did NOT call ensurePdfParse()
+    // (it's lazy — only invoked during extract()). Reset counter to isolate the
+    // concurrent extract() calls below.
     importInvocationCount = 0;
 
     // Fire two concurrent extractions — both will call ensurePdfParse()
@@ -115,10 +125,12 @@ describe("PdfExtractor concurrent-import singleton", () => {
     expect(result2.content).toBeTruthy();
     expect(result2.metadata).toBeDefined();
 
-    // The singleton should have prevented a second import() invocation.
-    // importInvocationCount may be 0 (if the promise was already cached from
-    // the static import resolution) or 1 (first concurrent call triggered it).
-    // It must NEVER be 2, which would mean the singleton failed.
-    expect(importInvocationCount).toBeLessThanOrEqual(1);
+    // With dynamic imports, ensurePdfParse() is not called until extract() runs.
+    // The first concurrent call enters the `if (!pdfParsePromise)` block and sets
+    // pdfParsePromise synchronously to the IIFE promise, triggering exactly one
+    // factory evaluation. The second concurrent call sees pdfParsePromise already
+    // set and returns the cached promise — no second factory evaluation.
+    // Count must be exactly 1: one import, not two (singleton deduplication works).
+    expect(importInvocationCount).toBe(1);
   });
 });


### PR DESCRIPTION
## Summary

- Adds isolated test validating that `ensurePdfParse()`'s async lazy singleton pattern prevents duplicate `import()` calls under concurrent access
- Uses `mock.module` to intercept `pdf-parse/lib/pdf-parse.js` with an invocation counter, then fires two concurrent `extractor.extract()` calls via `Promise.all`
- Asserts both extractions succeed and `importInvocationCount` never exceeds 1
- Fixes pre-existing CI typecheck failure: adds missing `getComponentLogger` import in `DocxExtractor.ts`

Closes #501

## Context

PR #500 fixed a race condition in `ensurePdfParse()` by caching the **promise** instead of the resolved value. The code review (Finding #2) noted there was no test validating the singleton behavior under concurrent access. This PR adds that missing test.

## Changes

### New file: `tests/isolated/pdf-extractor-concurrent-import.test.ts`
- Mocks `pdf-parse/lib/pdf-parse.js` with an invocation counter
- Fires two concurrent `extractor.extract()` calls via `Promise.all`
- Asserts both succeed and the import factory runs at most once (singleton works)
- Isolated test (runs in its own Bun worker for clean `pdfParsePromise` state)

### Fix: `src/documents/extractors/DocxExtractor.ts`
- Added missing `import { getComponentLogger } from "../../logging/index.js"`
- Resolves 4x TS2304 errors that were failing the CI typecheck step

## Test plan

- [x] New test passes individually (`bun test tests/isolated/pdf-extractor-concurrent-import.test.ts`)
- [x] Full unit test suite — no regressions (pre-existing flaky DocxExtractor failures unchanged)
- [x] TypeScript typecheck passes clean (`bun run typecheck`)
- [x] Build completes successfully (`bun run build`)
- [x] Lint-staged hooks pass on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)