### PR TITLE
refactor: rename GitHub-specific identifiers to generic git names

### DIFF
--- a/docs/architecture/Phase1-System-Design-Document.md
+++ b/docs/architecture/Phase1-System-Design-Document.md
@@ -1688,7 +1688,7 @@ const semanticSearchSchema = z.object({
 **URL Validation for Repository Cloning:**
 
 ```typescript
-function validateGitHubUrl(url: string): boolean {
+function validateGitUrl(url: string): boolean {
   const pattern = /^https:\/\/github\.com\/[\w.-]+\/[\w.-]+(\.git)?$/;
   return pattern.test(url);
 }

--- a/docs/architecture/incremental-updates-plan.md
+++ b/docs/architecture/incremental-updates-plan.md
@@ -446,7 +446,7 @@ class IncrementalUpdateCoordinator {
     }
 
     // 2. Parse owner/repo from URL
-    const { owner, repo } = parseGitHubUrl(repoInfo.url);
+    const { owner, repo } = parseGitUrl(repoInfo.url);
 
     // 3. Get current HEAD commit (primary branch only)
     const headCommit = await this.githubClient.getHeadCommit(owner, repo, repoInfo.branch);

--- a/src/cli/commands/status-command.ts
+++ b/src/cli/commands/status-command.ts
@@ -14,7 +14,7 @@ import {
   createMetricsTable,
   type RepositoryDisplayInfo,
 } from "../output/formatters.js";
-import { parseGitHubUrl } from "../../utils/git-url-parser.js";
+import { parseGitUrl } from "../../utils/git-url-parser.js";
 import type { RepositoryInfo } from "../../repositories/types.js";
 import { calculateAggregateMetrics } from "../../services/metrics-calculator.js";
 
@@ -147,7 +147,7 @@ async function checkRepositoryUpdates(
   for (const repo of repositories) {
     try {
       // Parse GitHub URL to extract owner/repo
-      const parsed = parseGitHubUrl(repo.url);
+      const parsed = parseGitUrl(repo.url);
 
       // If not a GitHub URL, mark as unknown
       if (!parsed) {

--- a/src/cli/commands/status-command.ts
+++ b/src/cli/commands/status-command.ts
@@ -146,10 +146,10 @@ async function checkRepositoryUpdates(
 
   for (const repo of repositories) {
     try {
-      // Parse GitHub URL to extract owner/repo
+      // Parse git URL to extract owner/repo
       const parsed = parseGitUrl(repo.url);
 
-      // If not a GitHub URL, mark as unknown
+      // If not a parseable git URL, mark as unknown
       if (!parsed) {
         displayRepos.push({
           ...repo,

--- a/src/ingestion/repository-cloner.ts
+++ b/src/ingestion/repository-cloner.ts
@@ -130,7 +130,7 @@ export class RepositoryCloner {
     const startTime = Date.now();
 
     // Step 1: Validate URL
-    this.validateGitHubUrl(url);
+    this.validateGitUrl(url);
 
     // Step 2: Extract or use provided repository name
     const repoName = options.name || this.extractRepoName(url);
@@ -450,7 +450,7 @@ export class RepositoryCloner {
    * @param url - URL to validate
    * @throws {ValidationError} If the URL is invalid
    */
-  private validateGitHubUrl(url: string): void {
+  private validateGitUrl(url: string): void {
     if (!url || typeof url !== "string") {
       throw new ValidationError("Repository URL cannot be empty", "url");
     }

--- a/src/ingestion/repository-cloner.ts
+++ b/src/ingestion/repository-cloner.ts
@@ -474,9 +474,9 @@ export class RepositoryCloner {
   }
 
   /**
-   * Extract repository name from GitHub URL.
+   * Extract repository name from a git repository URL.
    *
-   * @param url - GitHub repository URL
+   * @param url - Git repository URL
    * @returns Repository name
    * @throws {ValidationError} If the repository name cannot be extracted
    *

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -10,7 +10,7 @@
 
 import simpleGit from "simple-git";
 import type { SimpleGit } from "simple-git";
-import { parseGitHubUrl } from "../utils/git-url-parser.js";
+import { parseGitUrl } from "../utils/git-url-parser.js";
 import { isLocalPath } from "../utils/path-utils.js";
 import type { Logger } from "pino";
 import { getComponentLogger } from "../logging/index.js";
@@ -271,7 +271,7 @@ export class IncrementalUpdateCoordinator {
 
       // Step 2-5: Detect changes — via GitHub API for github.com repos,
       // or via local git diff for all other hosts and local paths.
-      const parsedUrl = parseGitHubUrl(repo.url);
+      const parsedUrl = parseGitUrl(repo.url);
       const isGitHub = parsedUrl?.isGitHub === true;
 
       let headCommit: CommitInfo;

--- a/src/utils/git-url-parser.ts
+++ b/src/utils/git-url-parser.ts
@@ -8,7 +8,7 @@
 /**
  * Parsed Git URL result
  */
-export interface ParsedGitHubUrl {
+export interface ParsedGitUrl {
   /**
    * Repository owner (user or organization)
    */
@@ -46,17 +46,17 @@ export interface ParsedGitHubUrl {
  *
  * @example
  * ```typescript
- * parseGitHubUrl('https://github.com/user/repo.git')
+ * parseGitUrl('https://github.com/user/repo.git')
  * // Returns: { owner: 'user', repo: 'repo', isGitHub: true, host: 'github.com' }
  *
- * parseGitHubUrl('https://gitlab.com/user/repo')
+ * parseGitUrl('https://gitlab.com/user/repo')
  * // Returns: { owner: 'user', repo: 'repo', isGitHub: false, host: 'gitlab.com' }
  *
- * parseGitHubUrl('git@github.com:org/project.git')
+ * parseGitUrl('git@github.com:org/project.git')
  * // Returns: { owner: 'org', repo: 'project', isGitHub: true, host: 'github.com' }
  * ```
  */
-export function parseGitHubUrl(url: string): ParsedGitHubUrl | null {
+export function parseGitUrl(url: string): ParsedGitUrl | null {
   if (!url || typeof url !== "string") {
     return null;
   }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -28,5 +28,5 @@ export {
 export type { RetryConfig, RetryOptions } from "./retry.js";
 
 // Git URL parsing utilities
-export { parseGitHubUrl } from "./git-url-parser.js";
-export type { ParsedGitHubUrl } from "./git-url-parser.js";
+export { parseGitUrl } from "./git-url-parser.js";
+export type { ParsedGitUrl } from "./git-url-parser.js";

--- a/tests/services/incremental-update-coordinator.test.ts
+++ b/tests/services/incremental-update-coordinator.test.ts
@@ -594,7 +594,7 @@ describe("IncrementalUpdateCoordinator", () => {
     });
   });
 
-  describe("parseGitHubUrl", () => {
+  describe("parseGitUrl", () => {
     it("should parse HTTPS URL without .git suffix", async () => {
       const repoWithoutGit: RepositoryInfo = {
         ...testRepo,

--- a/tests/unit/utils/git-url-parser.test.ts
+++ b/tests/unit/utils/git-url-parser.test.ts
@@ -6,12 +6,12 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { parseGitHubUrl } from "../../../src/utils/git-url-parser.js";
+import { parseGitUrl } from "../../../src/utils/git-url-parser.js";
 
-describe("parseGitHubUrl", () => {
+describe("parseGitUrl", () => {
   describe("GitHub HTTPS URLs", () => {
     it("should parse HTTPS URL with .git suffix", () => {
-      const result = parseGitHubUrl("https://github.com/user/repo.git");
+      const result = parseGitUrl("https://github.com/user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -21,7 +21,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse HTTPS URL without .git suffix", () => {
-      const result = parseGitHubUrl("https://github.com/user/repo");
+      const result = parseGitUrl("https://github.com/user/repo");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -31,7 +31,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse HTTPS URL with organization owner", () => {
-      const result = parseGitHubUrl("https://github.com/my-org/my-project.git");
+      const result = parseGitUrl("https://github.com/my-org/my-project.git");
       expect(result).toEqual({
         owner: "my-org",
         repo: "my-project",
@@ -41,7 +41,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse HTTPS URL with underscores and hyphens", () => {
-      const result = parseGitHubUrl("https://github.com/my_user-123/my_repo-456.git");
+      const result = parseGitUrl("https://github.com/my_user-123/my_repo-456.git");
       expect(result).toEqual({
         owner: "my_user-123",
         repo: "my_repo-456",
@@ -51,7 +51,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse HTTPS URL with dots in names", () => {
-      const result = parseGitHubUrl("https://github.com/user.name/repo.name.git");
+      const result = parseGitUrl("https://github.com/user.name/repo.name.git");
       expect(result).toEqual({
         owner: "user.name",
         repo: "repo.name",
@@ -63,7 +63,7 @@ describe("parseGitHubUrl", () => {
 
   describe("GitHub SSH URLs", () => {
     it("should parse SSH URL with .git suffix", () => {
-      const result = parseGitHubUrl("git@github.com:user/repo.git");
+      const result = parseGitUrl("git@github.com:user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -73,7 +73,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse SSH URL without .git suffix", () => {
-      const result = parseGitHubUrl("git@github.com:user/repo");
+      const result = parseGitUrl("git@github.com:user/repo");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -83,7 +83,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse SSH URL with organization owner", () => {
-      const result = parseGitHubUrl("git@github.com:my-org/my-project.git");
+      const result = parseGitUrl("git@github.com:my-org/my-project.git");
       expect(result).toEqual({
         owner: "my-org",
         repo: "my-project",
@@ -93,7 +93,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse SSH URL with special characters", () => {
-      const result = parseGitHubUrl("git@github.com:my_user-123/my_repo-456.git");
+      const result = parseGitUrl("git@github.com:my_user-123/my_repo-456.git");
       expect(result).toEqual({
         owner: "my_user-123",
         repo: "my_repo-456",
@@ -105,7 +105,7 @@ describe("parseGitHubUrl", () => {
 
   describe("Non-GitHub host URLs (isGitHub: false)", () => {
     it("should parse GitLab HTTPS URL", () => {
-      const result = parseGitHubUrl("https://gitlab.com/user/repo.git");
+      const result = parseGitUrl("https://gitlab.com/user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -115,7 +115,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse Bitbucket HTTPS URL", () => {
-      const result = parseGitHubUrl("https://bitbucket.org/user/repo.git");
+      const result = parseGitUrl("https://bitbucket.org/user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -125,7 +125,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse self-hosted HTTPS URL", () => {
-      const result = parseGitHubUrl("https://git.company.com/user/repo.git");
+      const result = parseGitUrl("https://git.company.com/user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -135,7 +135,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse GitLab SSH URL", () => {
-      const result = parseGitHubUrl("git@gitlab.com:user/repo.git");
+      const result = parseGitUrl("git@gitlab.com:user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -145,7 +145,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse Gitea SSH URL", () => {
-      const result = parseGitHubUrl("git@gitea.example.com:org/project.git");
+      const result = parseGitUrl("git@gitea.example.com:org/project.git");
       expect(result).toEqual({
         owner: "org",
         repo: "project",
@@ -157,67 +157,67 @@ describe("parseGitHubUrl", () => {
 
   describe("Malformed URLs", () => {
     it("should return null for empty string", () => {
-      const result = parseGitHubUrl("");
+      const result = parseGitUrl("");
       expect(result).toBeNull();
     });
 
     it("should return null for whitespace-only string", () => {
-      const result = parseGitHubUrl("   ");
+      const result = parseGitUrl("   ");
       expect(result).toBeNull();
     });
 
     it("should return null for null input", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      const result = parseGitHubUrl(null as any);
+      const result = parseGitUrl(null as any);
       expect(result).toBeNull();
     });
 
     it("should return null for undefined input", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      const result = parseGitHubUrl(undefined as any);
+      const result = parseGitUrl(undefined as any);
       expect(result).toBeNull();
     });
 
     it("should return null for non-string input", () => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-explicit-any
-      const result = parseGitHubUrl(12345 as any);
+      const result = parseGitUrl(12345 as any);
       expect(result).toBeNull();
     });
 
     it("should return null for URL with missing owner", () => {
-      const result = parseGitHubUrl("https://github.com//repo.git");
+      const result = parseGitUrl("https://github.com//repo.git");
       expect(result).toBeNull();
     });
 
     it("should return null for URL with missing repo", () => {
-      const result = parseGitHubUrl("https://github.com/user/");
+      const result = parseGitUrl("https://github.com/user/");
       expect(result).toBeNull();
     });
 
     it("should return null for URL with only one path segment", () => {
-      const result = parseGitHubUrl("https://github.com/user");
+      const result = parseGitUrl("https://github.com/user");
       expect(result).toBeNull();
     });
 
     it("should return null for URL with too many path segments", () => {
-      const result = parseGitHubUrl("https://github.com/user/repo/extra");
+      const result = parseGitUrl("https://github.com/user/repo/extra");
       expect(result).toBeNull();
     });
 
     it("should return null for SSH URL with missing colon", () => {
-      const result = parseGitHubUrl("git@github.com/user/repo.git");
+      const result = parseGitUrl("git@github.com/user/repo.git");
       expect(result).toBeNull();
     });
 
     it("should return null for incomplete HTTPS URL", () => {
-      const result = parseGitHubUrl("https://github.com/");
+      const result = parseGitUrl("https://github.com/");
       expect(result).toBeNull();
     });
   });
 
   describe("Edge Cases", () => {
     it("should handle URL with trailing whitespace", () => {
-      const result = parseGitHubUrl("https://github.com/user/repo.git   ");
+      const result = parseGitUrl("https://github.com/user/repo.git   ");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -227,7 +227,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should handle URL with leading whitespace", () => {
-      const result = parseGitHubUrl("   https://github.com/user/repo.git");
+      const result = parseGitUrl("   https://github.com/user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -237,12 +237,12 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should return null for HTTP (non-HTTPS) URL", () => {
-      const result = parseGitHubUrl("http://github.com/user/repo.git");
+      const result = parseGitUrl("http://github.com/user/repo.git");
       expect(result).toBeNull();
     });
 
     it("should parse www.github.com URL as non-GitHub host", () => {
-      const result = parseGitHubUrl("https://www.github.com/user/repo.git");
+      const result = parseGitUrl("https://www.github.com/user/repo.git");
       expect(result).toEqual({
         owner: "user",
         repo: "repo",
@@ -252,12 +252,12 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should return null for owner/repo names starting with special char", () => {
-      const result = parseGitHubUrl("https://github.com/-user/repo.git");
+      const result = parseGitUrl("https://github.com/-user/repo.git");
       expect(result).toBeNull();
     });
 
     it("should parse owner/repo names ending with hyphen", () => {
-      const result = parseGitHubUrl("https://github.com/user-/repo.git");
+      const result = parseGitUrl("https://github.com/user-/repo.git");
       expect(result).toEqual({
         owner: "user-",
         repo: "repo",
@@ -267,7 +267,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse single-character owner and repo names", () => {
-      const result = parseGitHubUrl("https://github.com/x/y");
+      const result = parseGitUrl("https://github.com/x/y");
       expect(result).toEqual({
         owner: "x",
         repo: "y",
@@ -277,7 +277,7 @@ describe("parseGitHubUrl", () => {
     });
 
     it("should parse single-character owner and repo names via SSH", () => {
-      const result = parseGitHubUrl("git@github.com:x/y.git");
+      const result = parseGitUrl("git@github.com:x/y.git");
       expect(result).toEqual({
         owner: "x",
         repo: "y",


### PR DESCRIPTION
## Summary

- Renames `parseGitHubUrl` → `parseGitUrl` (exported function + all call sites)
- Renames `ParsedGitHubUrl` → `ParsedGitUrl` (exported interface + all references)
- Renames `RepositoryCloner.validateGitHubUrl()` → `validateGitUrl()` (private method)

These identifiers were misleading after PR #535 generalized git URL support to any host (GitLab, Gitea, Bitbucket, self-hosted). Pure rename — no behavior change.

Closes #537

## Files Changed (7)

- `src/utils/git-url-parser.ts` — interface + function + JSDoc examples
- `src/utils/index.ts` — re-exports
- `src/cli/commands/status-command.ts` — import + call site
- `src/services/incremental-update-coordinator.ts` — import + call site
- `src/ingestion/repository-cloner.ts` — call site + method definition
- `tests/unit/utils/git-url-parser.test.ts` — import + describe block + ~30 call sites
- `tests/services/incremental-update-coordinator.test.ts` — describe block label

## Test plan

- [x] `bun run typecheck` — zero type errors
- [x] `bun test` (affected files) — 80 tests pass, 0 fail
- [x] `bun run build` — clean build, no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)