### PR TITLE
fix: address code review findings for PdfPageToImageConverter (#398)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "personal-knowledge-mcp",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
+        "@napi-rs/canvas": "0.1.96",
         "@xenova/transformers": "2.17.2",
         "@xmldom/xmldom": "^0.8.6",
         "chalk": "5.6.2",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",
+    "@napi-rs/canvas": "0.1.96",
     "@xenova/transformers": "2.17.2",
     "@xmldom/xmldom": "^0.8.6",
     "chalk": "5.6.2",

--- a/src/documents/PdfPageToImageConverter.ts
+++ b/src/documents/PdfPageToImageConverter.ts
@@ -132,14 +132,27 @@ export class PdfPageToImageConverter {
    * @param config - Converter configuration (missing fields use defaults)
    */
   constructor(config?: PdfImageConverterConfig) {
-    this.config = {
-      dpiResolution: config?.dpiResolution ?? DEFAULT_PDF_IMAGE_CONFIG.dpiResolution,
-      maxPagesPerDocument:
-        config?.maxPagesPerDocument ?? DEFAULT_PDF_IMAGE_CONFIG.maxPagesPerDocument,
-      pageTimeoutMs: config?.pageTimeoutMs ?? DEFAULT_PDF_IMAGE_CONFIG.pageTimeoutMs,
-      maxFileSizeBytes: config?.maxFileSizeBytes ?? DEFAULT_PDF_IMAGE_CONFIG.maxFileSizeBytes,
-      timeoutMs: config?.timeoutMs ?? DEFAULT_PDF_IMAGE_CONFIG.timeoutMs,
-    };
+    const dpiResolution = config?.dpiResolution ?? DEFAULT_PDF_IMAGE_CONFIG.dpiResolution;
+    const maxPagesPerDocument =
+      config?.maxPagesPerDocument ?? DEFAULT_PDF_IMAGE_CONFIG.maxPagesPerDocument;
+    const pageTimeoutMs = config?.pageTimeoutMs ?? DEFAULT_PDF_IMAGE_CONFIG.pageTimeoutMs;
+    const maxFileSizeBytes = config?.maxFileSizeBytes ?? DEFAULT_PDF_IMAGE_CONFIG.maxFileSizeBytes;
+    const timeoutMs = config?.timeoutMs ?? DEFAULT_PDF_IMAGE_CONFIG.timeoutMs;
+
+    if (dpiResolution <= 0) {
+      throw new ExtractionError(`dpiResolution must be positive, got ${dpiResolution}`);
+    }
+    if (maxPagesPerDocument <= 0) {
+      throw new ExtractionError(`maxPagesPerDocument must be positive, got ${maxPagesPerDocument}`);
+    }
+
+    this.config = Object.freeze({
+      dpiResolution,
+      maxPagesPerDocument,
+      pageTimeoutMs,
+      maxFileSizeBytes,
+      timeoutMs,
+    });
   }
 
   /**
@@ -284,6 +297,10 @@ export class PdfPageToImageConverter {
    * or discard each page before the next is rendered. Useful for large
    * documents where holding all images in memory is not desirable.
    *
+   * Unlike convertAllPages which catches per-page rendering errors and continues
+   * processing, this iterator propagates per-page errors to the caller. Consumers
+   * should wrap the for-await loop in try/catch for graceful degradation.
+   *
    * @param pdfBuffer - PDF file data
    * @yields Rendered page images one at a time
    * @throws {ExtractionError} If the PDF cannot be loaded
@@ -335,7 +352,13 @@ export class PdfPageToImageConverter {
   private async loadDocument(buffer: Buffer | Uint8Array): Promise<PDFDocumentProxy> {
     const pdfjs = await ensurePdfjs();
     try {
-      const data = new Uint8Array(buffer);
+      // pdfjs-dist accepts Uint8Array directly; Buffer is a Uint8Array subclass.
+      // Only copy when the buffer is a view into a larger ArrayBuffer to avoid
+      // doubling peak memory usage for large PDFs (up to 50MB configured max).
+      const data =
+        buffer.byteOffset === 0 && buffer.byteLength === buffer.buffer.byteLength
+          ? buffer
+          : new Uint8Array(buffer);
       const doc = await pdfjs.getDocument({ data }).promise;
       return doc;
     } catch (error) {

--- a/tests/unit/documents/PdfPageToImageConverter.test.ts
+++ b/tests/unit/documents/PdfPageToImageConverter.test.ts
@@ -224,8 +224,34 @@ describe("PdfPageToImageConverter", () => {
       const converter = new PdfPageToImageConverter();
       const config = converter.getConfig();
 
-      // Config should be readonly - TypeScript enforces this, but verify at runtime
-      expect(Object.isFrozen(config) || typeof config === "object").toBe(true);
+      // Config should be frozen at runtime (Object.freeze applied in constructor)
+      expect(Object.isFrozen(config)).toBe(true);
+    });
+
+    test("throws ExtractionError for zero dpiResolution", () => {
+      expect(() => new PdfPageToImageConverter({ dpiResolution: 0 })).toThrow(ExtractionError);
+      expect(() => new PdfPageToImageConverter({ dpiResolution: 0 })).toThrow(
+        /dpiResolution must be positive/
+      );
+    });
+
+    test("throws ExtractionError for negative dpiResolution", () => {
+      expect(() => new PdfPageToImageConverter({ dpiResolution: -1 })).toThrow(ExtractionError);
+    });
+
+    test("throws ExtractionError for zero maxPagesPerDocument", () => {
+      expect(() => new PdfPageToImageConverter({ maxPagesPerDocument: 0 })).toThrow(
+        ExtractionError
+      );
+      expect(() => new PdfPageToImageConverter({ maxPagesPerDocument: 0 })).toThrow(
+        /maxPagesPerDocument must be positive/
+      );
+    });
+
+    test("throws ExtractionError for negative maxPagesPerDocument", () => {
+      expect(() => new PdfPageToImageConverter({ maxPagesPerDocument: -5 })).toThrow(
+        ExtractionError
+      );
     });
   });
 
@@ -479,8 +505,9 @@ describe("PdfPageToImageConverter", () => {
       const converter = new PdfPageToImageConverter({ timeoutMs: 0 });
       const results = await converter.convertAllPages(TEST_PDF_BUFFER);
 
-      // Should have stopped early due to timeout
-      expect(results.length).toBeLessThan(100);
+      // With timeoutMs: 0, the elapsed check triggers at the start of the first iteration
+      // so no pages should be rendered (or at most 1 if timing is very tight).
+      expect(results.length).toBeLessThanOrEqual(1);
     });
 
     test("per-page failure does not abort batch", async () => {


### PR DESCRIPTION
## Summary

Addresses all actionable findings from the code review on PR #530 that were not included before merge.

| # | Severity | Fix | 
|---|----------|-----|
| 1 | **HIGH** | Add `@napi-rs/canvas` as direct dependency (was only optional transitive via pdfjs-dist) |
| 2 | **MEDIUM** | Optimize buffer copy in `loadDocument` — only copy when buffer is a view into a larger ArrayBuffer |
| 3 | **MEDIUM** | Add constructor validation for `dpiResolution` and `maxPagesPerDocument` (must be positive) |
| 4 | **MEDIUM** | Tighten non-deterministic timeout test assertion to `toBeLessThanOrEqual(1)` |
| 5 | **LOW** | Freeze config object with `Object.freeze()` for runtime immutability |
| 6 | **LOW** | Fix tautological test assertion for frozen config check |
| 7 | **INFO** | Document `convertPagesIterator` error propagation behavior in JSDoc |

### Changes
- 4 files modified, +65 -13 lines
- 4 new test cases for config validation (55 total, 100% coverage maintained)

## Test plan

- [x] `bun run typecheck` — passed
- [x] `bun test tests/unit/documents/PdfPageToImageConverter.test.ts` — 55/55 pass
- [x] `bun run build` — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)