### PR TITLE
test: add integration tests for Phase 6 document MCP tools

### DIFF
--- a/tests/integration/mcp/tools/list-watched-folders.integration.test.ts
+++ b/tests/integration/mcp/tools/list-watched-folders.integration.test.ts
@@ -461,6 +461,9 @@ describe("list_watched_folders MCP Tool Integration Tests", () => {
   );
 
   // ---- 11. Enabled flag is preserved in response --------------------------
+  // Note: only enabled=true is tested here because FolderWatcherService.startWatching()
+  // requires an active watcher. Testing enabled=false would require a different setup
+  // path (e.g. loading persisted config) which is beyond the scope of this integration test.
 
   it(
     "should preserve the enabled flag from the folder configuration",

--- a/tests/integration/mcp/tools/search-documents.integration.test.ts
+++ b/tests/integration/mcp/tools/search-documents.integration.test.ts
@@ -583,6 +583,38 @@ describeIntegration("search_documents MCP Tool Integration Tests", () => {
         expect(r.isTable).toBeUndefined();
       }
     });
+
+    it("should return both table and non-table chunks when include_tables is 'include'", async () => {
+      await indexTestDocumentFolder(REPO_TABLE, COLLECTION_TABLE_FOLDER, [
+        {
+          content: "| Metric | Value |\n|---|---|\n| Recall | 0.88 |",
+          filePath: "combined.pdf",
+          chunkIndex: 0,
+          documentType: "pdf",
+          isTable: true,
+          tableCaption: "Recall Metrics",
+          tableColumnCount: 2,
+          tableRowCount: 1,
+        },
+        {
+          content: "The recall metric measures the proportion of relevant items retrieved.",
+          filePath: "combined.pdf",
+          chunkIndex: 1,
+          documentType: "pdf",
+        },
+      ]);
+
+      const { parsed, result } = await callHandler({
+        query: "recall metric proportion",
+        include_tables: "include",
+        threshold: 0.0,
+        limit: 10,
+      });
+
+      expect(result.isError).toBe(false);
+      // Both table and non-table chunks should appear
+      expect(parsed.results.length).toBeGreaterThanOrEqual(1);
+    });
   });
 
   describe("Threshold filtering", () => {

--- a/tests/integration/mcp/tools/search-images.integration.test.ts
+++ b/tests/integration/mcp/tools/search-images.integration.test.ts
@@ -1,6 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /**
  * Integration tests for the search_images MCP tool handler
  *
@@ -15,6 +12,10 @@
  *
  * @module tests/integration/mcp/tools/search-images.integration
  */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import { createSearchImagesHandler } from "../../../../src/mcp/tools/search-images.js";
@@ -526,6 +527,7 @@ describe("search_images MCP Tool - Integration Tests", () => {
       // mapToMCPError sanitizes generic Error messages
       expect(errorText).not.toContain("/internal/secret/path");
       expect(errorText).not.toContain("5432");
+      expect(errorText).toContain("unexpected error occurred");
     });
 
     it("should handle non-Error thrown values gracefully", async () => {
@@ -536,15 +538,17 @@ describe("search_images MCP Tool - Integration Tests", () => {
         throw "unexpected string error";
       };
 
-      const handler = createSearchImagesHandler(mockService);
-      const result = await handler({});
+      try {
+        const handler = createSearchImagesHandler(mockService);
+        const result = await handler({});
 
-      expect(result.isError).toBe(true);
-      const errorText = (result.content[0] as TextContent).text;
-      expect(errorText).toContain("Error:");
-
-      // Restore original function
-      mockService.searchImages = originalFn;
+        expect(result.isError).toBe(true);
+        const errorText = (result.content[0] as TextContent).text;
+        expect(errorText).toContain("Error:");
+      } finally {
+        // Restore original function even if assertions fail
+        mockService.searchImages = originalFn;
+      }
     });
   });
 

--- a/tests/integration/mcp/tools/semantic-search-documents.integration.test.ts
+++ b/tests/integration/mcp/tools/semantic-search-documents.integration.test.ts
@@ -188,6 +188,18 @@ describeIntegration("semantic_search MCP Tool with include_documents Integration
       }
     }
     createdCollections.length = 0;
+
+    // Clean up repository metadata for any repos created in previous tests
+    const allRepos = await repositoryService.listRepositories();
+    for (const repo of allRepos) {
+      if (repo.name.startsWith("search-docs-")) {
+        try {
+          await repositoryService.removeRepository(repo.name);
+        } catch (_error) {
+          // Ignore cleanup errors
+        }
+      }
+    }
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add end-to-end integration tests for all Phase 6 document MCP tools: `search_documents`, `search_images`, `list_watched_folders`, and `semantic_search` with `include_documents=true`
- Include performance benchmarks verifying <500ms response targets per PRD requirements
- Total: **103 new test cases** with **296+ assertions** across 4 new test files

## Test Files Created

### `search-documents.integration.test.ts` (24 tests, ChromaDB-gated)
- Full pipeline: MCP handler → `DocumentSearchServiceImpl` → ChromaDB → JSON formatting
- Tests: document metadata fields, `document_types` filter, folder filter, table content filtering (`include`/`only`/`exclude`), threshold/limit enforcement, response format validation, error handling, performance benchmark

### `search-images.integration.test.ts` (49 tests, no external deps)
- Real validation + error mapping + formatting with mock `ImageSearchService`
- Tests: all filter parameters (format, date range, dimensions, filename pattern), EXIF data inclusion/exclusion, limit enforcement, empty results, invalid argument handling (bad dates, inverted ranges, type errors), performance benchmark

### `list-watched-folders.integration.test.ts` (18 tests, filesystem only)
- Real `FolderWatcherService` + `ListWatchedFoldersServiceImpl` + temp directories
- Tests: single/multiple/empty folder lists, response format validation, pattern preservation, null→empty array mapping, handler argument flexibility, error handling, performance benchmark

### `semantic-search-documents.integration.test.ts` (12 tests, ChromaDB-gated)
- Parallel code + document search with merged results
- Tests: `source_type` tagging, similarity-sorted merge, limit on merged total, metadata format (both `repositories_searched` and `document_folders_searched`), graceful degradation when `DocumentSearchService` unavailable, legacy format when `include_documents=false`

## Test Architecture
- ChromaDB-dependent tests gated by `RUN_INTEGRATION_TESTS=true`
- Filesystem tests use temp directories (no gating needed)
- Deterministic `MockEmbeddingProvider` for reproducible similarity scores
- Timestamp-based collection names prevent parallel test conflicts

## Test plan
- [x] `bun run typecheck` — passes
- [x] `bun test tests/integration/mcp/tools/` — 73 pass, 36 skip (ChromaDB/Neo4j not running), 0 fail
- [x] `bun test tests/mcp/ tests/auth/ tests/cli/ ...` — 1131 unit tests pass, 0 fail
- [x] `bun test tests/integration/` — 454 pass, 108 skip, 0 fail
- [x] `bun run build` — succeeds

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)