### PR TITLE
feat: CLI remove command now cleans up FalkorDB graph data (#534)

### DIFF
--- a/src/cli/commands/remove-command.ts
+++ b/src/cli/commands/remove-command.ts
@@ -51,6 +51,9 @@ export async function removeCommand(
     console.log("This will delete:");
     console.log("  • Vector embeddings from ChromaDB");
     console.log("  • Repository metadata");
+    if (deps.graphIngestionService) {
+      console.log("  • Graph data from FalkorDB");
+    }
     if (options.deleteFiles) {
       console.log("  • Local repository files");
     }
@@ -70,6 +73,21 @@ export async function removeCommand(
   try {
     // Remove from ingestion service (deletes ChromaDB collection and metadata)
     await deps.ingestionService.removeRepository(repositoryName);
+
+    // Delete graph data if graph service is available (best-effort)
+    let graphDeleted = false;
+    if (deps.graphIngestionService) {
+      try {
+        await deps.graphIngestionService.deleteRepositoryData(repositoryName);
+        graphDeleted = true;
+      } catch (error) {
+        spinner.warn(
+          chalk.yellow(`Repository removed, but failed to delete graph data from FalkorDB`) +
+            "\n  " +
+            chalk.gray(error instanceof Error ? error.message : String(error))
+        );
+      }
+    }
 
     // Delete local files if requested
     let filesDeleted = false;
@@ -102,7 +120,7 @@ export async function removeCommand(
     }
 
     // Complete spinner with success
-    completeRemoveSpinner(spinner, true, filesDeleted);
+    completeRemoveSpinner(spinner, true, filesDeleted, graphDeleted);
   } catch (error) {
     // Complete spinner with failure
     completeRemoveSpinner(spinner, false, false);

--- a/src/cli/output/progress.ts
+++ b/src/cli/output/progress.ts
@@ -137,16 +137,26 @@ export function createRemoveSpinner(repositoryName: string): Ora {
  * @param spinner - Ora spinner instance
  * @param success - Whether the operation succeeded
  * @param deletedFiles - Whether local files were deleted
+ * @param graphDeleted - Whether graph data was deleted from FalkorDB
  */
-export function completeRemoveSpinner(spinner: Ora, success: boolean, deletedFiles: boolean): void {
+export function completeRemoveSpinner(
+  spinner: Ora,
+  success: boolean,
+  deletedFiles: boolean,
+  graphDeleted?: boolean
+): void {
   if (success) {
-    let message = chalk.green("Repository removed successfully!");
+    let message =
+      chalk.green("Repository removed successfully!") +
+      "\n  • Vector embeddings deleted from ChromaDB" +
+      "\n  • Repository metadata removed";
+    if (graphDeleted) {
+      message += "\n  • Graph data deleted from FalkorDB";
+    }
     if (deletedFiles) {
-      message +=
-        "\n  • Vector embeddings deleted from ChromaDB\n  • Repository metadata removed\n  • Local repository files deleted";
+      message += "\n  • Local repository files deleted";
     } else {
-      message +=
-        "\n  • Vector embeddings deleted from ChromaDB\n  • Repository metadata removed\n  • Local repository files preserved";
+      message += "\n  • Local repository files preserved";
     }
     spinner.succeed(message);
   } else {

--- a/tests/cli/commands/remove-command.test.ts
+++ b/tests/cli/commands/remove-command.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for Remove Command
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/await-thenable */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+
+import { describe, it, expect, beforeEach, vi, type Mock } from "bun:test";
+import { removeCommand } from "../../../src/cli/commands/remove-command.js";
+import type { CliDependencies } from "../../../src/cli/utils/dependency-init.js";
+import * as prompts from "../../../src/cli/utils/prompts.js";
+
+describe("Remove Command", () => {
+  let mockDeps: CliDependencies;
+  let mockGetRepository: Mock<(name: string) => Promise<any>>;
+  let mockRemoveRepository: Mock<(name: string) => Promise<void>>;
+
+  beforeEach(() => {
+    mockGetRepository = vi.fn();
+    mockRemoveRepository = vi.fn().mockResolvedValue(undefined);
+
+    mockDeps = {
+      repositoryService: {
+        getRepository: mockGetRepository,
+      },
+      ingestionService: {
+        removeRepository: mockRemoveRepository,
+      },
+    } as unknown as CliDependencies;
+  });
+
+  describe("repository not found", () => {
+    it("should throw an error when repository does not exist", async () => {
+      mockGetRepository.mockResolvedValue(null);
+
+      await expect(removeCommand("nonexistent-repo", { force: true }, mockDeps)).rejects.toThrow(
+        "Repository 'nonexistent-repo' not found."
+      );
+
+      expect(mockRemoveRepository).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("confirmation prompt", () => {
+    it("should log 'Operation cancelled' and not remove when user declines", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      const confirmSpy = vi.spyOn(prompts, "confirm").mockResolvedValue(false);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        await removeCommand("test-repo", { force: false }, mockDeps);
+
+        expect(mockRemoveRepository).not.toHaveBeenCalled();
+        // Check that Operation cancelled was logged
+        const calls = consoleSpy.mock.calls.map((c) => String(c[0]));
+        expect(calls.some((msg) => msg.includes("Operation cancelled"))).toBe(true);
+      } finally {
+        confirmSpy.mockRestore();
+        consoleSpy.mockRestore();
+      }
+    });
+
+    it("should proceed when user confirms", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      const confirmSpy = vi.spyOn(prompts, "confirm").mockResolvedValue(true);
+
+      try {
+        await removeCommand("test-repo", { force: false }, mockDeps);
+
+        expect(confirmSpy).toHaveBeenCalledWith("Type 'yes' to confirm:");
+        expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
+      } finally {
+        confirmSpy.mockRestore();
+      }
+    });
+
+    it("should mention graph data in prompt when graphIngestionService is available", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      const mockGraphIngestionService = {
+        deleteRepositoryData: vi.fn().mockResolvedValue(undefined),
+      };
+
+      const depsWithGraph = {
+        ...mockDeps,
+        graphIngestionService: mockGraphIngestionService,
+      } as unknown as CliDependencies;
+
+      const confirmSpy = vi.spyOn(prompts, "confirm").mockResolvedValue(false);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        await removeCommand("test-repo", { force: false }, depsWithGraph);
+
+        const loggedMessages = consoleSpy.mock.calls.map((c) => String(c[0]));
+        expect(loggedMessages.some((msg) => msg.includes("Graph data from FalkorDB"))).toBe(true);
+      } finally {
+        confirmSpy.mockRestore();
+        consoleSpy.mockRestore();
+      }
+    });
+
+    it("should not mention graph data in prompt when graphIngestionService is not available", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      const confirmSpy = vi.spyOn(prompts, "confirm").mockResolvedValue(false);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      try {
+        await removeCommand("test-repo", { force: false }, mockDeps);
+
+        const loggedMessages = consoleSpy.mock.calls.map((c) => String(c[0]));
+        expect(loggedMessages.some((msg) => msg.includes("Graph data from FalkorDB"))).toBe(false);
+      } finally {
+        confirmSpy.mockRestore();
+        consoleSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("remove without graph adapter", () => {
+    it("should succeed without calling graph service", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      await removeCommand("test-repo", { force: true }, mockDeps);
+
+      expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
+    });
+  });
+
+  describe("remove with graph adapter (success)", () => {
+    it("should call deleteRepositoryData and succeed", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      const mockDeleteRepositoryData = vi.fn().mockResolvedValue(undefined);
+      const depsWithGraph = {
+        ...mockDeps,
+        graphIngestionService: {
+          deleteRepositoryData: mockDeleteRepositoryData,
+        },
+      } as unknown as CliDependencies;
+
+      await removeCommand("test-repo", { force: true }, depsWithGraph);
+
+      expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
+      expect(mockDeleteRepositoryData).toHaveBeenCalledWith("test-repo");
+    });
+  });
+
+  describe("remove with graph adapter (failure)", () => {
+    it("should warn but not throw when graph deletion fails", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      const mockDeleteRepositoryData = vi
+        .fn()
+        .mockRejectedValue(new Error("FalkorDB connection refused"));
+
+      const depsWithGraph = {
+        ...mockDeps,
+        graphIngestionService: {
+          deleteRepositoryData: mockDeleteRepositoryData,
+        },
+      } as unknown as CliDependencies;
+
+      // Should not throw
+      await expect(
+        removeCommand("test-repo", { force: true }, depsWithGraph)
+      ).resolves.toBeUndefined();
+
+      expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
+      expect(mockDeleteRepositoryData).toHaveBeenCalledWith("test-repo");
+    });
+  });
+
+  describe("remove with --force flag", () => {
+    it("should skip confirmation prompt when --force is set", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+
+      const confirmSpy = vi.spyOn(prompts, "confirm");
+
+      try {
+        await removeCommand("test-repo", { force: true }, mockDeps);
+
+        expect(confirmSpy).not.toHaveBeenCalled();
+        expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
+      } finally {
+        confirmSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("propagates removal errors", () => {
+    it("should re-throw errors from ingestionService.removeRepository", async () => {
+      mockGetRepository.mockResolvedValue({ name: "test-repo", localPath: null });
+      mockRemoveRepository.mockRejectedValue(new Error("ChromaDB unavailable"));
+
+      await expect(removeCommand("test-repo", { force: true }, mockDeps)).rejects.toThrow(
+        "ChromaDB unavailable"
+      );
+    });
+  });
+});

--- a/tests/cli/commands/remove-command.test.ts
+++ b/tests/cli/commands/remove-command.test.ts
@@ -150,6 +150,26 @@ describe("Remove Command", () => {
       expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
       expect(mockDeleteRepositoryData).toHaveBeenCalledWith("test-repo");
     });
+
+    it("should call deleteRepositoryData and succeed even when deleteFiles is requested but path does not exist", async () => {
+      mockGetRepository.mockResolvedValue({
+        name: "test-repo",
+        localPath: "/nonexistent/path",
+      });
+
+      const mockDeleteRepositoryData = vi.fn().mockResolvedValue(undefined);
+      const depsWithGraph = {
+        ...mockDeps,
+        graphIngestionService: {
+          deleteRepositoryData: mockDeleteRepositoryData,
+        },
+      } as unknown as CliDependencies;
+
+      await removeCommand("test-repo", { force: true, deleteFiles: true }, depsWithGraph);
+
+      expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
+      expect(mockDeleteRepositoryData).toHaveBeenCalledWith("test-repo");
+    });
   });
 
   describe("remove with graph adapter (failure)", () => {
@@ -170,6 +190,34 @@ describe("Remove Command", () => {
       // Should not throw
       await expect(
         removeCommand("test-repo", { force: true }, depsWithGraph)
+      ).resolves.toBeUndefined();
+
+      expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");
+      expect(mockDeleteRepositoryData).toHaveBeenCalledWith("test-repo");
+    });
+
+    it("should still attempt file deletion when graph deletion fails", async () => {
+      // localPath doesn't exist on disk so rm is skipped,
+      // but control flow reaches the file-deletion branch
+      mockGetRepository.mockResolvedValue({
+        name: "test-repo",
+        localPath: "/nonexistent/path",
+      });
+
+      const mockDeleteRepositoryData = vi
+        .fn()
+        .mockRejectedValue(new Error("FalkorDB connection refused"));
+
+      const depsWithGraph = {
+        ...mockDeps,
+        graphIngestionService: {
+          deleteRepositoryData: mockDeleteRepositoryData,
+        },
+      } as unknown as CliDependencies;
+
+      // Should not throw - graph failure is best-effort
+      await expect(
+        removeCommand("test-repo", { force: true, deleteFiles: true }, depsWithGraph)
       ).resolves.toBeUndefined();
 
       expect(mockRemoveRepository).toHaveBeenCalledWith("test-repo");

--- a/tests/cli/output/progress.test.ts
+++ b/tests/cli/output/progress.test.ts
@@ -15,6 +15,17 @@ import {
   completeRemoveSpinner,
 } from "../../../src/cli/output/progress.js";
 
+/** Returns a getter that captures the text passed to spinner.succeed */
+function captureSucceedText(spinner: Ora): () => string {
+  let captured = "";
+  const original = spinner.succeed.bind(spinner);
+  spinner.succeed = (text?: string): Ora => {
+    captured = text ?? "";
+    return original(text);
+  };
+  return () => captured;
+}
+
 describe("CLI Progress Indicators", () => {
   describe("createIndexSpinner", () => {
     it("should create a spinner with the repository name", () => {
@@ -415,46 +426,30 @@ describe("CLI Progress Indicators", () => {
     });
 
     it("should include graph data line when graphDeleted is true", () => {
-      // Capture the text set on succeed by checking spinner state after call
-      let succeededWith = "";
-      const originalSucceed = spinner.succeed.bind(spinner);
-      spinner.succeed = (text?: string): Ora => {
-        succeededWith = text ?? "";
-        return originalSucceed(text);
-      };
+      const getSucceededWith = captureSucceedText(spinner);
 
       completeRemoveSpinner(spinner, true, false, true);
 
       expect(spinner.isSpinning).toBe(false);
-      expect(succeededWith).toContain("Graph data deleted from FalkorDB");
+      expect(getSucceededWith()).toContain("Graph data deleted from FalkorDB");
     });
 
     it("should not include graph data line when graphDeleted is false", () => {
-      let succeededWith = "";
-      const originalSucceed = spinner.succeed.bind(spinner);
-      spinner.succeed = (text?: string): Ora => {
-        succeededWith = text ?? "";
-        return originalSucceed(text);
-      };
+      const getSucceededWith = captureSucceedText(spinner);
 
       completeRemoveSpinner(spinner, true, false, false);
 
       expect(spinner.isSpinning).toBe(false);
-      expect(succeededWith).not.toContain("Graph data deleted from FalkorDB");
+      expect(getSucceededWith()).not.toContain("Graph data deleted from FalkorDB");
     });
 
     it("should not include graph data line when graphDeleted is omitted", () => {
-      let succeededWith = "";
-      const originalSucceed = spinner.succeed.bind(spinner);
-      spinner.succeed = (text?: string): Ora => {
-        succeededWith = text ?? "";
-        return originalSucceed(text);
-      };
+      const getSucceededWith = captureSucceedText(spinner);
 
       completeRemoveSpinner(spinner, true, false);
 
       expect(spinner.isSpinning).toBe(false);
-      expect(succeededWith).not.toContain("Graph data deleted from FalkorDB");
+      expect(getSucceededWith()).not.toContain("Graph data deleted from FalkorDB");
     });
   });
 

--- a/tests/cli/output/progress.test.ts
+++ b/tests/cli/output/progress.test.ts
@@ -413,6 +413,49 @@ describe("CLI Progress Indicators", () => {
       // Spinner should be stopped after failure
       expect(spinner.isSpinning).toBe(false);
     });
+
+    it("should include graph data line when graphDeleted is true", () => {
+      // Capture the text set on succeed by checking spinner state after call
+      let succeededWith = "";
+      const originalSucceed = spinner.succeed.bind(spinner);
+      spinner.succeed = (text?: string): Ora => {
+        succeededWith = text ?? "";
+        return originalSucceed(text);
+      };
+
+      completeRemoveSpinner(spinner, true, false, true);
+
+      expect(spinner.isSpinning).toBe(false);
+      expect(succeededWith).toContain("Graph data deleted from FalkorDB");
+    });
+
+    it("should not include graph data line when graphDeleted is false", () => {
+      let succeededWith = "";
+      const originalSucceed = spinner.succeed.bind(spinner);
+      spinner.succeed = (text?: string): Ora => {
+        succeededWith = text ?? "";
+        return originalSucceed(text);
+      };
+
+      completeRemoveSpinner(spinner, true, false, false);
+
+      expect(spinner.isSpinning).toBe(false);
+      expect(succeededWith).not.toContain("Graph data deleted from FalkorDB");
+    });
+
+    it("should not include graph data line when graphDeleted is omitted", () => {
+      let succeededWith = "";
+      const originalSucceed = spinner.succeed.bind(spinner);
+      spinner.succeed = (text?: string): Ora => {
+        succeededWith = text ?? "";
+        return originalSucceed(text);
+      };
+
+      completeRemoveSpinner(spinner, true, false);
+
+      expect(spinner.isSpinning).toBe(false);
+      expect(succeededWith).not.toContain("Graph data deleted from FalkorDB");
+    });
   });
 
   describe("Integration scenarios", () => {


### PR DESCRIPTION
## Summary

- **Graph cleanup on remove**: `pk-mcp remove <repo>` now calls `GraphIngestionService.deleteRepositoryData()` after removing ChromaDB embeddings, eliminating orphaned nodes/relationships in FalkorDB
- **Best-effort semantics**: Graph deletion failure emits a `spinner.warn()` but does not abort the command or propagate an error — removing vector data and metadata still succeeds
- **Updated UX**: Confirmation prompt lists "Graph data from FalkorDB" when the graph adapter is configured; success spinner includes "Graph data deleted from FalkorDB" when applicable

## Changes

### `src/cli/output/progress.ts`
- Added optional `graphDeleted?: boolean` parameter to `completeRemoveSpinner`
- Success message now shows graph line between metadata and files when `graphDeleted === true`
- Output order: ChromaDB → metadata → graph (optional) → files (optional/preserved)

### `src/cli/commands/remove-command.ts`
- Confirmation prompt conditionally shows graph data bullet when `deps.graphIngestionService` is set
- After `ingestionService.removeRepository()`, calls `deps.graphIngestionService.deleteRepositoryData()` in a try/catch with warning on failure
- Passes `graphDeleted` flag to `completeRemoveSpinner`

### `tests/cli/commands/remove-command.test.ts` (new)
- 9 test cases covering: repo not found, cancel, confirm, graph prompt visibility, remove without graph, remove with graph success, remove with graph failure, `--force` flag, propagated removal errors

### `tests/cli/output/progress.test.ts`
- 3 new test cases for `completeRemoveSpinner` with `graphDeleted=true`, `graphDeleted=false`, and omitted

## Test plan

- [x] `bun test tests/cli/commands/remove-command.test.ts tests/cli/output/progress.test.ts` — 47 pass, 0 fail
- [x] `bun run typecheck` — no errors
- [x] `bun run build` — clean build

Closes #534

🤖 Generated with [Claude Code](https://claude.com/claude-code)