### PR TITLE
fix(#547): review follow-ups — update-all drift handling, recovery, async MCP parity

### DIFF
--- a/docs/integration/cicd-index-updates.md
+++ b/docs/integration/cicd-index-updates.md
@@ -202,6 +202,34 @@ Triggers an incremental update for a repository.
 }
 ```
 
+**Response (Drift Detected):**
+```json
+{
+  "status": "drift_detected",
+  "repository": "my-api",
+  "commit_sha": "7eee88b",
+  "commit_message": "up-to-date",
+  "completeness_status": "incomplete",
+  "completeness_indexed_files": 89,
+  "completeness_eligible_files": 424,
+  "completeness_missing_files": 335,
+  "completeness_divergence_percent": 79,
+  "recovery_hint": "Index drift detected: HEAD SHA matches the tracked commit but the index is incomplete. Run 'bun run cli update my-api --force' to re-index and recover."
+}
+```
+
+When `drift_detected` is returned, the tracked SHA matches HEAD but the index is
+incomplete — incremental updates cannot self-heal this state. Trigger a forced
+re-index via `pk-mcp update <repo> --force` (or the equivalent API call).
+
+**CI workflow guidance:**
+- Workflows using the `pk-mcp update <repo>` or `pk-mcp update --all` CLI wrappers will
+  exit non-zero automatically when drift is detected — no extra handling needed.
+- Workflows calling the HTTP API directly should check `status === "drift_detected"`
+  and alert (e.g., file an issue, page on-call, open a follow-up PR). Do not swallow
+  drift responses with `continue-on-error: true` — that re-creates the original
+  failure mode.
+
 ## Error Handling
 
 ### Retry on Failure

--- a/src/cli/commands/update-all-command.ts
+++ b/src/cli/commands/update-all-command.ts
@@ -93,6 +93,18 @@ function createUpdateAllTable(results: UpdateResult[]): InstanceType<typeof Tabl
         chalk.gray("-"),
         `${result.durationMs}ms`,
       ]);
+    } else if (result.status === "drift_detected") {
+      const missing = result.completenessCheck?.missingFileCount ?? "?";
+      const pct = result.completenessCheck?.divergencePercent ?? "?";
+      const commit = result.commitSha ? result.commitSha.substring(0, 7) : "-";
+      table.push([
+        repository,
+        chalk.yellow("Drift"),
+        commit,
+        chalk.yellow(`${missing} missing (${pct}%)`),
+        chalk.gray("-"),
+        `${result.durationMs}ms`,
+      ]);
     } else if (result.status === "updated") {
       const commitRange = result.commitSha ? result.commitSha.substring(0, 7) : "-";
       table.push([
@@ -159,6 +171,12 @@ export async function updateAllCommand(
       // Stop spinner based on result
       if (result.status === "no_changes") {
         spinner.info(chalk.cyan(`${repo.name} is already up-to-date`));
+      } else if (result.status === "drift_detected") {
+        spinner.warn(
+          chalk.yellow(
+            `${repo.name} drift detected — run 'pk-mcp update ${repo.name} --force' to recover`
+          )
+        );
       } else if (result.status === "updated") {
         if (result.errors.length > 0) {
           spinner.warn(chalk.yellow(`${repo.name} updated with ${result.errors.length} warnings`));
@@ -183,11 +201,14 @@ export async function updateAllCommand(
   // Display summary
   console.log(); // Blank line
 
+  const drifted = results.filter((r) => r.result?.status === "drift_detected").length;
+
   if (options.json) {
     const summary = {
       total: results.length,
       updated: results.filter((r) => r.result?.status === "updated").length,
       current: results.filter((r) => r.result?.status === "no_changes").length,
+      drift_detected: drifted,
       failed: results.filter((r) => r.error || r.result?.status === "failed").length,
     };
 
@@ -201,6 +222,7 @@ export async function updateAllCommand(
             error: r.error,
             stats: r.result?.stats,
             durationMs: r.result?.durationMs,
+            completenessCheck: r.result?.completenessCheck,
           })),
         },
         null,
@@ -219,8 +241,18 @@ export async function updateAllCommand(
     const summaryParts: string[] = [];
     if (updated > 0) summaryParts.push(chalk.green(`${updated} updated`));
     if (current > 0) summaryParts.push(chalk.cyan(`${current} current`));
+    if (drifted > 0) summaryParts.push(chalk.yellow(`${drifted} drift_detected`));
     if (failed > 0) summaryParts.push(chalk.red(`${failed} failed`));
 
     console.log(chalk.bold("Summary: ") + summaryParts.join(", "));
+  }
+
+  // Exit non-zero if any drift was detected so CI workflows catch it.
+  // This mirrors the single-repo `update <name>` command's throw-on-drift.
+  if (drifted > 0) {
+    throw new Error(
+      `Drift detected in ${drifted} repository/repositories. ` +
+        `Re-run each with 'pk-mcp update <repo> --force' to re-index.`
+    );
   }
 }

--- a/src/mcp/job-tracker.ts
+++ b/src/mcp/job-tracker.ts
@@ -10,6 +10,7 @@
 import { randomBytes } from "node:crypto";
 import type { CoordinatorResult } from "../services/incremental-update-coordinator-types.js";
 import { getComponentLogger } from "../logging/index.js";
+import { buildDriftRecoveryHint } from "./tools/utils/drift-recovery-hint.js";
 
 /**
  * Status of an update job
@@ -47,7 +48,7 @@ export interface JobResponse {
   started_at: string;
   completed_at?: string;
   result?: {
-    status: string;
+    status: "updated" | "no_changes" | "incomplete" | "drift_detected" | "failed";
     commit_sha?: string;
     commit_message?: string;
     files_added: number;
@@ -65,6 +66,14 @@ export interface JobResponse {
     graph_files_processed?: number;
     graph_files_skipped?: number;
     graph_error_count?: number;
+    // Index completeness check (present when completeness checker is configured)
+    completeness_status?: "complete" | "incomplete" | "error";
+    completeness_indexed_files?: number;
+    completeness_eligible_files?: number;
+    completeness_missing_files?: number;
+    completeness_divergence_percent?: number;
+    // Populated only when status === "drift_detected"
+    recovery_hint?: string;
   };
   error?: string;
 }
@@ -315,6 +324,23 @@ export class JobTracker {
         response.result.graph_files_processed = job.result.stats.graph.graphFilesProcessed;
         response.result.graph_files_skipped = job.result.stats.graph.graphFilesSkipped;
         response.result.graph_error_count = job.result.stats.graph.graphErrors.length;
+      }
+
+      // Include completeness check results if available
+      if (job.result.completenessCheck) {
+        response.result.completeness_status = job.result.completenessCheck.status;
+        response.result.completeness_indexed_files = job.result.completenessCheck.indexedFileCount;
+        response.result.completeness_eligible_files =
+          job.result.completenessCheck.eligibleFileCount;
+        response.result.completeness_missing_files = job.result.completenessCheck.missingFileCount;
+        response.result.completeness_divergence_percent =
+          job.result.completenessCheck.divergencePercent;
+      }
+
+      // Populate recovery_hint only on drift_detected so async callers
+      // polling get_update_status see the same guidance as sync callers
+      if (job.result.status === "drift_detected") {
+        response.result.recovery_hint = buildDriftRecoveryHint(job.repository);
       }
     }
 

--- a/src/mcp/tools/trigger-incremental-update.ts
+++ b/src/mcp/tools/trigger-incremental-update.ts
@@ -22,6 +22,7 @@ import { getComponentLogger } from "../../logging/index.js";
 import type { ToolHandler } from "../types.js";
 import type { MCPRateLimiter } from "../rate-limiter.js";
 import type { JobTracker } from "../job-tracker.js";
+import { buildDriftRecoveryHint } from "./utils/drift-recovery-hint.js";
 
 /**
  * Timeout for update operations (10 minutes)
@@ -219,9 +220,7 @@ function formatSyncSuccessResponse(repository: string, result: CoordinatorResult
   }
 
   if (result.status === "drift_detected") {
-    response.recovery_hint =
-      `Index drift detected: HEAD SHA matches the tracked commit but the index is incomplete. ` +
-      `Run 'bun run cli update ${repository} --force' to re-index and recover.`;
+    response.recovery_hint = buildDriftRecoveryHint(repository);
   }
 
   // Include graph statistics if available

--- a/src/mcp/tools/utils/drift-recovery-hint.ts
+++ b/src/mcp/tools/utils/drift-recovery-hint.ts
@@ -1,0 +1,21 @@
+/**
+ * Drift recovery hint formatter.
+ *
+ * Shared between the sync (`trigger_incremental_update`) and async
+ * (`get_update_status` / `JobTracker`) MCP response paths so the
+ * user-facing recovery message stays identical as the two call sites
+ * evolve.
+ *
+ * @module mcp/tools/utils/drift-recovery-hint
+ */
+
+/**
+ * Build the recovery-hint string shown to MCP callers when a repository
+ * returns `status: "drift_detected"`.
+ */
+export function buildDriftRecoveryHint(repository: string): string {
+  return (
+    `Index drift detected: HEAD SHA matches the tracked commit but the index is incomplete. ` +
+    `Run 'bun run cli update ${repository} --force' to re-index and recover.`
+  );
+}

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -314,20 +314,10 @@ export class IncrementalUpdateCoordinator {
             repositoryName,
             logger
           );
+          // runCompletenessCheck already emits a structured warn on `incomplete`,
+          // so don't log a second line here. The returned status below is what
+          // callers act on.
           const isDrift = noChangesCompletenessCheck?.status === "incomplete";
-          if (isDrift && noChangesCompletenessCheck) {
-            logger.warn(
-              {
-                operation: "coordinator_drift_detected",
-                repository: repositoryName,
-                indexedFileCount: noChangesCompletenessCheck.indexedFileCount,
-                eligibleFileCount: noChangesCompletenessCheck.eligibleFileCount,
-                missingFileCount: noChangesCompletenessCheck.missingFileCount,
-                divergencePercent: noChangesCompletenessCheck.divergencePercent,
-              },
-              "Drift detected: HEAD SHA matches tracked commit but index is incomplete; recommend forced re-index"
-            );
-          }
           return {
             status: isDrift ? "drift_detected" : "no_changes",
             commitSha: headCommit.sha,
@@ -404,20 +394,10 @@ export class IncrementalUpdateCoordinator {
             repositoryName,
             logger
           );
+          // runCompletenessCheck already emits a structured warn on `incomplete`,
+          // so don't log a second line here. The returned status below is what
+          // callers act on.
           const isDrift = noChangesCompletenessCheck?.status === "incomplete";
-          if (isDrift && noChangesCompletenessCheck) {
-            logger.warn(
-              {
-                operation: "coordinator_drift_detected",
-                repository: repositoryName,
-                indexedFileCount: noChangesCompletenessCheck.indexedFileCount,
-                eligibleFileCount: noChangesCompletenessCheck.eligibleFileCount,
-                missingFileCount: noChangesCompletenessCheck.missingFileCount,
-                divergencePercent: noChangesCompletenessCheck.divergencePercent,
-              },
-              "Drift detected: HEAD SHA matches tracked commit but index is incomplete; recommend forced re-index"
-            );
-          }
           return {
             status: isDrift ? "drift_detected" : "no_changes",
             commitSha: repo.lastIndexedCommitSha,

--- a/src/services/interrupted-update-recovery.ts
+++ b/src/services/interrupted-update-recovery.ts
@@ -346,6 +346,34 @@ async function executeResumeRecovery(
       };
     }
 
+    if (result.status === "drift_detected") {
+      // Incremental update cannot self-heal when the tracked SHA matches HEAD
+      // but the index is incomplete. Recovery is not successful — the caller
+      // needs to run a forced re-index.
+      const durationMsFinal = Date.now() - startTime;
+      const missing = result.completenessCheck?.missingFileCount ?? "?";
+      const pct = result.completenessCheck?.divergencePercent ?? "?";
+      logger.warn(
+        {
+          repository: repositoryName,
+          missingFileCount: result.completenessCheck?.missingFileCount,
+          divergencePercent: result.completenessCheck?.divergencePercent,
+          durationMs: durationMsFinal,
+        },
+        "Resume recovery detected index drift — forced re-index required"
+      );
+      return {
+        strategy,
+        success: false,
+        repositoryName,
+        message:
+          `Index drift detected: tracked SHA matches HEAD but index is incomplete ` +
+          `(${missing} files missing, ${pct}%). ` +
+          `Run 'pk-mcp update ${repositoryName} --force' to re-index and recover.`,
+        durationMs: durationMsFinal,
+      };
+    }
+
     // Partial or failed status
     const durationMsFinal = Date.now() - startTime;
     logger.warn(

--- a/tests/cli/commands/update-all-command.test.ts
+++ b/tests/cli/commands/update-all-command.test.ts
@@ -11,6 +11,9 @@
 /* eslint-disable @typescript-eslint/no-unsafe-call */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
+// Note: await-thenable disable needed for `await expect(...).rejects.toThrow()` patterns
+// which return Promises but ESLint's type inference doesn't recognize this properly
+/* eslint-disable @typescript-eslint/await-thenable */
 
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "bun:test";
 import {
@@ -25,6 +28,7 @@ import {
   SAMPLE_UPDATED_RESULT,
   SAMPLE_UPDATED_WITH_ERRORS_RESULT,
   SAMPLE_FAILED_RESULT,
+  SAMPLE_DRIFT_DETECTED_RESULT,
   TEST_COMMIT_SHAS,
 } from "../../fixtures/incremental-update-fixtures.js";
 import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
@@ -559,6 +563,53 @@ describe("Update All Command", () => {
       expect(consoleLogSpy).toHaveBeenCalledWith(
         expect.stringContaining("Updating 3 repositories")
       );
+    });
+  });
+
+  describe("Drift detected", () => {
+    it("should render a Drift row, count it in the summary, and throw non-zero", async () => {
+      const repos = [createSampleRepo("drifted-repo"), createSampleRepo("healthy-repo")];
+      mockListRepositories.mockResolvedValue(repos);
+      mockUpdateRepository
+        .mockResolvedValueOnce(SAMPLE_DRIFT_DETECTED_RESULT)
+        .mockResolvedValueOnce(SAMPLE_NO_CHANGES_RESULT);
+
+      const options: UpdateAllCommandOptions = {};
+
+      await expect(updateAllCommand(options, mockDeps)).rejects.toThrow(/Drift detected in 1/);
+
+      // Table contains the missing-file count (column is truncated so we match
+      // just the number, which is unambiguous).
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("335"));
+      // Table shows "Drift" status cell for the drifted repo
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("Drift"));
+      // Summary line shows drift_detected count
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.stringContaining("drift_detected"));
+    });
+
+    it("should include drift_detected in JSON summary and still throw", async () => {
+      const repos = [createSampleRepo("drifted-repo")];
+      mockListRepositories.mockResolvedValue(repos);
+      mockUpdateRepository.mockResolvedValue(SAMPLE_DRIFT_DETECTED_RESULT);
+
+      const options: UpdateAllCommandOptions = { json: true };
+
+      await expect(updateAllCommand(options, mockDeps)).rejects.toThrow(/Drift detected/);
+
+      const jsonCalls = consoleLogSpy.mock.calls.filter((call) => {
+        try {
+          JSON.parse(call[0]);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+      expect(jsonCalls.length).toBeGreaterThan(0);
+      const parsed = JSON.parse(jsonCalls[0]![0]);
+      expect(parsed.summary.drift_detected).toBe(1);
+      expect(parsed.results[0].status).toBe("drift_detected");
+      expect(parsed.results[0].completenessCheck).toBeDefined();
+      expect(parsed.results[0].completenessCheck.missingFileCount).toBe(335);
     });
   });
 });

--- a/tests/cli/commands/update-repository-command.test.ts
+++ b/tests/cli/commands/update-repository-command.test.ts
@@ -187,12 +187,16 @@ describe("Update Repository Command", () => {
 
       const options: UpdateCommandOptions = {};
 
-      await expect(updateRepositoryCommand("test-repo", options, mockDeps)).rejects.toThrow(
-        /Drift detected/
-      );
-      await expect(updateRepositoryCommand("test-repo", options, mockDeps)).rejects.toThrow(
-        /--force/
-      );
+      let err: unknown;
+      try {
+        await updateRepositoryCommand("test-repo", options, mockDeps);
+      } catch (e) {
+        err = e;
+      }
+
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toMatch(/Drift detected/);
+      expect((err as Error).message).toMatch(/--force/);
     });
 
     it("should print divergence counts and --force recovery hint", async () => {

--- a/tests/mcp/tools/get-update-status.test.ts
+++ b/tests/mcp/tools/get-update-status.test.ts
@@ -284,4 +284,83 @@ describe("createGetUpdateStatusHandler", () => {
       expect(text).toContain("  ");
     });
   });
+
+  describe("drift_detected job", () => {
+    it("should surface recovery_hint and completeness fields when drift is detected", async () => {
+      const jobId = jobTracker.createJob("test-repo");
+      jobTracker.updateStatus(jobId, "running");
+      jobTracker.complete(
+        jobId,
+        createMockResult({
+          status: "drift_detected",
+          commitSha: "7eee88b05bfc0ea6748be4954f1e8f986133782b",
+          commitMessage: "up-to-date",
+          stats: {
+            filesAdded: 0,
+            filesModified: 0,
+            filesDeleted: 0,
+            chunksUpserted: 0,
+            chunksDeleted: 0,
+            durationMs: 0,
+          },
+          completenessCheck: {
+            status: "incomplete",
+            indexedFileCount: 89,
+            eligibleFileCount: 424,
+            missingFileCount: 335,
+            divergencePercent: 79,
+            durationMs: 142,
+          },
+        })
+      );
+
+      const result = await handler({ job_id: jobId });
+
+      expect(result.isError).toBe(false);
+      const parsed = JSON.parse(getTextContent(result.content)) as {
+        result: {
+          status: string;
+          recovery_hint?: string;
+          completeness_status?: string;
+          completeness_missing_files?: number;
+          completeness_divergence_percent?: number;
+        };
+      };
+
+      expect(parsed.result.status).toBe("drift_detected");
+      expect(parsed.result.recovery_hint).toBeDefined();
+      expect(parsed.result.recovery_hint).toContain("--force");
+      expect(parsed.result.recovery_hint).toContain("test-repo");
+      expect(parsed.result.completeness_status).toBe("incomplete");
+      expect(parsed.result.completeness_missing_files).toBe(335);
+      expect(parsed.result.completeness_divergence_percent).toBe(79);
+    });
+
+    it("should not emit recovery_hint on non-drift statuses", async () => {
+      const jobId = jobTracker.createJob("test-repo");
+      jobTracker.complete(
+        jobId,
+        createMockResult({
+          status: "no_changes",
+          completenessCheck: {
+            status: "complete",
+            indexedFileCount: 100,
+            eligibleFileCount: 100,
+            missingFileCount: 0,
+            divergencePercent: 0,
+            durationMs: 20,
+          },
+        })
+      );
+
+      const result = await handler({ job_id: jobId });
+      const parsed = JSON.parse(getTextContent(result.content)) as {
+        result: { status: string; recovery_hint?: string; completeness_status?: string };
+      };
+
+      expect(parsed.result.status).toBe("no_changes");
+      expect(parsed.result.recovery_hint).toBeUndefined();
+      expect(parsed.result.completeness_status).toBe("complete");
+    });
+  });
 });

--- a/tests/unit/services/interrupted-update-recovery.test.ts
+++ b/tests/unit/services/interrupted-update-recovery.test.ts
@@ -96,21 +96,31 @@ function createMockIngestionService(
 // Helper to create mock update coordinator
 function createMockUpdateCoordinator(
   options: {
-    status?: "updated" | "no_changes" | "failed";
+    status?: "updated" | "no_changes" | "failed" | "drift_detected";
     stats?: { filesAdded: number; filesModified: number; filesDeleted: number };
     errors?: string[];
+    completenessCheck?: {
+      status: "complete" | "incomplete" | "error";
+      indexedFileCount: number;
+      eligibleFileCount: number;
+      missingFileCount: number;
+      divergencePercent: number;
+      durationMs: number;
+    };
   } = {}
 ): IncrementalUpdateCoordinator {
   const {
     status = "updated",
     stats = { filesAdded: 5, filesModified: 3, filesDeleted: 1 },
     errors = [],
+    completenessCheck,
   } = options;
   return {
     updateRepository: mock(async () => ({
       status,
       stats,
       errors,
+      ...(completenessCheck ? { completenessCheck } : {}),
     })),
   } as unknown as IncrementalUpdateCoordinator;
 }
@@ -289,6 +299,47 @@ describe("executeRecovery", () => {
 
       expect(result.success).toBe(true);
       expect(result.message).toContain("up-to-date");
+    });
+
+    it("should report drift as unsuccessful recovery and guide user to --force", async () => {
+      const repo = createMockRepo({ name: "drifted-repo" });
+      const info = createMockInterruptedInfo({
+        repositoryName: "drifted-repo",
+        repository: repo,
+      });
+      const strategy: RecoveryStrategy = {
+        type: "resume",
+        reason: "Test resume",
+        canAutoRecover: true,
+      };
+      const deps: RecoveryDependencies = {
+        repositoryService: createMockRepositoryService([repo]),
+        ingestionService: createMockIngestionService(),
+        updateCoordinator: createMockUpdateCoordinator({
+          status: "drift_detected",
+          stats: { filesAdded: 0, filesModified: 0, filesDeleted: 0 },
+          completenessCheck: {
+            status: "incomplete",
+            indexedFileCount: 89,
+            eligibleFileCount: 424,
+            missingFileCount: 335,
+            divergencePercent: 79,
+            durationMs: 142,
+          },
+        }),
+      };
+
+      const result = await executeRecovery(info, strategy, deps);
+
+      // Drift means the coordinator short-circuited on SHA match while the
+      // index is actually incomplete — recovery did NOT succeed.
+      expect(result.success).toBe(false);
+      expect(result.message).toMatch(/drift/i);
+      expect(result.message).toContain("--force");
+      expect(result.message).toContain("335");
+      // Must NOT fall back to full re-index — that's for exceptions, not drift
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(deps.ingestionService.indexRepository).not.toHaveBeenCalled();
     });
 
     it("should fall back to full reindex when resume fails", async () => {


### PR DESCRIPTION
## Summary

Follow-up PR to [#548](https://github.com/sethships/PersonalKnowledgeMCP/pull/548), addressing the master-code-reviewer findings that were identified after #548 was already merged. #548 wired `drift_detected` through the single-repo CLI and sync MCP response; this PR closes the sibling call-site gaps and secondary findings from the [code review comment](https://github.com/sethships/PersonalKnowledgeMCP/pull/548#issuecomment-4288645101).

Follow-up to #547.

## What's fixed

**🟠 High severity (2)**
- `src/cli/commands/update-all-command.ts` — handle `drift_detected` in the table renderer, spinner, summary counts (incl. JSON), and **throw non-zero on any drift** so CI workflows catch drift at the bulk entrypoint (not just single-repo `update <name>`). This was the PR #548 reviewer's top concern: without this, a CI job running `update --all` weekly still silently passes on drift, defeating the merged PR's CI-ergonomics goal.
- `src/services/interrupted-update-recovery.ts` — add explicit `drift_detected` branch in `executeResumeRecovery`. Returns `success: false` with `--force` recovery guidance. No longer misreports drift as successful resume recovery.

**🟡 Medium severity (2)**
- `src/services/incremental-update-coordinator.ts` — drop the duplicate drift warn on both short-circuit paths. `runCompletenessCheck` already emits an equivalent structured warn when status is `incomplete`.
- `src/mcp/job-tracker.ts`, `src/mcp/tools/get-update-status.ts` — extend `JobResponse.result` with `completeness_*` fields and `recovery_hint`, narrow the `status: string` to the full discriminated union. Async MCP callers (`get_update_status` polling) now see drift guidance identical to sync callers.

**🟢 Low / Nit (3)**
- `src/mcp/tools/utils/drift-recovery-hint.ts` (new) — extracted `buildDriftRecoveryHint(repository)` helper; sync and async response paths now use a single source of truth for the user-facing hint string.
- `docs/integration/cicd-index-updates.md` — documented `drift_detected` response shape and added CI-workflow guidance paragraph.
- `tests/cli/commands/update-repository-command.test.ts` — collapsed the CLI drift test's two `rejects.toThrow` invocations into a single try/catch with two matchers on the captured error.

## New tests

- `tests/mcp/tools/get-update-status.test.ts` — 2 cases covering async drift flow (recovery_hint + completeness fields surface correctly; no hint on non-drift).
- `tests/cli/commands/update-all-command.test.ts` — 2 cases (Drift row renders with divergence count; summary counts it + throws; drift_detected flows through JSON mode).
- `tests/unit/services/interrupted-update-recovery.test.ts` — 1 case (drift during resume returns `success: false` with `--force` guidance, does not fall back to full re-index).

## Filed as follow-up issues (per reviewer's own guidance, not in this PR)

- #552 — Consolidate `SimpleGit` mock helpers across coordinator tests (Info)
- #553 — CLI update command silently swallows `incomplete` coordinator status (Info, pre-existing bug — not introduced by #548 or this PR)

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean
- [x] Focused suites (6 test files covering all changed areas): **124 / 124 pass**, 356 expect() calls
- [x] Broader scope validated against `main` baseline: pre-existing `sharp` native-module DLL load on Windows + network-dependent mock retries are NOT caused by this PR
- [ ] Reviewer: confirm the throw-on-drift behavior in `update --all` is acceptable (alternative: keep exit 0 and return a JSON flag). I made it throw to mirror single-repo `update <name>`, which is consistent with the PR #548 reviewer's recommendation.

## Files changed (11 files, +336 / -37)

```
 docs/integration/cicd-index-updates.md                   | +28
 src/cli/commands/update-all-command.ts                   | +32
 src/mcp/job-tracker.ts                                   | +28 -3
 src/mcp/tools/trigger-incremental-update.ts              | +4 -4
 src/mcp/tools/utils/drift-recovery-hint.ts               | +21 (new)
 src/services/incremental-update-coordinator.ts           | +8 -29
 src/services/interrupted-update-recovery.ts              | +28
 tests/cli/commands/update-all-command.test.ts            | +51
 tests/cli/commands/update-repository-command.test.ts     | +9 -6
 tests/mcp/tools/get-update-status.test.ts                | +79
 tests/unit/services/interrupted-update-recovery.test.ts  | +52 -1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)