### PR TITLE
fix(#557): sharp install, pdfjs bundling, provider dimensions, CLI shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ docs/pm/*plan*.md
 # Claude Code MCP configuration (machine-specific paths)
 .claude/mcp.json
 
+# Claude Code runtime lock files (e.g. scheduled_tasks.lock for /schedule and /loop)
+.claude/*.lock
+
 # Claude Code temporary files
 tmpclaude-*-cwd
 

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,7 @@ docs/pm/*plan*.md
 
 # Claude Code runtime lock files (e.g. scheduled_tasks.lock for /schedule and /loop)
 .claude/*.lock
+.claude/*.tmp
 
 # Claude Code temporary files
 tmpclaude-*-cwd

--- a/bun.lock
+++ b/bun.lock
@@ -77,6 +77,7 @@
     },
   },
   "trustedDependencies": [
+    "sharp",
     "@modelcontextprotocol/sdk",
   ],
   "packages": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "bun build src/index.ts --outfile dist/index.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node --external pdfjs-dist && bun build src/cli/index.ts --outfile dist/cli.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node --external pdfjs-dist",
+    "build": "bun build src/index.ts --outfile dist/index.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node --external pdfjs-dist --external pdf-parse && bun build src/cli/index.ts --outfile dist/cli.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node --external pdfjs-dist --external pdf-parse",
     "dev": "bun --watch src/index.ts",
     "start": "bun run dist/index.js",
     "cli": "bun run dist/cli.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "build": "bun build src/index.ts --outfile dist/index.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node && bun build src/cli/index.ts --outfile dist/cli.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node",
+    "build": "bun build src/index.ts --outfile dist/index.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node --external pdfjs-dist && bun build src/cli/index.ts --outfile dist/cli.js --target bun --external chromadb --external @xenova/transformers --external onnxruntime-node --external pdfjs-dist",
     "dev": "bun --watch src/index.ts",
     "start": "bun run dist/index.js",
     "cli": "bun run dist/cli.js",
@@ -129,6 +129,7 @@
   },
   "homepage": "https://github.com/sethships/PersonalKnowledgeMCP#readme",
   "trustedDependencies": [
-    "@modelcontextprotocol/sdk"
+    "@modelcontextprotocol/sdk",
+    "sharp"
   ]
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -744,4 +744,14 @@ watchProgram
     }
   });
 
-program.parse();
+// `program.parseAsync()` awaits all async `.action(...)` handlers, so we know
+// every command has finished by the time it resolves. The explicit `exit(0)`
+// is needed because long-lived clients (ChromaDB HTTP keepalive, FalkorDB Redis
+// connection, embedder workers) keep the event loop alive otherwise.
+// Per-command errors are already caught inside each `.action()` and routed through
+// `handleCommandError` (which calls `process.exit(1)`); the catch here is a safety
+// net for parse-time errors and any handler that didn't catch its own throw.
+program
+  .parseAsync()
+  .then(() => process.exit(0))
+  .catch((err: unknown) => handleCommandError(err));

--- a/src/providers/EmbeddingProviderFactory.ts
+++ b/src/providers/EmbeddingProviderFactory.ts
@@ -11,14 +11,9 @@ import type { EmbeddingProvider, EmbeddingProviderConfig } from "./types.js";
 import { OpenAIEmbeddingProvider, type OpenAIProviderConfig } from "./openai-embedding.js";
 import {
   TransformersJsEmbeddingProvider,
-  getTransformersJsModelDimensions,
   type TransformersJsProviderConfig,
 } from "./transformersjs-embedding.js";
-import {
-  OllamaEmbeddingProvider,
-  getOllamaModelDimensions,
-  type OllamaProviderConfig,
-} from "./ollama-embedding.js";
+import { OllamaEmbeddingProvider, type OllamaProviderConfig } from "./ollama-embedding.js";
 import { EmbeddingValidationError } from "./errors.js";
 
 /**
@@ -281,14 +276,17 @@ export class EmbeddingProviderFactory {
   private createTransformersJsProvider(
     config: EmbeddingProviderConfig
   ): TransformersJsEmbeddingProvider {
-    const modelPath = (config.options?.["modelPath"] as string) || "Xenova/all-MiniLM-L6-v2";
-    // The model produces a fixed-size vector. Override any caller-supplied dimensions
-    // (commonly an OpenAI-shaped 1536 from EMBEDDING_DIMENSIONS env default) with the
-    // model's true output size so downstream metadata is accurate.
-    const trueDimensions = getTransformersJsModelDimensions(modelPath) ?? config.dimensions;
+    // Fall back to `config.model` so users who set only EMBEDDING_MODEL (without
+    // an explicit `options.modelPath`) get their actual model loaded. Without
+    // this fallback the lookup silently keyed off the hardcoded default and
+    // ignored the user's intent. The provider constructor performs the real
+    // dimension lookup; the caller-supplied `config.dimensions` (typically an
+    // OpenAI-shaped 1536 default leaked from `dependency-init.ts` / `index.ts`)
+    // is overridden there for any model present in the dimensions table.
+    const modelPath =
+      (config.options?.["modelPath"] as string) || config.model || "Xenova/all-MiniLM-L6-v2";
     const transformersConfig: TransformersJsProviderConfig = {
       ...config,
-      dimensions: trueDimensions,
       modelPath,
       cacheDir: Bun.env["TRANSFORMERS_CACHE"] || undefined,
       quantized: (config.options?.["quantized"] as boolean) || false,
@@ -336,13 +334,14 @@ export class EmbeddingProviderFactory {
       baseUrl = `http://${host}:${port}`;
     }
 
-    const modelName = (config.options?.["modelName"] as string) || "nomic-embed-text";
-    // Same reasoning as transformersjs: override any caller-supplied dimensions
-    // with the model's true output size.
-    const trueDimensions = getOllamaModelDimensions(modelName) ?? config.dimensions;
+    // Fall back to `config.model` so users who set only EMBEDDING_MODEL (without
+    // an explicit `options.modelName`) get their actual model loaded. Same
+    // reasoning as the transformersjs path — see that branch for full context.
+    // The provider constructor handles the dimension override.
+    const modelName =
+      (config.options?.["modelName"] as string) || config.model || "nomic-embed-text";
     const ollamaConfig: OllamaProviderConfig = {
       ...config,
-      dimensions: trueDimensions,
       modelName,
       baseUrl,
       keepAlive: (config.options?.["keepAlive"] as string) || "5m",

--- a/src/providers/EmbeddingProviderFactory.ts
+++ b/src/providers/EmbeddingProviderFactory.ts
@@ -11,9 +11,14 @@ import type { EmbeddingProvider, EmbeddingProviderConfig } from "./types.js";
 import { OpenAIEmbeddingProvider, type OpenAIProviderConfig } from "./openai-embedding.js";
 import {
   TransformersJsEmbeddingProvider,
+  getTransformersJsModelDimensions,
   type TransformersJsProviderConfig,
 } from "./transformersjs-embedding.js";
-import { OllamaEmbeddingProvider, type OllamaProviderConfig } from "./ollama-embedding.js";
+import {
+  OllamaEmbeddingProvider,
+  getOllamaModelDimensions,
+  type OllamaProviderConfig,
+} from "./ollama-embedding.js";
 import { EmbeddingValidationError } from "./errors.js";
 
 /**
@@ -276,9 +281,15 @@ export class EmbeddingProviderFactory {
   private createTransformersJsProvider(
     config: EmbeddingProviderConfig
   ): TransformersJsEmbeddingProvider {
+    const modelPath = (config.options?.["modelPath"] as string) || "Xenova/all-MiniLM-L6-v2";
+    // The model produces a fixed-size vector. Override any caller-supplied dimensions
+    // (commonly an OpenAI-shaped 1536 from EMBEDDING_DIMENSIONS env default) with the
+    // model's true output size so downstream metadata is accurate.
+    const trueDimensions = getTransformersJsModelDimensions(modelPath) ?? config.dimensions;
     const transformersConfig: TransformersJsProviderConfig = {
       ...config,
-      modelPath: (config.options?.["modelPath"] as string) || "Xenova/all-MiniLM-L6-v2",
+      dimensions: trueDimensions,
+      modelPath,
       cacheDir: Bun.env["TRANSFORMERS_CACHE"] || undefined,
       quantized: (config.options?.["quantized"] as boolean) || false,
     };
@@ -325,9 +336,14 @@ export class EmbeddingProviderFactory {
       baseUrl = `http://${host}:${port}`;
     }
 
+    const modelName = (config.options?.["modelName"] as string) || "nomic-embed-text";
+    // Same reasoning as transformersjs: override any caller-supplied dimensions
+    // with the model's true output size.
+    const trueDimensions = getOllamaModelDimensions(modelName) ?? config.dimensions;
     const ollamaConfig: OllamaProviderConfig = {
       ...config,
-      modelName: (config.options?.["modelName"] as string) || "nomic-embed-text",
+      dimensions: trueDimensions,
+      modelName,
       baseUrl,
       keepAlive: (config.options?.["keepAlive"] as string) || "5m",
     };

--- a/src/providers/ollama-embedding.ts
+++ b/src/providers/ollama-embedding.ts
@@ -19,11 +19,16 @@ import {
  * Output dimensions for popular Ollama embedding models.
  *
  * Like Transformers.js, an Ollama model produces a fixed-size vector regardless
- * of any `dimensions` value the caller passes. The factory uses this to overwrite
- * a stale env-derived `config.dimensions` with the model's true size before
- * constructing the provider. Ollama model names may carry a `:tag` suffix
- * (e.g. `nomic-embed-text:latest`) — `getOllamaModelDimensions` strips it.
+ * of any `dimensions` value the caller passes. The provider constructor uses
+ * this to overwrite a stale `config.dimensions` (often an OpenAI-shaped 1536
+ * default leaked from `dependency-init.ts` / `index.ts`) with the model's true
+ * size before initializing. Ollama model names may carry a `:tag` suffix (e.g.
+ * `nomic-embed-text:latest`) — `getOllamaModelDimensions` strips it.
  */
+// NOTE: keep this table in sync with the Ollama model registry.
+// Models not listed here fall back to the caller-supplied `config.dimensions`
+// (which is usually wrong — see ADR-0003 / issue #557). Add new entries when
+// users adopt new Ollama embedding models.
 export const OLLAMA_MODEL_DIMENSIONS: Readonly<Record<string, number>> = {
   "nomic-embed-text": 768,
   "mxbai-embed-large": 1024,
@@ -154,7 +159,11 @@ export class OllamaEmbeddingProvider implements EmbeddingProvider {
     this.validateConfig(config);
 
     this.modelId = config.modelName;
-    this.dimensions = config.dimensions;
+    // The model produces a fixed-size vector. Prefer the canonical lookup over
+    // any caller-supplied `dimensions` (which historically leaked the OpenAI
+    // env-default of 1536). Falls back to `config.dimensions` only for models
+    // not yet in the table — see OLLAMA_MODEL_DIMENSIONS.
+    this.dimensions = getOllamaModelDimensions(config.modelName) ?? config.dimensions;
     this.baseUrl = config.baseUrl || "http://localhost:11434";
     this.keepAlive = config.keepAlive || "5m";
     this.timeoutMs = config.timeoutMs;

--- a/src/providers/ollama-embedding.ts
+++ b/src/providers/ollama-embedding.ts
@@ -16,6 +16,32 @@ import {
 } from "./errors.js";
 
 /**
+ * Output dimensions for popular Ollama embedding models.
+ *
+ * Like Transformers.js, an Ollama model produces a fixed-size vector regardless
+ * of any `dimensions` value the caller passes. The factory uses this to overwrite
+ * a stale env-derived `config.dimensions` with the model's true size before
+ * constructing the provider. Ollama model names may carry a `:tag` suffix
+ * (e.g. `nomic-embed-text:latest`) — `getOllamaModelDimensions` strips it.
+ */
+export const OLLAMA_MODEL_DIMENSIONS: Readonly<Record<string, number>> = {
+  "nomic-embed-text": 768,
+  "mxbai-embed-large": 1024,
+  "all-minilm": 384,
+  "snowflake-arctic-embed": 1024,
+};
+
+/**
+ * Resolve the output dimension for an Ollama model by name (with or without tag).
+ *
+ * @returns The known output dimension, or `undefined` if the model is not in the table.
+ */
+export function getOllamaModelDimensions(modelName: string): number | undefined {
+  const baseName = modelName.split(":")[0] ?? modelName;
+  return OLLAMA_MODEL_DIMENSIONS[baseName];
+}
+
+/**
  * Configuration specific to Ollama embedding provider
  */
 export interface OllamaProviderConfig extends EmbeddingProviderConfig {

--- a/src/providers/transformersjs-embedding.ts
+++ b/src/providers/transformersjs-embedding.ts
@@ -19,6 +19,39 @@ import { EmbeddingError, EmbeddingValidationError, EmbeddingNetworkError } from 
 const DEFAULT_CACHE_DIR = path.join(os.homedir(), ".cache", "huggingface", "transformers");
 
 /**
+ * Output dimensions for popular Transformers.js embedding models.
+ *
+ * The Transformers.js model produces a fixed-size vector regardless of any
+ * `dimensions` value the caller passes in config. The factory uses this map
+ * to overwrite a stale env-derived `config.dimensions` (which often defaults
+ * to an OpenAI-shaped 1536) with the model's true output size before
+ * constructing the provider.
+ */
+export const TRANSFORMERSJS_MODEL_DIMENSIONS: Readonly<Record<string, number>> = {
+  "Xenova/all-MiniLM-L6-v2": 384,
+  "Xenova/all-MiniLM-L12-v2": 384,
+  "Xenova/bge-small-en-v1.5": 384,
+  "Xenova/bge-base-en-v1.5": 768,
+  "Xenova/bge-large-en-v1.5": 1024,
+  "Xenova/gte-small": 384,
+  "Xenova/gte-base": 768,
+  "Xenova/gte-large": 1024,
+  "Xenova/e5-small-v2": 384,
+  "Xenova/e5-base-v2": 768,
+  "Xenova/e5-large-v2": 1024,
+};
+
+/**
+ * Resolve the output dimension for a Transformers.js model by path.
+ *
+ * @returns The known output dimension, or `undefined` if the model is not in the table.
+ *   Callers should fall back to whatever value the user supplied in that case.
+ */
+export function getTransformersJsModelDimensions(modelPath: string): number | undefined {
+  return TRANSFORMERSJS_MODEL_DIMENSIONS[modelPath];
+}
+
+/**
  * Progress information during model download
  */
 export interface ModelDownloadProgress {

--- a/src/providers/transformersjs-embedding.ts
+++ b/src/providers/transformersjs-embedding.ts
@@ -22,11 +22,15 @@ const DEFAULT_CACHE_DIR = path.join(os.homedir(), ".cache", "huggingface", "tran
  * Output dimensions for popular Transformers.js embedding models.
  *
  * The Transformers.js model produces a fixed-size vector regardless of any
- * `dimensions` value the caller passes in config. The factory uses this map
- * to overwrite a stale env-derived `config.dimensions` (which often defaults
- * to an OpenAI-shaped 1536) with the model's true output size before
- * constructing the provider.
+ * `dimensions` value the caller passes in config. The provider constructor
+ * uses this map to overwrite a stale `config.dimensions` (which often defaults
+ * to an OpenAI-shaped 1536 leaked from `dependency-init.ts` / `index.ts`) with
+ * the model's true output size before initializing.
  */
+// NOTE: keep this table in sync with the model's HuggingFace metadata.
+// Models not listed here fall back to the caller-supplied `config.dimensions`
+// (which is usually wrong — see ADR-0003 / issue #557). Add new entries when
+// users adopt new HuggingFace embedding models.
 export const TRANSFORMERSJS_MODEL_DIMENSIONS: Readonly<Record<string, number>> = {
   "Xenova/all-MiniLM-L6-v2": 384,
   "Xenova/all-MiniLM-L12-v2": 384,
@@ -164,7 +168,11 @@ export class TransformersJsEmbeddingProvider implements EmbeddingProvider {
     this.validateConfig(config);
     this.config = config;
     this.modelId = config.modelPath;
-    this.dimensions = config.dimensions;
+    // The model produces a fixed-size vector. Prefer the canonical lookup over
+    // any caller-supplied `dimensions` (which historically leaked the OpenAI
+    // env-default of 1536). Falls back to `config.dimensions` only for models
+    // not yet in the table — see TRANSFORMERSJS_MODEL_DIMENSIONS.
+    this.dimensions = getTransformersJsModelDimensions(config.modelPath) ?? config.dimensions;
   }
 
   /**

--- a/tests/unit/providers/EmbeddingProviderFactory.test.ts
+++ b/tests/unit/providers/EmbeddingProviderFactory.test.ts
@@ -155,6 +155,61 @@ describe("EmbeddingProviderFactory", () => {
 
       expect(() => factory.createProvider(config)).toThrow("openai, transformersjs, ollama");
     });
+
+    // Regression: a stale env-default `EMBEDDING_DIMENSIONS=1536` (an OpenAI shape)
+    // was being passed through to the transformersjs/ollama provider and recorded in
+    // repository metadata, causing search-time dimension-mismatch failures. The factory
+    // must override `config.dimensions` with the model's true output size.
+    test("overrides config.dimensions with model's true size for transformersjs", () => {
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "transformersjs",
+        model: "Xenova/all-MiniLM-L6-v2",
+        dimensions: 1536, // wrong (OpenAI default leaking through)
+        batchSize: 32,
+        maxRetries: 0,
+        timeoutMs: 60000,
+      };
+
+      const provider = factory.createProvider(config);
+
+      expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
+      expect(provider.dimensions).toBe(384);
+    });
+
+    test("overrides config.dimensions with model's true size for ollama", () => {
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "ollama",
+        model: "nomic-embed-text",
+        dimensions: 1536, // wrong
+        batchSize: 32,
+        maxRetries: 3,
+        timeoutMs: 30000,
+      };
+
+      const provider = factory.createProvider(config);
+
+      expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+      expect(provider.dimensions).toBe(768);
+    });
+
+    test("falls back to caller-supplied dimensions for unknown transformersjs model", () => {
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "transformersjs",
+        model: "some/custom-model-not-in-table",
+        dimensions: 512,
+        batchSize: 32,
+        maxRetries: 0,
+        timeoutMs: 60000,
+        options: { modelPath: "some/custom-model-not-in-table" },
+      };
+
+      const provider = factory.createProvider(config);
+
+      expect(provider.dimensions).toBe(512);
+    });
   });
 
   describe("listAvailableProviders", () => {

--- a/tests/unit/providers/EmbeddingProviderFactory.test.ts
+++ b/tests/unit/providers/EmbeddingProviderFactory.test.ts
@@ -210,6 +210,82 @@ describe("EmbeddingProviderFactory", () => {
 
       expect(provider.dimensions).toBe(512);
     });
+
+    // Regression: an EMBEDDING_MODEL env var without an accompanying options.modelPath
+    // (or a caller passing a non-default `model` directly) must still hit the dimension
+    // table. The factory is responsible for resolving `modelPath` from options first,
+    // then `config.model`, then the hardcoded default.
+    test("uses model's true dimensions for a non-default transformersjs model via options.modelPath", () => {
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "transformersjs",
+        model: "Xenova/bge-base-en-v1.5",
+        dimensions: 1536, // wrong (OpenAI default leaking through)
+        batchSize: 32,
+        maxRetries: 0,
+        timeoutMs: 60000,
+        options: { modelPath: "Xenova/bge-base-en-v1.5" },
+      };
+
+      const provider = factory.createProvider(config);
+
+      expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
+      expect(provider.dimensions).toBe(768);
+    });
+
+    test("uses config.model when options.modelPath is absent so EMBEDDING_MODEL env vars work", () => {
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "transformersjs",
+        model: "Xenova/bge-base-en-v1.5",
+        dimensions: 1536, // wrong (OpenAI default leaking through)
+        batchSize: 32,
+        maxRetries: 0,
+        timeoutMs: 60000,
+        // No `options` — simulates EMBEDDING_MODEL set without explicit modelPath option.
+      };
+
+      const provider = factory.createProvider(config);
+
+      expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
+      expect(provider.dimensions).toBe(768);
+    });
+
+    test("uses model's true dimensions for a non-default ollama model via options.modelName", () => {
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "ollama",
+        model: "mxbai-embed-large",
+        dimensions: 1536, // wrong (OpenAI default leaking through)
+        batchSize: 32,
+        maxRetries: 3,
+        timeoutMs: 30000,
+        options: { modelName: "mxbai-embed-large" },
+      };
+
+      const provider = factory.createProvider(config);
+
+      expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+      expect(provider.dimensions).toBe(1024);
+    });
+
+    test("uses config.model when options.modelName is absent so EMBEDDING_MODEL env vars work for ollama", () => {
+      const factory = new EmbeddingProviderFactory();
+      const config: EmbeddingProviderConfig = {
+        provider: "ollama",
+        model: "mxbai-embed-large",
+        dimensions: 1536, // wrong
+        batchSize: 32,
+        maxRetries: 3,
+        timeoutMs: 30000,
+        // No `options` — simulates EMBEDDING_MODEL set without explicit modelName option.
+      };
+
+      const provider = factory.createProvider(config);
+
+      expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+      expect(provider.dimensions).toBe(1024);
+    });
   });
 
   describe("listAvailableProviders", () => {

--- a/tests/unit/providers/factory.test.ts
+++ b/tests/unit/providers/factory.test.ts
@@ -351,11 +351,15 @@ describe("createEmbeddingProvider", () => {
       expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
     });
 
-    test("passes dimensions through to provider", () => {
+    test("uses model's true dimensions even when caller-supplied dimensions differ", () => {
+      // The model produces a fixed-size vector (bge-small-en-v1.5 → 384). The factory
+      // must override a stale or wrong caller-supplied `dimensions` with the model's
+      // real output so downstream metadata is accurate. Regression test for the
+      // dimension-mismatch bug where env-default 1536 leaked into transformersjs metadata.
       const config: EmbeddingProviderConfig = {
         provider: "transformersjs",
         model: "Xenova/bge-small-en-v1.5",
-        dimensions: 768, // Different dimensions
+        dimensions: 768, // wrong on purpose
         batchSize: 32,
         maxRetries: 0,
         timeoutMs: 60000,
@@ -365,7 +369,7 @@ describe("createEmbeddingProvider", () => {
       };
 
       const provider = createEmbeddingProvider(config);
-      expect(provider.dimensions).toBe(768);
+      expect(provider.dimensions).toBe(384);
     });
   });
 

--- a/tests/unit/providers/factory.test.ts
+++ b/tests/unit/providers/factory.test.ts
@@ -283,10 +283,14 @@ describe("createEmbeddingProvider", () => {
       expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
     });
 
-    test("uses default model path when not specified in options", () => {
+    test("uses config.model when options.modelPath is absent", () => {
+      // Regression for issue #557: previously the factory ignored `config.model`
+      // and silently fell through to the hardcoded default whenever
+      // `options.modelPath` was missing, defeating EMBEDDING_MODEL env vars.
+      // Now `config.model` takes precedence over the hardcoded default.
       const config: EmbeddingProviderConfig = {
         provider: "transformersjs",
-        model: "default-model",
+        model: "Xenova/bge-small-en-v1.5",
         dimensions: 384,
         batchSize: 32,
         maxRetries: 0,
@@ -295,7 +299,23 @@ describe("createEmbeddingProvider", () => {
 
       const provider = createEmbeddingProvider(config);
       expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
-      // Default model path is Xenova/all-MiniLM-L6-v2
+      expect(provider.modelId).toBe("Xenova/bge-small-en-v1.5");
+    });
+
+    test("falls back to hardcoded default when neither options.modelPath nor config.model resolves", () => {
+      // When `config.model` is the empty string (an unusual but possible state),
+      // the factory falls through to the hardcoded Xenova/all-MiniLM-L6-v2.
+      const config: EmbeddingProviderConfig = {
+        provider: "transformersjs",
+        model: "",
+        dimensions: 384,
+        batchSize: 32,
+        maxRetries: 0,
+        timeoutMs: 60000,
+      };
+
+      const provider = createEmbeddingProvider(config);
+      expect(provider).toBeInstanceOf(TransformersJsEmbeddingProvider);
       expect(provider.modelId).toBe("Xenova/all-MiniLM-L6-v2");
     });
 
@@ -421,10 +441,31 @@ describe("createEmbeddingProvider", () => {
       expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
     });
 
-    test("uses default model name when not specified in options", () => {
+    test("uses config.model when options.modelName is absent", () => {
+      // Regression for issue #557: previously the factory ignored `config.model`
+      // and silently fell through to the hardcoded `nomic-embed-text` whenever
+      // `options.modelName` was missing, defeating EMBEDDING_MODEL env vars.
+      // Now `config.model` takes precedence over the hardcoded default.
       const config: EmbeddingProviderConfig = {
         provider: "ollama",
-        model: "some-model",
+        model: "mxbai-embed-large",
+        dimensions: 1024,
+        batchSize: 32,
+        maxRetries: 3,
+        timeoutMs: 30000,
+      };
+
+      const provider = createEmbeddingProvider(config);
+      expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
+      expect(provider.modelId).toBe("mxbai-embed-large");
+    });
+
+    test("falls back to hardcoded default when neither options.modelName nor config.model resolves", () => {
+      // When `config.model` is the empty string, the factory falls through to
+      // the hardcoded `nomic-embed-text`.
+      const config: EmbeddingProviderConfig = {
+        provider: "ollama",
+        model: "",
         dimensions: 768,
         batchSize: 32,
         maxRetries: 3,
@@ -433,7 +474,6 @@ describe("createEmbeddingProvider", () => {
 
       const provider = createEmbeddingProvider(config);
       expect(provider).toBeInstanceOf(OllamaEmbeddingProvider);
-      // Default model name is nomic-embed-text
       expect(provider.modelId).toBe("nomic-embed-text");
     });
 

--- a/tests/unit/providers/ollama-embedding.test.ts
+++ b/tests/unit/providers/ollama-embedding.test.ts
@@ -9,6 +9,8 @@
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
   OllamaEmbeddingProvider,
+  OLLAMA_MODEL_DIMENSIONS,
+  getOllamaModelDimensions,
   type OllamaProviderConfig,
 } from "../../../src/providers/ollama-embedding.js";
 import {
@@ -548,5 +550,29 @@ describe("OllamaEmbeddingProvider", () => {
 
       expect(capturedBody.keep_alive).toBe("30m");
     });
+  });
+});
+
+describe("getOllamaModelDimensions", () => {
+  test("returns 768 for nomic-embed-text", () => {
+    expect(getOllamaModelDimensions("nomic-embed-text")).toBe(768);
+  });
+
+  test("returns 1024 for mxbai-embed-large", () => {
+    expect(getOllamaModelDimensions("mxbai-embed-large")).toBe(1024);
+  });
+
+  test("strips :tag suffix before lookup", () => {
+    expect(getOllamaModelDimensions("nomic-embed-text:latest")).toBe(768);
+    expect(getOllamaModelDimensions("nomic-embed-text:v1")).toBe(768);
+  });
+
+  test("returns undefined for unknown model so caller can fall back", () => {
+    expect(getOllamaModelDimensions("not-in-table-model")).toBeUndefined();
+  });
+
+  test("MODEL_DIMENSIONS table is non-empty and contains the default model", () => {
+    expect(Object.keys(OLLAMA_MODEL_DIMENSIONS).length).toBeGreaterThan(0);
+    expect(OLLAMA_MODEL_DIMENSIONS["nomic-embed-text"]).toBe(768);
   });
 });

--- a/tests/unit/providers/transformersjs-embedding.test.ts
+++ b/tests/unit/providers/transformersjs-embedding.test.ts
@@ -11,6 +11,8 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 import {
   TransformersJsEmbeddingProvider,
+  TRANSFORMERSJS_MODEL_DIMENSIONS,
+  getTransformersJsModelDimensions,
   type TransformersJsProviderConfig,
 } from "../../../src/providers/transformersjs-embedding.js";
 import { EmbeddingValidationError } from "../../../src/providers/errors.js";
@@ -275,5 +277,24 @@ describe("TransformersJsEmbeddingProvider - Mock Integration", () => {
 
     const output = await mockPipeline.call("Hello");
     expect(output.data).toBeInstanceOf(Float32Array);
+  });
+});
+
+describe("getTransformersJsModelDimensions", () => {
+  test("returns 384 for all-MiniLM-L6-v2", () => {
+    expect(getTransformersJsModelDimensions("Xenova/all-MiniLM-L6-v2")).toBe(384);
+  });
+
+  test("returns 768 for bge-base-en-v1.5", () => {
+    expect(getTransformersJsModelDimensions("Xenova/bge-base-en-v1.5")).toBe(768);
+  });
+
+  test("returns undefined for unknown model so caller can fall back", () => {
+    expect(getTransformersJsModelDimensions("not-in-table/whatever")).toBeUndefined();
+  });
+
+  test("MODEL_DIMENSIONS table is non-empty and contains the default model", () => {
+    expect(Object.keys(TRANSFORMERSJS_MODEL_DIMENSIONS).length).toBeGreaterThan(0);
+    expect(TRANSFORMERSJS_MODEL_DIMENSIONS["Xenova/all-MiniLM-L6-v2"]).toBe(384);
   });
 });

--- a/tests/unit/providers/transformersjs-embedding.test.ts
+++ b/tests/unit/providers/transformersjs-embedding.test.ts
@@ -232,7 +232,10 @@ describe("TransformersJsEmbeddingProvider", () => {
       const provider = new TransformersJsEmbeddingProvider(bgeConfig);
 
       expect(provider.modelId).toBe("Xenova/bge-small-en-v1.5");
-      expect(provider.dimensions).toBe(768);
+      // The provider constructor looks up the model's true dimension from the
+      // canonical table — bge-small-en-v1.5 is 384, regardless of any wrong
+      // value the fixture/caller may carry. See ADR-0003 / issue #557.
+      expect(provider.dimensions).toBe(384);
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes four bugs that combined to make the local-first happy path nearly unusable on a clean Windows clone. Surfaced together while running a full local-provider index of a ~2k-file repository.

| # | Bug | Fix |
|---|-----|-----|
| 1 | sharp postinstall skipped → Transformers.js provider crashes | Add `"sharp"` to `package.json` ▸ `trustedDependencies` |
| 2 | `pdfjs-dist` bundled → bundled CLI can't parse PDFs | Add `--external pdfjs-dist` to both `bun build` invocations |
| 3 | Indexer recorded env-default `embeddingDimensions=1536` even when the real provider dimension was 384 → search rejects every query as dimension mismatch | Override `config.dimensions` in the factory for `transformersjs` and `ollama` using a small model→dimensions lookup table |
| 4 | CLI commands log "completed" but never exit (open Chroma/Falkor/embedder handles keep the event loop alive) | Replace `program.parse()` with `parseAsync().then(exit(0)).catch(handleCommandError)` — covers all 36 commands |

Closes #557.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run build` — clean (index.js + cli.js bundle)
- [x] `bun test tests/unit/providers/` — 143/143 pass (includes new helper + factory regression tests)
- [x] `bun test` (full suite) — 11 pre-existing failures (sharp-libvips and Roslyn .NET runtime, neither touched by this PR; baseline `main` shows 35 pre-existing failures, my branch's 11 are a strict subset)
- [x] Manual repro:
  - `bun install` → confirmed `node_modules/@xenova/transformers/node_modules/sharp/build/Release/sharp-win32-x64.node` lands.
  - `bun run dist/cli.js index <repo> -p transformersjs -f` → PDFs no longer in failure list, `embeddingDimensions: 384` recorded in `data/repositories.json`, process exits within seconds of completion.
  - `bun run dist/cli.js search "<query>" -r <repo>` → returns results without dimension-mismatch error, exits cleanly.

## Notes

- New unit tests cover the helpers (`getTransformersJsModelDimensions`, `getOllamaModelDimensions`) and the factory's dimension override path (including the unknown-model fallback case).
- One existing factory test (`passes dimensions through to provider`) was effectively encoding the old buggy behavior; renamed and re-asserted to require the model's true dimension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)