### PR TITLE
fix(#547): drift_detected status on no_changes SHA-match when index is incomplete

### DIFF
--- a/src/cli/commands/update-repository-command.ts
+++ b/src/cli/commands/update-repository-command.ts
@@ -251,6 +251,47 @@ export async function updateRepositoryCommand(
       return;
     }
 
+    // Handle drift detected: HEAD SHA matches the tracked commit but the index
+    // is incomplete, so an incremental update cannot self-heal. Surface the
+    // discrepancy and exit non-zero so CI/cron workflows don't silently pass.
+    if (result.status === "drift_detected") {
+      spinner.warn(chalk.yellow(`⚠ Drift detected for ${repositoryName}`));
+
+      if (options.json) {
+        console.log(
+          JSON.stringify(
+            formatUpdateResultJson(repositoryName, result, repo.lastIndexedCommitSha),
+            null,
+            2
+          )
+        );
+      } else {
+        console.log(
+          chalk.yellow(`  The tracked commit matches HEAD, but the index is missing content.`)
+        );
+        const completeness = result.completenessCheck;
+        if (completeness) {
+          console.log(`  ${chalk.gray("Indexed files:")} ${completeness.indexedFileCount}`);
+          console.log(
+            `  ${chalk.gray("Eligible files on disk:")} ${completeness.eligibleFileCount}`
+          );
+          console.log(
+            `  ${chalk.gray("Missing:")} ${completeness.missingFileCount} (${completeness.divergencePercent}%)`
+          );
+        }
+        console.log(
+          chalk.cyan(
+            `\n  To recover: ${chalk.bold(`bun run cli update ${repositoryName} --force`)}`
+          )
+        );
+      }
+
+      throw new Error(
+        `Drift detected for '${repositoryName}': tracked SHA matches HEAD but index is incomplete. ` +
+          `Re-run with --force to re-index.`
+      );
+    }
+
     // Handle updated status
     if (result.status === "updated") {
       spinner.succeed(chalk.green(`✓ Updated ${repositoryName}`));

--- a/src/mcp/tools/trigger-incremental-update.ts
+++ b/src/mcp/tools/trigger-incremental-update.ts
@@ -65,7 +65,7 @@ interface TriggerUpdateArgs {
 interface SyncSuccessResponse {
   success: true;
   repository: string;
-  status: "updated" | "no_changes" | "incomplete";
+  status: "updated" | "no_changes" | "incomplete" | "drift_detected";
   files_added: number;
   files_modified: number;
   files_deleted: number;
@@ -88,6 +88,8 @@ interface SyncSuccessResponse {
   completeness_eligible_files?: number;
   completeness_missing_files?: number;
   completeness_divergence_percent?: number;
+  // Populated only when status === "drift_detected" to guide callers toward recovery
+  recovery_hint?: string;
 }
 
 /**
@@ -195,6 +197,7 @@ function formatSyncSuccessResponse(repository: string, result: CoordinatorResult
   const statusMap: Record<string, SyncSuccessResponse["status"]> = {
     no_changes: "no_changes",
     incomplete: "incomplete",
+    drift_detected: "drift_detected",
   };
   const response: SyncSuccessResponse = {
     success: true,
@@ -213,6 +216,12 @@ function formatSyncSuccessResponse(repository: string, result: CoordinatorResult
   }
   if (result.commitMessage) {
     response.commit_message = result.commitMessage;
+  }
+
+  if (result.status === "drift_detected") {
+    response.recovery_hint =
+      `Index drift detected: HEAD SHA matches the tracked commit but the index is incomplete. ` +
+      `Run 'bun run cli update ${repository} --force' to re-index and recover.`;
   }
 
   // Include graph statistics if available

--- a/src/services/incremental-update-coordinator-types.ts
+++ b/src/services/incremental-update-coordinator-types.ts
@@ -45,12 +45,20 @@ export interface CoordinatorConfig {
  * Result status for an incremental update operation.
  *
  * Indicates the outcome of the update attempt:
- * - `no_changes`: HEAD commit matches last indexed commit, no action taken
+ * - `no_changes`: HEAD commit matches last indexed commit and the index is healthy; no action taken
  * - `updated`: Incremental update completed successfully (includes partial success)
  * - `failed`: Update failed with errors (all files failed)
  * - `incomplete`: Eligible files existed but all were filtered out; SHA not advanced
+ * - `drift_detected`: HEAD commit matches last indexed commit but the completeness check
+ *   reports the index is incomplete (chunks missing relative to files on disk). The tracked
+ *   SHA has drifted ahead of what is actually indexed; a forced re-index is required to recover.
  */
-export type CoordinatorStatus = "no_changes" | "updated" | "failed" | "incomplete";
+export type CoordinatorStatus =
+  | "no_changes"
+  | "updated"
+  | "failed"
+  | "incomplete"
+  | "drift_detected";
 
 /**
  * Complete result of an incremental update operation.

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -314,8 +314,22 @@ export class IncrementalUpdateCoordinator {
             repositoryName,
             logger
           );
+          const isDrift = noChangesCompletenessCheck?.status === "incomplete";
+          if (isDrift && noChangesCompletenessCheck) {
+            logger.warn(
+              {
+                operation: "coordinator_drift_detected",
+                repository: repositoryName,
+                indexedFileCount: noChangesCompletenessCheck.indexedFileCount,
+                eligibleFileCount: noChangesCompletenessCheck.eligibleFileCount,
+                missingFileCount: noChangesCompletenessCheck.missingFileCount,
+                divergencePercent: noChangesCompletenessCheck.divergencePercent,
+              },
+              "Drift detected: HEAD SHA matches tracked commit but index is incomplete; recommend forced re-index"
+            );
+          }
           return {
-            status: "no_changes",
+            status: isDrift ? "drift_detected" : "no_changes",
             commitSha: headCommit.sha,
             commitMessage: headCommit.message,
             stats: {
@@ -390,8 +404,22 @@ export class IncrementalUpdateCoordinator {
             repositoryName,
             logger
           );
+          const isDrift = noChangesCompletenessCheck?.status === "incomplete";
+          if (isDrift && noChangesCompletenessCheck) {
+            logger.warn(
+              {
+                operation: "coordinator_drift_detected",
+                repository: repositoryName,
+                indexedFileCount: noChangesCompletenessCheck.indexedFileCount,
+                eligibleFileCount: noChangesCompletenessCheck.eligibleFileCount,
+                missingFileCount: noChangesCompletenessCheck.missingFileCount,
+                divergencePercent: noChangesCompletenessCheck.divergencePercent,
+              },
+              "Drift detected: HEAD SHA matches tracked commit but index is incomplete; recommend forced re-index"
+            );
+          }
           return {
-            status: "no_changes",
+            status: isDrift ? "drift_detected" : "no_changes",
             commitSha: repo.lastIndexedCommitSha,
             commitMessage: "up-to-date",
             stats: {

--- a/tests/cli/commands/update-repository-command.test.ts
+++ b/tests/cli/commands/update-repository-command.test.ts
@@ -26,6 +26,7 @@ import {
   SAMPLE_UPDATED_RESULT,
   SAMPLE_UPDATED_WITH_ERRORS_RESULT,
   SAMPLE_FAILED_RESULT,
+  SAMPLE_DRIFT_DETECTED_RESULT,
   TEST_COMMIT_SHAS,
 } from "../../fixtures/incremental-update-fixtures.js";
 import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
@@ -176,6 +177,66 @@ describe("Update Repository Command", () => {
       // Note: JSON output uses commitRange (from formatUpdateResultJson), not commitSha
       expect(jsonOutput.commitRange).toBeDefined();
       expect(jsonOutput.stats).toBeDefined();
+    });
+  });
+
+  describe("Incremental update - Drift detected", () => {
+    it("should throw and include recovery guidance in message", async () => {
+      mockGetRepository.mockResolvedValue(sampleRepo);
+      mockUpdateRepository.mockResolvedValue(SAMPLE_DRIFT_DETECTED_RESULT);
+
+      const options: UpdateCommandOptions = {};
+
+      await expect(updateRepositoryCommand("test-repo", options, mockDeps)).rejects.toThrow(
+        /Drift detected/
+      );
+      await expect(updateRepositoryCommand("test-repo", options, mockDeps)).rejects.toThrow(
+        /--force/
+      );
+    });
+
+    it("should print divergence counts and --force recovery hint", async () => {
+      mockGetRepository.mockResolvedValue(sampleRepo);
+      mockUpdateRepository.mockResolvedValue(SAMPLE_DRIFT_DETECTED_RESULT);
+
+      const options: UpdateCommandOptions = {};
+
+      try {
+        await updateRepositoryCommand("test-repo", options, mockDeps);
+      } catch {
+        /* expected to throw */
+      }
+
+      // Missing file count surfaced to the user
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("335"));
+      // Recovery hint uses --force
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("--force"));
+    });
+
+    it("should emit drift_detected status in JSON mode and still throw", async () => {
+      mockGetRepository.mockResolvedValue(sampleRepo);
+      mockUpdateRepository.mockResolvedValue(SAMPLE_DRIFT_DETECTED_RESULT);
+
+      const options: UpdateCommandOptions = { json: true };
+
+      try {
+        await updateRepositoryCommand("test-repo", options, mockDeps);
+      } catch {
+        /* expected to throw */
+      }
+
+      const jsonCalls = consoleLogSpy.mock.calls.filter((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(jsonCalls.length).toBeGreaterThan(0);
+      const jsonOutput = JSON.parse(jsonCalls[0]![0]);
+      expect(jsonOutput.status).toBe("drift_detected");
     });
   });
 

--- a/tests/fixtures/incremental-update-fixtures.ts
+++ b/tests/fixtures/incremental-update-fixtures.ts
@@ -258,6 +258,30 @@ export const SAMPLE_FAILED_RESULT: CoordinatorResult = {
 };
 
 /**
+ * Sample coordinator result - Drift detected
+ *
+ * Tracked SHA matches HEAD but the completeness check flags the index as
+ * incomplete, so an incremental update cannot self-heal. Mirrors the
+ * Muzehub-code reproduction in issue #547.
+ */
+export const SAMPLE_DRIFT_DETECTED_RESULT: CoordinatorResult = {
+  status: "drift_detected",
+  commitSha: TEST_COMMIT_SHAS.head,
+  commitMessage: "up-to-date",
+  stats: SAMPLE_NO_CHANGES_STATS,
+  errors: [],
+  durationMs: 180,
+  completenessCheck: {
+    status: "incomplete",
+    indexedFileCount: 89,
+    eligibleFileCount: 424,
+    missingFileCount: 335,
+    divergencePercent: 79,
+    durationMs: 142,
+  },
+};
+
+/**
  * Helper: Create mock GitHub commit comparison response
  *
  * @param base - Base commit SHA

--- a/tests/mcp/tools/trigger-incremental-update-completeness.test.ts
+++ b/tests/mcp/tools/trigger-incremental-update-completeness.test.ts
@@ -22,7 +22,7 @@ import { initializeLogger } from "../../../src/logging/index.js";
 interface SyncSuccessResponse {
   success: true;
   repository: string;
-  status: "updated" | "no_changes";
+  status: "updated" | "no_changes" | "incomplete" | "drift_detected";
   files_added: number;
   files_modified: number;
   files_deleted: number;
@@ -36,6 +36,7 @@ interface SyncSuccessResponse {
   completeness_eligible_files?: number;
   completeness_missing_files?: number;
   completeness_divergence_percent?: number;
+  recovery_hint?: string;
 }
 
 /**
@@ -260,5 +261,100 @@ describe("trigger_incremental_update - Completeness Fields", () => {
     expect(response.completeness_status).toBe("error");
     expect(response.completeness_indexed_files).toBe(100);
     expect(response.completeness_eligible_files).toBe(0);
+  });
+
+  describe("drift_detected status", () => {
+    it("surfaces drift_detected with recovery_hint and preserved completeness fields", async () => {
+      const driftResult: CoordinatorResult = {
+        status: "drift_detected",
+        commitSha: "7eee88b05bfc0ea6748be4954f1e8f986133782b",
+        commitMessage: "up-to-date",
+        stats: {
+          filesAdded: 0,
+          filesModified: 0,
+          filesDeleted: 0,
+          chunksUpserted: 0,
+          chunksDeleted: 0,
+          durationMs: 0,
+        },
+        errors: [],
+        durationMs: 120,
+        completenessCheck: {
+          status: "incomplete",
+          indexedFileCount: 89,
+          eligibleFileCount: 424,
+          missingFileCount: 335,
+          divergencePercent: 79,
+          durationMs: 142,
+        },
+      };
+
+      const mockCoordinator = {
+        updateRepository: mock(async () => driftResult),
+      } as unknown as IncrementalUpdateCoordinator;
+
+      const handler = createTriggerUpdateHandler({
+        repositoryService: mockRepositoryService,
+        updateCoordinator: mockCoordinator,
+        rateLimiter: new MCPRateLimiter({ cooldownMs: 0 }),
+        jobTracker: new JobTracker(),
+      });
+
+      const callResult = await handler({ repository: "test-repo" });
+
+      expect(callResult.isError).toBe(false);
+      const response = parseResponse(callResult.content);
+
+      expect(response.status).toBe("drift_detected");
+      expect(response.recovery_hint).toBeDefined();
+      expect(response.recovery_hint).toContain("--force");
+      expect(response.recovery_hint).toContain("test-repo");
+      // Completeness payload must be carried through so callers can inspect it
+      expect(response.completeness_status).toBe("incomplete");
+      expect(response.completeness_missing_files).toBe(335);
+    });
+
+    it("does not emit recovery_hint for non-drift statuses", async () => {
+      const noChangesResult: CoordinatorResult = {
+        status: "no_changes",
+        commitSha: "abc123",
+        commitMessage: "existing commit",
+        stats: {
+          filesAdded: 0,
+          filesModified: 0,
+          filesDeleted: 0,
+          chunksUpserted: 0,
+          chunksDeleted: 0,
+          durationMs: 0,
+        },
+        errors: [],
+        durationMs: 50,
+        completenessCheck: {
+          status: "complete",
+          indexedFileCount: 100,
+          eligibleFileCount: 100,
+          missingFileCount: 0,
+          divergencePercent: 0,
+          durationMs: 20,
+        },
+      };
+
+      const mockCoordinator = {
+        updateRepository: mock(async () => noChangesResult),
+      } as unknown as IncrementalUpdateCoordinator;
+
+      const handler = createTriggerUpdateHandler({
+        repositoryService: mockRepositoryService,
+        updateCoordinator: mockCoordinator,
+        rateLimiter: new MCPRateLimiter({ cooldownMs: 0 }),
+        jobTracker: new JobTracker(),
+      });
+
+      const callResult = await handler({ repository: "test-repo" });
+      const response = parseResponse(callResult.content);
+
+      expect(response.status).toBe("no_changes");
+      expect(response.recovery_hint).toBeUndefined();
+    });
   });
 });

--- a/tests/services/incremental-update-coordinator-completeness.test.ts
+++ b/tests/services/incremental-update-coordinator-completeness.test.ts
@@ -11,6 +11,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
+import type { SimpleGit } from "simple-git";
 import { IncrementalUpdateCoordinator } from "../../src/services/incremental-update-coordinator.js";
 import { initializeLogger } from "../../src/logging/index.js";
 import type {
@@ -381,6 +382,164 @@ describe("IncrementalUpdateCoordinator - Completeness Integration", () => {
       expect(result.status).toBe("updated");
       // Completeness check should be undefined since repo not found on re-fetch
       expect(result.completenessCheck).toBeUndefined();
+    });
+  });
+
+  describe("drift detection on no_changes short-circuit", () => {
+    // Builds a GitHubClient whose HEAD SHA matches the tracked lastIndexedCommitSha,
+    // which is what drives the `no_changes` short-circuit path.
+    const buildSameHeadClient = (): GitHubClient => ({
+      getHeadCommit: mock(async () => sameHeadCommit),
+      compareCommits: mock(async () => comparison),
+      healthCheck: mock(async () => true),
+    });
+
+    it("GitHub path: returns drift_detected when completeness is incomplete", async () => {
+      const incompleteChecker = {
+        checkCompleteness: mock(async () => incompleteResult),
+      } as unknown as IndexCompletenessChecker;
+
+      const coordinator = new IncrementalUpdateCoordinator(
+        buildSameHeadClient(),
+        mockRepositoryService,
+        mockUpdatePipeline,
+        {
+          customGitPull: mock(async () => {}),
+          completenessChecker: incompleteChecker,
+        }
+      );
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("drift_detected");
+      expect(result.completenessCheck).toBeDefined();
+      expect(result.completenessCheck!.status).toBe("incomplete");
+      expect(result.completenessCheck!.missingFileCount).toBe(335);
+      expect(result.commitSha).toBe(sameHeadCommit.sha);
+      // The pipeline must not have run — this is a short-circuit path
+      expect(mockUpdatePipeline.processChanges).not.toHaveBeenCalled();
+    });
+
+    it("GitHub path: returns no_changes when completeness is complete (regression guard)", async () => {
+      const coordinator = new IncrementalUpdateCoordinator(
+        buildSameHeadClient(),
+        mockRepositoryService,
+        mockUpdatePipeline,
+        {
+          customGitPull: mock(async () => {}),
+          completenessChecker: mockCompletenessChecker,
+        }
+      );
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("no_changes");
+      expect(result.completenessCheck!.status).toBe("complete");
+    });
+
+    it("GitHub path: returns no_changes when completeness errors (don't escalate on infra failures)", async () => {
+      const errorChecker = {
+        checkCompleteness: mock(
+          async (): Promise<CompletenessCheckResult> => ({
+            status: "error",
+            indexedFileCount: 100,
+            eligibleFileCount: 0,
+            missingFileCount: 0,
+            divergencePercent: 0,
+            durationMs: 5,
+            errorMessage: "File scan failed",
+          })
+        ),
+      } as unknown as IndexCompletenessChecker;
+
+      const coordinator = new IncrementalUpdateCoordinator(
+        buildSameHeadClient(),
+        mockRepositoryService,
+        mockUpdatePipeline,
+        {
+          customGitPull: mock(async () => {}),
+          completenessChecker: errorChecker,
+        }
+      );
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("no_changes");
+      expect(result.completenessCheck!.status).toBe("error");
+    });
+
+    it("GitHub path: returns no_changes when completeness checker is not configured", async () => {
+      const coordinator = new IncrementalUpdateCoordinator(
+        buildSameHeadClient(),
+        mockRepositoryService,
+        mockUpdatePipeline,
+        {
+          customGitPull: mock(async () => {}),
+          // No completenessChecker — drift detection must not fire
+        }
+      );
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("no_changes");
+      expect(result.completenessCheck).toBeUndefined();
+    });
+
+    it("local-git path: returns drift_detected when SHA matches and completeness is incomplete", async () => {
+      const baseSha = "abc123def456abc123def456abc123def456abc1";
+      const localRepo: RepositoryInfo = {
+        ...testRepo,
+        name: "local-repo",
+        url: "C:/local/path/to/repo",
+        localPath: "C:/local/path/to/repo",
+        lastIndexedCommitSha: baseSha,
+      };
+
+      const localRepoService: RepositoryMetadataService = {
+        listRepositories: mock(async () => [localRepo]),
+        getRepository: mock(async (name: string) => (name === "local-repo" ? localRepo : null)),
+        updateRepository: mock(async () => {}),
+        removeRepository: mock(async () => {}),
+      };
+
+      // simple-git stub: revparse returns same SHA, so buildLocalGitComparison returns null
+      // which drives the local-git no_changes short-circuit.
+      const revparse = mock((_args: string[]) => Promise.resolve(baseSha));
+      const mockGit = {
+        revparse,
+        fetch: mock(() => Promise.resolve()),
+        log: mock(() => Promise.resolve({ latest: null, total: 0, all: [] })),
+        diff: mock(() => Promise.resolve("")),
+        raw: mock(() => Promise.resolve("")),
+        pull: mock(() =>
+          Promise.resolve({ files: [], insertions: {}, deletions: {}, summary: {} })
+        ),
+      };
+
+      const incompleteChecker = {
+        checkCompleteness: mock(async () => incompleteResult),
+      } as unknown as IndexCompletenessChecker;
+
+      const coordinator = new IncrementalUpdateCoordinator(
+        mockGitHubClient,
+        localRepoService,
+        mockUpdatePipeline,
+        {
+          customGitPull: mock(async () => {}),
+          completenessChecker: incompleteChecker,
+          simpleGitFactory: () => mockGit as unknown as SimpleGit,
+        }
+      );
+
+      const result = await coordinator.updateRepository("local-repo");
+
+      expect(result.status).toBe("drift_detected");
+      expect(result.completenessCheck!.status).toBe("incomplete");
+      // Local path must use HEAD (not origin/<branch>) and must not fetch.
+      expect(revparse).toHaveBeenCalledWith(["HEAD"]);
+      expect(mockGit.fetch).not.toHaveBeenCalled();
+      // commitSha in the local-git no_changes path reports the tracked SHA
+      expect(result.commitSha).toBe(baseSha);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Incremental update used to return `status: \"no_changes\"` whenever `lastIndexedCommitSha === HEAD`, even if the index was actually incomplete — so any SHA-tracker drift (crashed run, broken CI workflow, etc.) became unrecoverable short of a forced re-index, and semantic search silently returned stale results.
- The `IndexCompletenessChecker` was already running on this path; its result was informational-only (attached to the response, but `status` still read `no_changes`).
- This PR promotes an `incomplete` completeness result on the short-circuit path to a new `CoordinatorStatus` value `drift_detected`, surfaced through the MCP tool (with a `recovery_hint`) and the CLI (yellow warning, divergence counts, non-zero exit so CI stops hiding it behind `continue-on-error: true`).

Fixes #547.

## Behavior matrix at the `no_changes` short-circuit

| Completeness check result | Returned status |
|---|---|
| `complete` | `no_changes` (unchanged) |
| `incomplete` | `drift_detected` (NEW) |
| `error` | `no_changes` (don't escalate on infra failures) |
| checker not configured | `no_changes` (backward compat) |

## Files changed (8)

- `src/services/incremental-update-coordinator-types.ts` — add `drift_detected` to `CoordinatorStatus`
- `src/services/incremental-update-coordinator.ts` — promote `no_changes` → `drift_detected` in both short-circuit paths (GitHub-API and local-git), with correlated `logger.warn`
- `src/mcp/tools/trigger-incremental-update.ts` — surface `drift_detected` + `recovery_hint` in the sync success response
- `src/cli/commands/update-repository-command.ts` — yellow-warn handler, prints divergence counts, throws so CI exits non-zero
- `tests/services/incremental-update-coordinator-completeness.test.ts` — 5 new cases (GitHub incomplete/complete/error/checker-absent paths + local-git incomplete path)
- `tests/mcp/tools/trigger-incremental-update-completeness.test.ts` — 2 new cases (drift_detected surfacing + recovery_hint absence on non-drift)
- `tests/fixtures/incremental-update-fixtures.ts` — new `SAMPLE_DRIFT_DETECTED_RESULT` mirroring the Muzehub-code repro
- `tests/cli/commands/update-repository-command.test.ts` — 3 new cases (throws with guidance, prints divergence, emits JSON status)

## Out of scope (follow-up issues to file)

- **Decoupled SHA trackers** (`lastSeenCommitSha` vs `lastSuccessfullyIndexedSha`) — issue's suggested fix #1.
- **Sample-based chunk-existence verification** — issue's suggested fix #2. `IndexCompletenessChecker` is file-count-only today, so content drift (files present but with stale chunks from an older commit) is not caught. Relevant because the file_count can match while the chunk_count reflects an older commit's content.
- **`get_repository_health` MCP tool** — issue's suggested fix #3.
- **Stuck `updateInProgress: true` on PersonalKnowledgeMCP since 2026-03-24** — tripped a `ConcurrentUpdateError` during exploration. Different drift flavor than this PR addresses; file separately.
- **Muzehub-code's `.github/workflows/update-knowledge-index.yml`** — wrong runner label + `continue-on-error: true` swallows the failure that caused this whole issue. Separate repo, separate PR. Now that the CLI exits non-zero on drift, `continue-on-error: true` should be removed once the runner is fixed.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean (7.16 MB `index.js`, 5.69 MB `cli.js`)
- [x] Focused suites: `tests/services/incremental-update-coordinator-completeness.test.ts`, `tests/mcp/tools/trigger-incremental-update-completeness.test.ts`, `tests/cli/commands/update-repository-command.test.ts` — 58/58 pass
- [x] Full service+CLI+MCP suite: 1111 pass / 1 fail / 1 error — the fail is a pre-existing Windows `sharp` native-module DLL load error also present on `main` (verified via stash+checkout)
- [x] Functional against Muzehub-code: `no_changes` + `complete` happy path exercised end-to-end (1844 indexed vs 1871 on disk, 1.4% divergence, below the 20%/50-file thresholds) — confirms the fix doesn't regress the healthy-index path
- [ ] Reviewer: confirm `drift_detected` should not auto-trigger a forced re-index (left out deliberately — force re-index is slow and embedding-cost-heavy; surfacing the condition and letting the operator choose timing is safer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)