### PR TITLE
fix(#559): make FalkorDB schema migrations actually run

### DIFF
--- a/src/graph/migration/MigrationRunner.ts
+++ b/src/graph/migration/MigrationRunner.ts
@@ -341,6 +341,8 @@ export class MigrationRunner {
       /index .* already exists/i,
       /duplicate/i,
       /equivalent .* already exists/i,
+      // FalkorDB phrasing: "Attribute 'name' is already indexed"
+      /already indexed/i,
     ];
 
     return alreadyExistsPatterns.some((pattern) => pattern.test(errorMessage));
@@ -352,15 +354,23 @@ export class MigrationRunner {
    * @param migration - Migration that was applied
    */
   private async recordMigration(migration: SchemaMigration): Promise<void> {
+    // Store appliedAt as an ISO string from JS rather than a server-side
+    // temporal call (Neo4j has datetime(); FalkorDB rejects it as
+    // "Unknown function 'datetime'"). The read path already normalizes string
+    // values via `new Date(...)`. Note: on Neo4j this means `s.appliedAt` is
+    // now a String property, not a Cypher DateTime — server-side temporal
+    // arithmetic (e.g. `WHERE s.appliedAt > datetime() - duration(...)`) on
+    // this property is no longer valid.
     const cypher = `
       MERGE (s:SchemaVersion {version: $version})
       SET s.description = $description,
-          s.appliedAt = datetime()
+          s.appliedAt = $appliedAt
     `;
 
     await this.client.runQuery(cypher, {
       version: migration.version,
       description: migration.description,
+      appliedAt: new Date().toISOString(),
     });
   }
 

--- a/src/graph/schema/falkordb.ts
+++ b/src/graph/schema/falkordb.ts
@@ -3,13 +3,22 @@
  *
  * FalkorDB schema definitions for the knowledge graph.
  *
- * This module defines the constraints and indexes using OpenCypher syntax
- * compatible with FalkorDB (Redis-based graph database).
+ * FalkorDB's Cypher dialect is restricted compared to Neo4j:
  *
- * Key differences from Neo4j 5.x:
- * - Constraint syntax: ON ... ASSERT ... IS UNIQUE (vs FOR ... REQUIRE ... IS UNIQUE)
- * - NODE KEY not supported - file uniqueness enforced at application level
- * - FULLTEXT indexes not supported - use individual indexes instead
+ * - `CREATE CONSTRAINT ...` is **not supported** as a Cypher statement at all.
+ *   FalkorDB exposes constraints through a Redis-side `GRAPH.CONSTRAINT CREATE`
+ *   command, which also requires a supporting exact-match index. Earlier
+ *   versions of this file emitted Neo4j-flavored `CREATE CONSTRAINT name ON
+ *   (n:L) ASSERT ...` strings; FalkorDB rejects those at parse time and the
+ *   server can drop the connection. We therefore omit constraints from the
+ *   schema and rely on application-level uniqueness, which is already enforced
+ *   by `FalkorDBAdapter.generateNodeId()` + `MERGE` upserts on a deterministic
+ *   `id` property.
+ *
+ * - `CREATE INDEX <name> FOR ...` (named-index form) is also rejected.
+ *   FalkorDB only accepts the unnamed form: `CREATE INDEX FOR (n:L) ON (n.p)`.
+ *
+ * - `FULLTEXT INDEX` is not supported.
  *
  * @see {@link file://./../../../docs/architecture/adr/0002-knowledge-graph-architecture.md} ADR-0002
  */
@@ -17,111 +26,102 @@
 import type { SchemaElement } from "./types.js";
 
 // =============================================================================
-// Constraint Definitions (OpenCypher Syntax for FalkorDB)
+// Constraint Definitions
 // =============================================================================
 
 /**
- * Unique constraints for node types
- *
- * These ensure data integrity by preventing duplicate nodes
- * with the same identifying properties.
- *
- * Uses OpenCypher syntax: ON ... ASSERT ... IS UNIQUE
- *
- * Note: NODE KEY constraints are not supported in FalkorDB.
- * File uniqueness (repository + path) is enforced at the application level
- * using a combined `id` property: "File:{repository}:{path}"
+ * FalkorDB does not accept Cypher `CREATE CONSTRAINT` statements. Uniqueness is
+ * enforced at the application layer through deterministic node IDs and `MERGE`
+ * upserts (see `FalkorDBAdapter.generateNodeId`). The properties that would
+ * otherwise be constrained are still indexed below for query performance.
  */
-export const CONSTRAINTS: readonly SchemaElement[] = [
-  {
-    name: "repo_name",
-    type: "constraint",
-    description: "Ensure repository names are unique",
-    cypher: "CREATE CONSTRAINT repo_name ON (r:Repository) ASSERT r.name IS UNIQUE",
-  },
-  // Note: FalkorDB does not support NODE KEY (composite constraints)
-  // File uniqueness is enforced via the `id` property: "File:{repository}:{path}"
-  {
-    name: "file_id",
-    type: "constraint",
-    description: "Ensure file IDs are unique (composite key workaround)",
-    cypher: "CREATE CONSTRAINT file_id ON (f:File) ASSERT f.id IS UNIQUE",
-  },
-  {
-    name: "chunk_id",
-    type: "constraint",
-    description: "Ensure chunk ChromaDB IDs are unique",
-    cypher: "CREATE CONSTRAINT chunk_id ON (c:Chunk) ASSERT c.chromaId IS UNIQUE",
-  },
-  {
-    name: "concept_name",
-    type: "constraint",
-    description: "Ensure concept names are unique",
-    cypher: "CREATE CONSTRAINT concept_name ON (co:Concept) ASSERT co.name IS UNIQUE",
-  },
-] as const;
+export const CONSTRAINTS: readonly SchemaElement[] = [] as const;
 
 // =============================================================================
 // Index Definitions
 // =============================================================================
 
 /**
- * Performance indexes for common query patterns
+ * Performance indexes for common query patterns.
  *
- * These indexes speed up lookups on frequently queried properties.
- * FalkorDB index syntax is compatible with OpenCypher.
+ * Uses the unnamed FalkorDB Cypher form: `CREATE INDEX FOR (n:Label) ON (n.p)`.
+ * The first four entries cover the properties that Neo4j enforces with unique
+ * constraints; here they're plain indexes (uniqueness is enforced at the app
+ * layer — see the module docstring).
  */
 export const INDEXES: readonly SchemaElement[] = [
+  // Indexes that backstop application-enforced uniqueness
+  {
+    name: "repository_name",
+    type: "index",
+    description: "Index Repository.name (uniqueness enforced at application layer)",
+    cypher: "CREATE INDEX FOR (r:Repository) ON (r.name)",
+  },
+  {
+    name: "file_id",
+    type: "index",
+    description: "Index File.id, the deterministic key 'File:{repository}:{path}'",
+    cypher: "CREATE INDEX FOR (f:File) ON (f.id)",
+  },
+  {
+    name: "chunk_id",
+    type: "index",
+    description: "Index Chunk.chromaId for chunk lookups",
+    cypher: "CREATE INDEX FOR (c:Chunk) ON (c.chromaId)",
+  },
+  {
+    name: "concept_name",
+    type: "index",
+    description: "Index Concept.name (uniqueness enforced at application layer)",
+    cypher: "CREATE INDEX FOR (co:Concept) ON (co.name)",
+  },
+  // Performance indexes
   {
     name: "file_extension",
     type: "index",
     description: "Index for filtering files by extension",
-    cypher: "CREATE INDEX file_extension FOR (f:File) ON (f.extension)",
+    cypher: "CREATE INDEX FOR (f:File) ON (f.extension)",
   },
   {
     name: "function_name",
     type: "index",
     description: "Index for looking up functions by name",
-    cypher: "CREATE INDEX function_name FOR (fn:Function) ON (fn.name)",
+    cypher: "CREATE INDEX FOR (fn:Function) ON (fn.name)",
   },
   {
     name: "class_name",
     type: "index",
     description: "Index for looking up classes by name",
-    cypher: "CREATE INDEX class_name FOR (c:Class) ON (c.name)",
+    cypher: "CREATE INDEX FOR (c:Class) ON (c.name)",
   },
   {
     name: "module_name",
     type: "index",
     description: "Index for looking up modules by name",
-    cypher: "CREATE INDEX module_name FOR (m:Module) ON (m.name)",
+    cypher: "CREATE INDEX FOR (m:Module) ON (m.name)",
   },
-  // Additional indexes to compensate for lack of fulltext search
   {
     name: "file_repository",
     type: "index",
     description: "Index for filtering files by repository",
-    cypher: "CREATE INDEX file_repository FOR (f:File) ON (f.repository)",
+    cypher: "CREATE INDEX FOR (f:File) ON (f.repository)",
   },
   {
     name: "function_repository",
     type: "index",
     description: "Index for filtering functions by repository",
-    cypher: "CREATE INDEX function_repository FOR (fn:Function) ON (fn.repository)",
+    cypher: "CREATE INDEX FOR (fn:Function) ON (fn.repository)",
   },
   {
     name: "class_repository",
     type: "index",
     description: "Index for filtering classes by repository",
-    cypher: "CREATE INDEX class_repository FOR (c:Class) ON (c.repository)",
+    cypher: "CREATE INDEX FOR (c:Class) ON (c.repository)",
   },
 ] as const;
 
 /**
- * Full-text indexes for semantic search across entities
- *
  * FalkorDB does not support full-text indexes.
- * This array is empty - use regular indexes for basic filtering.
  */
 export const FULLTEXT_INDEXES: readonly SchemaElement[] = [] as const;
 
@@ -129,9 +129,6 @@ export const FULLTEXT_INDEXES: readonly SchemaElement[] = [] as const;
 // Combined Schema
 // =============================================================================
 
-/**
- * All schema elements combined for iteration
- */
 export const ALL_SCHEMA_ELEMENTS: readonly SchemaElement[] = [
   ...CONSTRAINTS,
   ...INDEXES,

--- a/tests/unit/graph/migration/MigrationRunner.test.ts
+++ b/tests/unit/graph/migration/MigrationRunner.test.ts
@@ -464,9 +464,13 @@ describe("MigrationRunner", () => {
       // Regression guard: appliedAt must be passed as a JS-side ISO string
       // parameter, not derived from a server-side datetime() call (FalkorDB
       // rejects datetime() as "Unknown function"). See MigrationRunner.recordMigration.
+      // The ISO_8601 regex pins the exact toISOString() shape so a future
+      // refactor that swaps to Date.toString() (also parseable by `new Date()`)
+      // would still fail the assertion.
+      const ISO_8601_UTC = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
       for (const recorded of recordedMigrations) {
         expect(typeof recorded.appliedAt).toBe("string");
-        expect(() => new Date(recorded.appliedAt as string)).not.toThrow();
+        expect(recorded.appliedAt as string).toMatch(ISO_8601_UTC);
         expect(Number.isNaN(new Date(recorded.appliedAt as string).getTime())).toBe(false);
         expect(recorded.cypher).toContain("$appliedAt");
         expect(recorded.cypher).not.toContain("datetime()");

--- a/tests/unit/graph/migration/MigrationRunner.test.ts
+++ b/tests/unit/graph/migration/MigrationRunner.test.ts
@@ -425,7 +425,12 @@ describe("MigrationRunner", () => {
     });
 
     test("should record applied migrations in Neo4j", async () => {
-      const recordedMigrations: Array<{ version: string; description: string }> = [];
+      const recordedMigrations: Array<{
+        version: string;
+        description: string;
+        appliedAt: unknown;
+        cypher: string;
+      }> = [];
       const client = {
         ...createMockClient({ appliedVersions: [] }),
         runQuery: async <T>(cypher: string, params?: Record<string, unknown>): Promise<T[]> => {
@@ -433,6 +438,8 @@ describe("MigrationRunner", () => {
             recordedMigrations.push({
               version: params?.["version"] as string,
               description: params?.["description"] as string,
+              appliedAt: params?.["appliedAt"],
+              cypher,
             });
           }
           if (cypher.includes("SchemaVersion") && cypher.includes("MATCH")) {
@@ -449,8 +456,21 @@ describe("MigrationRunner", () => {
       await runner.migrate();
 
       expect(recordedMigrations).toHaveLength(2);
-      expect(recordedMigrations[0]).toEqual({ version: "1.0.0", description: "Initial schema" });
-      expect(recordedMigrations[1]).toEqual({ version: "1.1.0", description: "Add index" });
+      expect(recordedMigrations[0]!.version).toBe("1.0.0");
+      expect(recordedMigrations[0]!.description).toBe("Initial schema");
+      expect(recordedMigrations[1]!.version).toBe("1.1.0");
+      expect(recordedMigrations[1]!.description).toBe("Add index");
+
+      // Regression guard: appliedAt must be passed as a JS-side ISO string
+      // parameter, not derived from a server-side datetime() call (FalkorDB
+      // rejects datetime() as "Unknown function"). See MigrationRunner.recordMigration.
+      for (const recorded of recordedMigrations) {
+        expect(typeof recorded.appliedAt).toBe("string");
+        expect(() => new Date(recorded.appliedAt as string)).not.toThrow();
+        expect(Number.isNaN(new Date(recorded.appliedAt as string).getTime())).toBe(false);
+        expect(recorded.cypher).toContain("$appliedAt");
+        expect(recorded.cypher).not.toContain("datetime()");
+      }
     });
 
     test("should execute all statements in a migration", async () => {

--- a/tests/unit/graph/migration/schema.test.ts
+++ b/tests/unit/graph/migration/schema.test.ts
@@ -307,30 +307,38 @@ describe("Adapter-Aware Schema Functions", () => {
 
     test("should return FalkorDB schema for falkordb adapter", () => {
       const schema = getSchemaForAdapter("falkordb");
-      expect(schema.constraints.length).toBe(4); // repo_name, file_id, chunk_id, concept_name
-      expect(schema.indexes.length).toBe(7); // file_extension, function_name, class_name, module_name + 3 repository indexes
 
-      // FalkorDB uses ASSERT syntax (OpenCypher)
-      for (const constraint of schema.constraints) {
-        expect(constraint.cypher).toContain("ASSERT");
-        expect(constraint.cypher).not.toContain("REQUIRE");
+      // FalkorDB does not accept Cypher CREATE CONSTRAINT statements; uniqueness
+      // is enforced at the application layer via deterministic node IDs.
+      expect(schema.constraints.length).toBe(0);
+
+      // 4 backstop indexes for what would have been constraints +
+      // 7 performance indexes (file_extension, function/class/module name,
+      // file/function/class repository).
+      expect(schema.indexes.length).toBe(11);
+
+      // FalkorDB only accepts the unnamed Cypher index form.
+      for (const index of schema.indexes) {
+        expect(index.cypher).toMatch(/^CREATE INDEX FOR \(/);
       }
 
       // FalkorDB doesn't support fulltext indexes
       expect(schema.fulltextIndexes.length).toBe(0);
     });
 
-    test("FalkorDB should not have NODE KEY constraint", () => {
+    test("FalkorDB should backstop former unique constraints with indexes", () => {
       const schema = getSchemaForAdapter("falkordb");
 
-      // FalkorDB uses file_id instead of file_path NODE KEY
-      const fileConstraint = schema.constraints.find((c) => c.name === "file_id");
-      expect(fileConstraint).toBeDefined();
-      expect(fileConstraint?.cypher).not.toContain("IS NODE KEY");
+      // The properties Neo4j enforces with unique constraints are exposed as
+      // plain indexes on the FalkorDB adapter (uniqueness is application-level).
+      const expectedIndexNames = ["repository_name", "file_id", "chunk_id", "concept_name"];
+      for (const name of expectedIndexNames) {
+        expect(schema.indexes.find((i) => i.name === name)).toBeDefined();
+      }
 
-      // Verify no NODE KEY constraints exist
-      for (const constraint of schema.constraints) {
-        expect(constraint.cypher).not.toContain("IS NODE KEY");
+      // No NODE KEY (FalkorDB doesn't support composite uniqueness via Cypher).
+      for (const index of schema.indexes) {
+        expect(index.cypher).not.toContain("IS NODE KEY");
       }
     });
 
@@ -371,10 +379,13 @@ describe("Adapter-Aware Schema Functions", () => {
     test("should return FalkorDB schema elements for falkordb adapter", () => {
       const elements = getAllSchemaElements("falkordb");
 
-      // Should have constraints with ASSERT syntax
+      // FalkorDB does not accept Cypher CREATE CONSTRAINT statements.
       const constraints = elements.filter((e) => e.type === "constraint");
-      for (const constraint of constraints) {
-        expect(constraint.cypher).toContain("ASSERT");
+      expect(constraints.length).toBe(0);
+
+      // All emitted elements should be valid FalkorDB Cypher index statements.
+      for (const element of elements) {
+        expect(element.cypher).toMatch(/^CREATE INDEX FOR \(/);
       }
 
       // Should not have fulltext indexes
@@ -387,11 +398,13 @@ describe("Adapter-Aware Schema Functions", () => {
     test("should return FalkorDB-compatible Cypher when adapter is falkordb", () => {
       const statements = getAllSchemaStatements("falkordb");
 
-      // All statements should use ASSERT (OpenCypher) not REQUIRE (Neo4j)
+      // FalkorDB does not accept CREATE CONSTRAINT or named CREATE INDEX.
       const constraintStatements = statements.filter((s) => s.startsWith("CREATE CONSTRAINT"));
-      for (const statement of constraintStatements) {
-        expect(statement).toContain("ASSERT");
-        expect(statement).not.toContain("REQUIRE");
+      expect(constraintStatements.length).toBe(0);
+
+      for (const statement of statements) {
+        // All statements must be the unnamed FalkorDB index form.
+        expect(statement).toMatch(/^CREATE INDEX FOR \(/);
       }
 
       // Should not have fulltext index statements


### PR DESCRIPTION
## Summary

Fixes #559. Makes `bun run cli graph migrate` actually succeed on a fresh FalkorDB install. Three FalkorDB Cypher-dialect bugs in the migration path are addressed plus an idempotency fix.

Follow-up to #450, which moved constraints to `ASSERT ... IS UNIQUE` syntax but didn't address that FalkorDB rejects Cypher `CREATE CONSTRAINT` in any form.

## Changes

| File | What changed |
|------|--------------|
| `src/graph/schema/falkordb.ts` | `CONSTRAINTS = []` (FalkorDB rejects Cypher `CREATE CONSTRAINT`); 11 indexes converted to unnamed form `CREATE INDEX FOR (n:L) ON (n.p)`; the four formerly-constrained properties (`Repository.name`, `File.id`, `Chunk.chromaId`, `Concept.name`) added as plain indexes; module docstring rewritten to explain the FalkorDB dialect restrictions. |
| `src/graph/migration/MigrationRunner.ts` | `recordMigration` now passes `appliedAt` as an ISO-string parameter rather than calling `datetime()` server-side; `isAlreadyExistsError` regex list extended with `/already indexed/i` so reruns are idempotent under FalkorDB's "Attribute 'name' is already indexed" phrasing. |
| `tests/unit/graph/migration/schema.test.ts` | FalkorDB-specific assertions updated — 0 constraints, 11 indexes, every cypher matches `^CREATE INDEX FOR \(`. |
| `tests/unit/graph/migration/MigrationRunner.test.ts` | New regression guards: assert `recordMigration` passes `appliedAt` as an ISO string parameter and that the cypher contains `$appliedAt` and not `datetime()`. |

Application-layer uniqueness is unaffected: `FalkorDBAdapter.generateNodeId()` produces deterministic IDs (e.g. `Repository:{name}`, `File:{repository}:{path}`) and every `upsertNode` call goes through `MERGE (n:Label {id: ...})`. Native FalkorDB `GRAPH.CONSTRAINT CREATE` enforcement is deferred — it requires a `SchemaElement` discriminated union and a new method on `GraphStorageAdapter`, which is a larger refactor not needed for migrations to work.

## Behavior change on Neo4j

`SchemaVersion.appliedAt` is now stored as a `String` property on Neo4j (was a Cypher `DateTime`). The read path already normalized both via `instanceof Date ? r.appliedAt : new Date(r.appliedAt)`, so consumers are unaffected. Server-side temporal arithmetic on `appliedAt` (e.g. `WHERE s.appliedAt > datetime() - duration(...)`) is no longer valid — confirmed via grep that nothing in the codebase currently does this.

## Pre-PR review

Independent pre-PR review by `master-code-reviewer` flagged one Medium finding (no test asserted the new `$appliedAt` parameter shape, so the bug could regress silently) and one Low finding (Neo4j read path safe but undertested for the type change). Both addressed in this PR before push:

- Medium: added regression guards in `MigrationRunner.test.ts` capturing `appliedAt` and the cypher string, asserting `typeof` is `"string"`, that `new Date(...)` parses, and that the cypher contains `$appliedAt` and not `datetime()`.
- Low: extended the `recordMigration` comment to flag that on Neo4j `appliedAt` is now a `String` property, with explicit mention that server-side temporal arithmetic on the property is no longer valid.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build` clean (1916 modules / 7.16 MB index, 1627 / 5.69 MB cli)
- [x] `bun test tests/unit/graph tests/unit/migration tests/isolated/graph-migrate-command.test.ts` — 723 pass / 1 unrelated pre-existing flake (`RoslynParser > (unnamed)` hook timeout, reproduced identically on `main`)
- [x] `bun test tests/unit/graph/migration/MigrationRunner.test.ts tests/unit/graph/migration/schema.test.ts` — 67 pass, 0 fail (regression guard for new `$appliedAt` path included)
- [ ] `bun run cli graph migrate` end-to-end on a fresh `docker compose --profile default up -d` FalkorDB — covered by reviewer's independent verification per `falkor-fix/falkordb-migration-fix/CHANGES.md` (1.0.0 applied, idempotent rerun, 11 OPERATIONAL indexes, `SchemaVersion.appliedAt` populated). Worth re-running on the reviewer's environment as well.
- [ ] Verify no regression on Neo4j environments — read path covered by existing tests; write path (string vs DateTime) not exercised by an integration test in this PR.

## Co-authors

Original patch authored by Tristan Parker (with Claude Opus 4.7), staged in the working tree at `falkor-fix/falkordb-migration-fix/` before this branch was opened. Pre-PR review and the two follow-up fixes (regression guard test + Neo4j storage-type comment) by Claude Opus 4.7 (1M context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
