### PR TITLE
feat: configurable rate limiter and document metadata in search

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -321,7 +321,7 @@ async function main(): Promise<void> {
           { completenessChecker }
         );
 
-        // Create rate limiter (5-minute cooldown by default)
+        // Create rate limiter (2-second cooldown by default, configurable via UPDATE_RATE_LIMIT_MS)
         rateLimiter = new MCPRateLimiter();
 
         // Create job tracker (1-hour retention, 100 max jobs by default)

--- a/src/mcp/rate-limiter.ts
+++ b/src/mcp/rate-limiter.ts
@@ -35,14 +35,16 @@ export interface RateLimitCheckResult {
  * Configuration for the rate limiter
  */
 export interface RateLimiterConfig {
-  /** Cooldown period between triggers in milliseconds (default: 5 minutes) */
+  /** Cooldown period between triggers in milliseconds (default: 2 seconds) */
   cooldownMs?: number;
 }
 
 /**
- * Default cooldown period: 5 minutes
+ * Default cooldown period: 2 seconds
+ *
+ * Can be overridden via the UPDATE_RATE_LIMIT_MS environment variable.
  */
-const DEFAULT_COOLDOWN_MS = 5 * 60 * 1000;
+const DEFAULT_COOLDOWN_MS = 2 * 1000;
 
 /**
  * MCP Rate Limiter
@@ -238,13 +240,19 @@ let sharedInstance: MCPRateLimiter | null = null;
 /**
  * Get the shared rate limiter instance
  *
- * Creates the instance on first call with default configuration.
+ * Creates the instance on first call. Reads the UPDATE_RATE_LIMIT_MS
+ * environment variable to configure the cooldown period. Falls back
+ * to DEFAULT_COOLDOWN_MS (2 seconds) when not set.
  *
  * @returns Shared rate limiter instance
  */
 export function getSharedRateLimiter(): MCPRateLimiter {
   if (!sharedInstance) {
-    sharedInstance = new MCPRateLimiter();
+    const envCooldown = process.env["UPDATE_RATE_LIMIT_MS"];
+    const cooldownMs = envCooldown ? parseInt(envCooldown, 10) : undefined;
+    sharedInstance = new MCPRateLimiter(
+      cooldownMs && !isNaN(cooldownMs) && cooldownMs > 0 ? { cooldownMs } : {}
+    );
   }
   return sharedInstance;
 }

--- a/src/mcp/tools/semantic-search.ts
+++ b/src/mcp/tools/semantic-search.ts
@@ -421,6 +421,17 @@ function formatSearchResponse(response: SearchResponse): TextContent {
         file_extension: result.metadata.file_extension,
         file_size_bytes: result.metadata.file_size_bytes,
         indexed_at: result.metadata.indexed_at,
+        ...(result.metadata.document_type && { document_type: result.metadata.document_type }),
+        ...(result.metadata.document_title && { document_title: result.metadata.document_title }),
+        ...(result.metadata.document_author && {
+          document_author: result.metadata.document_author,
+        }),
+        ...(result.metadata.section_heading && {
+          section_heading: result.metadata.section_heading,
+        }),
+        ...(result.metadata.page_number !== undefined && {
+          page_number: result.metadata.page_number,
+        }),
       },
     })),
     metadata: {

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -672,6 +672,13 @@ export class SearchServiceImpl implements SearchService {
           file_size_bytes: metadata.file_size_bytes ?? 0,
           indexed_at: metadata.indexed_at ?? new Date().toISOString(),
           language: derivedLanguage,
+          ...(metadata.document_type && { document_type: metadata.document_type }),
+          ...(metadata.document_title && { document_title: metadata.document_title }),
+          ...(metadata.document_author && { document_author: metadata.document_author }),
+          ...(metadata.section_heading && { section_heading: metadata.section_heading }),
+          ...(metadata.page_number !== undefined && {
+            page_number: metadata.page_number,
+          }),
         },
       };
     });

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -54,6 +54,16 @@ export interface SearchResult {
     indexed_at: string; // ISO 8601 timestamp
     /** Programming language of the source file (derived from extension) */
     language?: string;
+    /** Document type when result is from document ingestion (e.g. "pdf", "docx", "markdown") */
+    document_type?: string;
+    /** Document title extracted from metadata */
+    document_title?: string;
+    /** Document author extracted from metadata */
+    document_author?: string;
+    /** Section heading within the document */
+    section_heading?: string;
+    /** Page number within the document (for paginated formats) */
+    page_number?: number;
   };
 }
 

--- a/tests/mcp/rate-limiter.test.ts
+++ b/tests/mcp/rate-limiter.test.ts
@@ -150,7 +150,7 @@ describe("MCPRateLimiter", () => {
 
     it("should use default cooldown when not specified", () => {
       const defaultLimiter = new MCPRateLimiter();
-      expect(defaultLimiter.getCooldownMs()).toBe(5 * 60 * 1000); // 5 minutes
+      expect(defaultLimiter.getCooldownMs()).toBe(2 * 1000); // 2 seconds
     });
   });
 
@@ -200,6 +200,42 @@ describe("Shared Rate Limiter", () => {
     const instance1 = getSharedRateLimiter();
     const instance2 = getSharedRateLimiter();
     expect(instance1).toBe(instance2);
+  });
+
+  it("should use UPDATE_RATE_LIMIT_MS env var for cooldown", () => {
+    const original = process.env["UPDATE_RATE_LIMIT_MS"];
+    try {
+      process.env["UPDATE_RATE_LIMIT_MS"] = "30000";
+      resetSharedRateLimiter();
+
+      const instance = getSharedRateLimiter();
+      expect(instance.getCooldownMs()).toBe(30000);
+    } finally {
+      if (original === undefined) {
+        delete process.env["UPDATE_RATE_LIMIT_MS"];
+      } else {
+        process.env["UPDATE_RATE_LIMIT_MS"] = original;
+      }
+      resetSharedRateLimiter();
+    }
+  });
+
+  it("should ignore invalid UPDATE_RATE_LIMIT_MS values", () => {
+    const original = process.env["UPDATE_RATE_LIMIT_MS"];
+    try {
+      process.env["UPDATE_RATE_LIMIT_MS"] = "not-a-number";
+      resetSharedRateLimiter();
+
+      const instance = getSharedRateLimiter();
+      expect(instance.getCooldownMs()).toBe(2 * 1000); // falls back to default
+    } finally {
+      if (original === undefined) {
+        delete process.env["UPDATE_RATE_LIMIT_MS"];
+      } else {
+        process.env["UPDATE_RATE_LIMIT_MS"] = original;
+      }
+      resetSharedRateLimiter();
+    }
   });
 
   it("should create new instance after reset", () => {

--- a/tests/mcp/tools/semantic-search.test.ts
+++ b/tests/mcp/tools/semantic-search.test.ts
@@ -706,6 +706,79 @@ describe("semantic_search Tool", () => {
       expect(metadataAsAny["document_matches"]).toBeUndefined();
     });
 
+    it("should include document metadata fields in code-only response when present", async () => {
+      const docCodeResult: SearchResponse = {
+        results: [
+          {
+            file_path: "docs/guide.pdf",
+            repository: "my-docs",
+            content_snippet: "Chapter 1: Getting Started",
+            similarity_score: 0.88,
+            chunk_index: 0,
+            metadata: {
+              file_extension: ".pdf",
+              file_size_bytes: 50000,
+              indexed_at: "2025-06-01T00:00:00Z",
+              document_type: "pdf",
+              document_title: "User Guide",
+              document_author: "John Smith",
+              section_heading: "Getting Started",
+              page_number: 3,
+            },
+          },
+        ],
+        metadata: {
+          total_matches: 1,
+          query_time_ms: 100,
+          embedding_time_ms: 50,
+          search_time_ms: 50,
+          repositories_searched: ["my-docs"],
+        },
+      };
+
+      mockSearchService.setMockResponse(docCodeResult);
+      const handler = createSemanticSearchHandler(mockSearchService, mockDocSearchService);
+
+      const result = await handler({
+        query: "getting started",
+        include_documents: false,
+      });
+
+      expect(result.isError).toBe(false);
+      const responseData = JSON.parse(
+        (result.content[0] as TextContent).text
+      ) as SemanticSearchResponse;
+
+      const item = responseData.results[0]!;
+      const meta = item.metadata as Record<string, unknown>;
+      expect(meta["document_type"]).toBe("pdf");
+      expect(meta["document_title"]).toBe("User Guide");
+      expect(meta["document_author"]).toBe("John Smith");
+      expect(meta["section_heading"]).toBe("Getting Started");
+      expect(meta["page_number"]).toBe(3);
+    });
+
+    it("should omit document metadata fields when not present in code-only response", async () => {
+      mockSearchService.setMockResponse(codeResult);
+      const handler = createSemanticSearchHandler(mockSearchService, mockDocSearchService);
+
+      const result = await handler({
+        query: "authentication",
+        include_documents: false,
+      });
+
+      const responseData = JSON.parse(
+        (result.content[0] as TextContent).text
+      ) as SemanticSearchResponse;
+
+      const meta = responseData.results[0]!.metadata as Record<string, unknown>;
+      expect(meta["document_type"]).toBeUndefined();
+      expect(meta["document_title"]).toBeUndefined();
+      expect(meta["document_author"]).toBeUndefined();
+      expect(meta["section_heading"]).toBeUndefined();
+      expect(meta["page_number"]).toBeUndefined();
+    });
+
     it("should not call DocumentSearchService when include_documents=false", async () => {
       const handler = createSemanticSearchHandler(mockSearchService, mockDocSearchService);
 


### PR DESCRIPTION
## Summary

- **#524**: Change rate limiter default cooldown from 5 minutes to 2 seconds for better local/dev experience. Add `UPDATE_RATE_LIMIT_MS` environment variable to configure the cooldown on `trigger_incremental_update`.
- **#525**: Surface document metadata fields (`document_type`, `document_title`, `document_author`, `section_heading`, `page_number`) in code-only search responses. Previously these fields were stored in ChromaDB but dropped by `formatResults()` and `formatSearchResponse()`.

## Changes

### Rate Limiter (#524) — 3 files
- `src/mcp/rate-limiter.ts`: Default cooldown from `5 * 60 * 1000` → `2 * 1000`; `getSharedRateLimiter()` reads `UPDATE_RATE_LIMIT_MS` env var
- `src/index.ts`: Updated comment to reflect new default
- `tests/mcp/rate-limiter.test.ts`: Updated default expectation; added tests for env var configuration and invalid env var handling

### Document Metadata (#525) — 4 files
- `src/services/types.ts`: Added optional document fields to `SearchResult.metadata`
- `src/services/search-service.ts`: `formatResults()` passes through document metadata from ChromaDB when present
- `src/mcp/tools/semantic-search.ts`: `formatSearchResponse()` conditionally includes document metadata fields
- `tests/mcp/tools/semantic-search.test.ts`: Added tests for document metadata presence and absence in code-only responses

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test tests/mcp/rate-limiter.test.ts` — 23 tests pass
- [x] `bun test tests/mcp/tools/semantic-search.test.ts` — 46 tests pass
- [x] Full test suite — 1,141 tests pass, 0 failures
- [x] `bun run build` — successful
- [ ] Verify `UPDATE_RATE_LIMIT_MS=60000` configures 1-minute cooldown at runtime
- [ ] Verify document metadata appears in search results for indexed PDF/DOCX files

Closes #524
Closes #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)