### PR TITLE
docs: PRD + implementation plan for local folder as repository

### DIFF
--- a/docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md
+++ b/docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md
@@ -1,0 +1,512 @@
+# Implementation Plan: Local Folder as First-Class Repository
+
+**Status:** Approved for implementation
+**Date:** 2026-05-04
+**Owner:** Architecture
+**Related PRD:** `docs/pm/Phase6-Document-Ingestion-PRD.md` (Phase 6 — parallel WatchedFolder concept)
+**Related ADR (to author):** `docs/architecture/adr/0007-local-folder-as-repository.md`
+
+---
+
+## 1. Architecture Summary
+
+### 1.1 The flow, in words
+
+```
+                                         +------------------------------+
+                                         | RepositoryInfo (registry)    |
+                                         | source: "git-remote" |       |
+                                         |         "local-git"  |       |
+                                         |         "local-folder"       |
+                                         +---------------+--------------+
+                                                         |
+   cli index <path>  ---+                                |
+   MCP register tool ---+--> IngestionService -----------+
+                              (existing, branches on isLocalPath today)
+                                  |
+                                  | for "local-folder":
+                                  |   - skip clone
+                                  |   - skip git revparse
+                                  |   - build initial FileManifest
+                                  v
+                          FileScanner (+ .gitignore filter)
+                                  |
+                                  v
+                  +---- FileChunker / DocumentChunker (existing) ----+
+                  |                                                  |
+                  v                                                  v
+            ChromaDB (repo_<name> collection)                  GraphIngestionService
+                                                                     |
+                                                                     v
+                                                +--- CodeEntityExtractor (existing, AST)
+                                                |
+                                                +--- DocEntityExtractor (NEW)
+                                                       - Document, Section, ExternalLink nodes
+                                                       - LINKS_TO, MENTIONS edges
+
+   Subsequent updates (manual or watcher-driven):
+
+   FolderEventRouter (NEW shared)
+        |  routes by folder ID lookup:
+        |    - WatchedFolder ID  -> FolderDocumentIndexingService (Phase 6, unchanged)
+        |    - RepositoryInfo where source="local-folder" -> LocalFolderUpdateCoordinator (NEW)
+        v
+   LocalFolderChangeDetector (NEW)
+        - walks tree under repo.localPath
+        - reads FileManifest (per-file hash/mtime/size)
+        - emits FileChange[] (added/modified/deleted/renamed)
+        v
+   IncrementalUpdatePipeline.processChanges (existing) --> Chroma + Graph delta updates
+```
+
+### 1.2 Where the new pieces sit
+
+| Concern | New component | Lives in |
+|---|---|---|
+| Per-file content fingerprint store | `FileManifestStore` | `src/services/file-manifest-store.ts` |
+| Non-git change detection | `LocalFolderChangeDetector` | `src/services/local-folder-change-detector.ts` |
+| Update orchestration for `local-folder` repos | `LocalFolderUpdateCoordinator` | `src/services/local-folder-update-coordinator.ts` |
+| Routing watcher events to either WatchedFolder or local-folder-repo | `FolderEventRouter` | `src/services/folder-event-router.ts` |
+| Markdown/doc graph extraction | `DocEntityExtractor` | `src/graph/extraction/DocEntityExtractor.ts` |
+| `.gitignore` honoring during scan | `GitignoreFilter` (wraps `ignore` npm package) | `src/ingestion/gitignore-filter.ts` |
+| MCP tool to register a folder | `register_local_folder` | `src/mcp/tools/register-local-folder.ts` |
+
+### 1.3 What does NOT change
+
+- ChromaDB collection naming (`repo_<sanitized_name>` for repos, `folder_<id>` for Phase 6 WatchedFolders — kept distinct).
+- The `IncrementalUpdatePipeline.processChanges()` contract — it already accepts `FileChange[]` and doesn't care how the diff was produced.
+- All graph MCP tools (`get_dependencies`, `get_dependents`, `get_architecture`, `find_path`, `get_graph_metrics`).
+- All search MCP tools (`semantic_search`, `search_documents`, `search_images`).
+- Phase 6 `WatchedFolder` and `FolderDocumentIndexingService` — left intact, no migration.
+
+---
+
+## 2. Component-by-Component Task Breakdown
+
+Tasks are grouped by PR (each targeting <400 LoC of diff per CLAUDE.md). Sizes: S ≤ 100 LoC, M ≤ 300, L ≤ 500, XL > 500 (must be split).
+
+### PR 1 — Data model + manifest plumbing (foundation)
+
+- [ ] **T1.1** Add `RepositoryInfo.source` discriminator. **(S, modify)**
+  - File: `src/repositories/types.ts`
+  - Add `source: "git-remote" | "local-git" | "local-folder"` (default `"git-remote"` on read for back-compat).
+  - Make `url` optional (`string | null`) when `source === "local-folder"`.
+  - Add `tier?: "private" | "work" | "public"` (default `"private"`; refused as `"public"` for local folders at registration).
+  - Add `lastManifestId?: string` pointer to manifest file.
+  - Acceptance: existing tests pass with default `source = "git-remote"` injected on read.
+- [ ] **T1.2** Migrate `metadata-store.ts` to handle the new field. **(S, modify)**
+  - File: `src/repositories/metadata-store.ts`
+  - Read path: synthesize `source: "git-remote"` if missing.
+  - Write path: persist new fields.
+  - Acceptance: round-trip test of all three source values.
+- [ ] **T1.3** Relax `UpdateHistoryEntry` schema for non-git repos. **(S, modify)**
+  - File: `src/repositories/types.ts`
+  - Make `previousCommit` and `newCommit` accept synthetic markers `local-<isoDate>` (string, not enforced 40-hex). Document semantics.
+  - Acceptance: unit test asserts both 40-hex and `local-...` markers are accepted.
+- [ ] **T1.4** Add `FileManifestStore`. **(M, new)**
+  - File: `src/services/file-manifest-store.ts`
+  - Pattern: same singleton + atomic-write as `watched-folder-store.ts`.
+  - Storage: `{DATA_PATH}/manifests/<repo-name>.json` (one file per repo).
+  - Schema: `{ version, repository, generatedAt, files: { [relPath]: { sha256, sizeBytes, mtimeMs } } }`.
+  - Operations: `loadManifest(repo)`, `saveManifest(repo, manifest)`, `deleteManifest(repo)`.
+  - Acceptance: 100% line coverage; concurrent-write serialization test.
+
+### PR 2 — Local-folder ingestion path (initial scan)
+
+- [ ] **T2.1** Extend `IngestionService` to accept `source` and skip git-revparse for non-git folders. **(S, modify)**
+  - File: `src/services/ingestion-service.ts` (lines ~244–295)
+  - Detect: if `isLocalPath(url)` AND no `.git` directory present, set `source = "local-folder"`, leave `commitSha` undefined, do not call `git revparse`.
+  - If `.git` present, set `source = "local-git"`, behave as today.
+  - Acceptance: integration test indexes a non-git folder end-to-end.
+- [ ] **T2.2** Build initial manifest after first scan. **(S, modify)**
+  - File: `src/services/ingestion-service.ts`
+  - After file scan completes for a `local-folder` repo, compute `(sha256, size, mtime)` per file and persist via `FileManifestStore.saveManifest`.
+  - Acceptance: manifest file written; size matches scanned file count.
+- [ ] **T2.3** Implement `GitignoreFilter`. **(S, new)**
+  - File: `src/ingestion/gitignore-filter.ts`
+  - Dependency: `ignore` npm package (MIT-licensed, well-maintained).
+  - Walks up from each candidate file looking for `.gitignore` files; merges rules.
+  - Acceptance: unit tests for nested `.gitignore`, negation rules (`!keep.txt`), and absence of any `.gitignore`.
+- [ ] **T2.4** Wire `GitignoreFilter` into `FileScanner`. **(S, modify)**
+  - File: `src/ingestion/file-scanner.ts`
+  - Apply filter only when scanning a `local-folder` or `local-git` source. Git-remote shallow clones don't need it (the remote already excludes ignored files; honoring `.gitignore` on a shallow clone is still safe but redundant).
+  - Acceptance: integration test with a folder containing `.gitignore` excluding `node_modules/`.
+- [ ] **T2.5** Size guardrails at registration. **(S, modify)**
+  - File: `src/services/ingestion-service.ts`
+  - Pre-scan pass: count files and sum bytes (after `.gitignore` filter, before chunking).
+  - Soft warn at 10K files OR 1 GiB; hard refuse at 100K files OR 10 GiB unless `--force` is set.
+  - Acceptance: unit tests for each threshold (warn, refuse, refuse+force).
+- [ ] **T2.6** Refuse `tier = "public"` for `local-folder`. **(S, modify)**
+  - File: `src/services/ingestion-service.ts`
+  - Throw `LocalFolderPublicTierRefusedError` (new error class).
+  - Acceptance: unit test confirms refusal; tier can be set to `private` or `work`.
+
+### PR 3 — Local-folder change detection + incremental update
+
+- [ ] **T3.1** Implement `LocalFolderChangeDetector`. **(M, new)**
+  - File: `src/services/local-folder-change-detector.ts`
+  - Algorithm: walk tree (respecting `.gitignore`, include extensions, symlink rules), build current `FileSnapshot[]`. Diff against stored manifest:
+    - In current and not in manifest -> `added`
+    - In manifest and not in current -> `deleted`
+    - In both, `(size, mtimeMs)` differ -> compute sha256; if hash also differs -> `modified`; if hash same (touch with no content change) -> skip
+    - In both, `(size, mtimeMs)` match -> skip (fast path, no hash)
+  - No rename detection in v1 (delete + add). Document this.
+  - Output: `FileChange[]` matching the existing pipeline contract.
+  - Acceptance: unit tests for added, modified-content, modified-mtime-only, deleted, large-tree (1K files) under 200 ms.
+- [ ] **T3.2** Implement `LocalFolderUpdateCoordinator`. **(M, new)**
+  - File: `src/services/local-folder-update-coordinator.ts`
+  - Mirrors `IncrementalUpdateCoordinator` but for `local-folder` repos:
+    1. Load `RepositoryInfo`, validate `source === "local-folder"` and `localPath` still exists.
+    2. If `localPath` missing -> return `drift_detected` (re-using existing status).
+    3. Run `LocalFolderChangeDetector` to produce `FileChange[]`.
+    4. Pass to `IncrementalUpdatePipeline.processChanges` (unchanged).
+    5. On success, update `FileManifestStore` with new snapshot + write `UpdateHistoryEntry` with `previousCommit = "local-<isoDate-prev>"`, `newCommit = "local-<isoDate-now>"`.
+  - Acceptance: integration test: register folder, modify a file, run update, confirm chunks updated and graph nodes updated.
+- [ ] **T3.3** Wire `trigger_incremental_update` MCP tool to dispatch by source. **(S, modify)**
+  - File: `src/mcp/tools/trigger-incremental-update.ts`
+  - Branch on `repo.source`: `git-remote`/`local-git` -> existing `IncrementalUpdateCoordinator`; `local-folder` -> `LocalFolderUpdateCoordinator`.
+  - Acceptance: tool works for both source types; existing tests still pass.
+- [ ] **T3.4** Update `list_indexed_repositories` output. **(S, modify)**
+  - File: `src/mcp/tools/list-indexed-repositories.ts`
+  - Add `source` and `localPath` (absolute) fields to response payload.
+  - Acceptance: contract test confirms new fields present; existing fields unchanged.
+
+### PR 4 — CLI and MCP registration surface
+
+- [ ] **T4.1** Auto-detect non-git folders in existing `cli index <path>`. **(S, modify)**
+  - File: `src/cli/commands/index-command.ts`
+  - If `isLocalPath(arg)` and no `.git` directory -> register as `local-folder` (no separate `index-folder` verb).
+  - Add flags: `--name <n>`, `--tier private|work`, `--force`, `--watch`, `--follow-symlinks`.
+  - Acceptance: CLI test indexes a non-git folder end-to-end.
+- [ ] **T4.2** Reject duplicate-name registrations. **(S, modify)**
+  - File: `src/services/ingestion-service.ts`
+  - Existing `RepositoryAlreadyExistsError` already handles this, but also check for path duplication: same absolute `localPath` registered under a different name should be rejected with a clear error pointing to the existing name.
+  - Acceptance: unit test for both name collision and path collision.
+- [ ] **T4.3** New MCP tool `register_local_folder`. **(M, new)**
+  - File: `src/mcp/tools/register-local-folder.ts`
+  - Parameters: `{ path: string, name?: string, tier?: "private"|"work", watch?: boolean, force?: boolean, followSymlinks?: boolean }`.
+  - Returns: job ID for async progress tracking (reuses Phase 6 `JobTracker`).
+  - Acceptance: contract test + integration test against running MCP server.
+- [ ] **T4.4** Register `register_local_folder` in tool index. **(S, modify)**
+  - File: `src/mcp/tools/index.ts`, `src/mcp/server.ts`
+  - Acceptance: tool appears in `tools/list` MCP response.
+
+### PR 5 — Watcher and FolderEventRouter
+
+- [ ] **T5.1** Extract a shared `FolderEventRouter`. **(M, new)**
+  - File: `src/services/folder-event-router.ts`
+  - On chokidar event `(folderId, eventType, absolutePath)`:
+    - Look up `folderId` in `WatchedFolderStore` -> route to `FolderDocumentIndexingService` (Phase 6, unchanged behavior).
+    - Else look up by `localPath` in `RepositoryMetadataStore` where `source === "local-folder"` -> debounce + enqueue an incremental update via `LocalFolderUpdateCoordinator`.
+  - Debounce per repo (default 2000 ms, configurable per repo).
+  - Acceptance: unit test confirms router dispatches to correct backend; integration test confirms file edit -> chunks updated within debounce window + processing time.
+- [ ] **T5.2** Make `FolderWatcherService` consume the router. **(S, modify)**
+  - File: `src/services/folder-watcher-service.ts`
+  - Replace direct call to `FolderDocumentIndexingService` with `FolderEventRouter.route(...)`.
+  - Acceptance: existing Phase 6 watcher tests still pass.
+- [ ] **T5.3** Watch lifecycle for local-folder repos. **(M, new)**
+  - File: `src/services/local-folder-update-coordinator.ts`
+  - Add `startWatching(repo)` / `stopWatching(repo)` that call into chokidar via the existing watcher service. Persist `watchEnabled: boolean` on `RepositoryInfo`.
+  - On MCP server startup, restart watchers for all `local-folder` repos with `watchEnabled === true`.
+  - Acceptance: integration test confirms watcher restarts after server reboot.
+- [ ] **T5.4** Symlink policy. **(S, modify)**
+  - File: `src/ingestion/file-scanner.ts`
+  - Default: do not follow symlinks. With `--follow-symlinks`, follow but cap depth at 8 and reject any symlink target outside the repo root unless target is also inside the repo root (TOCTOU-aware: stat after resolve).
+  - Acceptance: unit test confirms a symlink to `/etc` is skipped by default; opt-in flag works for in-repo symlinks.
+
+### PR 6 — Document graph extraction (Markdown)
+
+**Note on doc-graph scope**: v1 ships markdown-graph at full fidelity (PR 6) and PDF/DOCX-graph at lower fidelity (PR 6b, immediately following). The markdown extractor and the PDF/DOCX extractor share the `Document` node schema introduced in T6.1 but are independent extractors with different input shapes and different MENTIONS confidence levels.
+
+- [ ] **T6.1** Schema additions for doc-graph. **(S, modify)**
+  - File: `src/graph/schema/falkordb.ts` (and `neo4j.ts` if dual-stack is still maintained)
+  - New node labels: `Document`, `Section`, `ExternalLink`.
+  - New indexes: `Document.id`, `Document.repository`, `Section.documentId`.
+  - New edges: `LINKS_TO` (Document -> Document or Document -> ExternalLink), `MENTIONS` (Document -> Function|Class|Module), `HAS_SECTION` (Document -> Section), `CONTAINS_SECTION` (Section -> Section, for nesting).
+  - Acceptance: migration runs cleanly on a fresh FalkorDB; idempotent on existing.
+- [ ] **T6.2** New `DocEntityExtractor`. **(M, new)**
+  - File: `src/graph/extraction/DocEntityExtractor.ts`
+  - Reuses `MarkdownParser` (already extracts sections + frontmatter via `marked`). **Decoupling constraint: this extractor takes a parsed document AST + repo context as input. It MUST NOT depend on `RepositoryInfo.source` or any local-folder-specific type, so a future PR can wire it into `FolderDocumentIndexingService` for retroactive Phase 6 `WatchedFolder` doc-graph coverage with a minimal change.**
+  - Extracts:
+    - `Document` node (one per markdown file): `{ id, repository, path, title (from frontmatter or H1), wordCount }`.
+    - `Section` nodes (one per heading): `{ id, documentId, level, title, anchor, startOffset, endOffset }` plus parent-child `CONTAINS_SECTION` edges based on heading nesting. **Section nodes are internal-only in v1 — they are not surfaced through `get_architecture` or any other MCP tool. They are queryable only via direct graph queries and via `find_path`.**
+    - Outbound markdown links (`[text](path)`): if `path` resolves to a file in the same repo -> `LINKS_TO Document`; else create/reuse `ExternalLink` node.
+    - Wikilinks (`[[Page]]`): resolved with **strict precedence order, first match wins**: (1) exact `Document.title` match in same repo; (2) path-stem match in same repo (basename without extension); (3) `Section.anchor` match in same repo; (4) `Function`/`Class`/`Module` name match in same repo. Subsequent matches logged at debug level.
+    - Inline code-symbol mentions: tokenize fenced code blocks and inline-code spans; extract identifiers matching the existing `Function`/`Class` table for the same repo (case-sensitive exact match, scoped to the repo). Emit `MENTIONS` edges. Cross-repo resolution is explicitly out of scope for v1 (see Deferred Features). **Resolution is best-effort and lossy by design** — see risk register.
+  - Acceptance: unit test fixtures cover frontmatter title, nested headings, relative links, wikilinks (with all four precedence tiers exercised in order), code-symbol mentions; bench on a 500-file Obsidian-style vault stays under 30 s total. Wikilink test must explicitly assert that when the same name exists at multiple precedence tiers, the higher-tier match wins.
+- [ ] **T6.3** Wire `DocEntityExtractor` into `GraphIngestionService`. **(M, modify)**
+  - File: `src/graph/ingestion/GraphIngestionService.ts`
+  - Add a parallel pipeline branch: if file extension is `.md` (and later `.pdf`/`.docx`), run `DocEntityExtractor` instead of `EntityExtractor`/`RelationshipExtractor`.
+  - File-deletion path must also remove `Document`/`Section`/`ExternalLink` nodes for that file.
+  - Acceptance: integration test indexes a markdown file, asserts `Document` and `Section` nodes appear; deletion test confirms cleanup.
+- [ ] **T6.4** Two-pass MENTIONS resolution. **(M, new)**
+  - The mention-resolution step needs the code-graph to already exist for the same repo. Solution: run `DocEntityExtractor` in a second pass after code extraction completes (per repo, per ingestion run). Re-resolve mentions on every incremental update where either the doc OR the referenced symbol changed.
+  - Acceptance: edit a markdown doc to mention `AuthService`; run update; confirm `MENTIONS` edge created. Delete `AuthService` class; confirm orphaned `MENTIONS` edge removed on next update.
+- [ ] **T6.5** Shared-parse refactor for `MarkdownParser`. **(S, modify)**
+  - File: `src/documents/extractors/MarkdownParser.ts`, `src/services/ingestion-service.ts`
+  - Expose the parsed token stream / AST so the chunker AND `DocEntityExtractor` consume one parse per file.
+  - **Hard user constraint: the entire document MUST remain indexed. This refactor MUST NOT cause any part of a document to be omitted from semantic search coverage.**
+  - Acceptance criteria (all required):
+    1. **Coverage invariant**: every byte and every heading-bounded section of the source document is represented by ≥1 semantic chunk after refactor. Specifically: the union of all chunk character-ranges, after normalizing whitespace per the chunker's existing rules, must equal the full source-file character range. No section heading and no body paragraph may be missing from the chunk set.
+    2. Sum of chunk char-ranges (post-normalization) equals total normalized file length.
+    3. Existing `tests/integration/documents/document-chunking-pipeline.integration.test.ts` continues to pass without modification.
+    4. New regression test (see T7.1): markdown corpus indexed, chunk coverage verified byte-complete.
+
+### PR 6b — PDF/DOCX graph extraction (v1 scope, lower fidelity than markdown)
+
+- [ ] **T6b.1** New `PdfDocxEntityExtractor`. **(M, new)**
+  - File: `src/graph/extraction/PdfDocxEntityExtractor.ts`
+  - Same decoupling constraint as `DocEntityExtractor`: takes parsed-document input + repo context, no local-folder-specific dependencies, so it can be retroactively wired into `FolderDocumentIndexingService` later.
+  - Reuses existing `PdfExtractor` and `DocxExtractor` (already produce text + page/section info).
+  - Minimum viable extraction:
+    - `Document` node (one per PDF/DOCX file): `{ id, repository, path, title (from document metadata or filename fallback), wordCount, format: "pdf" | "docx", pageCount }`.
+    - **No `Section` hierarchy** unless the source provides a trivially extractable outline:
+      - DOCX: use heading styles (`Heading 1`, `Heading 2`, ...) when present in the docx style map.
+      - PDF: use the document outline / bookmarks when present in the PDF metadata. If absent, no `Section` nodes are created — the `Document` node stands alone.
+    - **Outbound code-symbol mentions only.** Run a regex/heuristic pass over the extracted plain text matching identifier-shaped tokens (`/[A-Z][A-Za-z0-9_]{2,}|[a-z][A-Za-z0-9_]{2,}\(/`) against the existing `Function`/`Class`/`Module` table for the same repo (case-sensitive, exact match, intra-repo only). Emit `MENTIONS` edges.
+    - **No `LINKS_TO` edges** in v1 — PDF hyperlinks and DOCX hyperlinks are not extracted. Defer to v2.
+    - All `MENTIONS` edges from PDF/DOCX carry a property `confidence: "low"` (vs `"high"` for markdown code-fence mentions). This lets users filter out noisy mentions in queries (e.g., `WHERE m.confidence = "high"`).
+  - Acceptance: unit test fixtures (use existing `tests/fixtures/documents/`) cover a PDF with outline, a PDF without outline, a DOCX with heading styles, a DOCX without; mention-resolution test against a known symbol table; confidence attribute present on every PDF/DOCX-sourced `MENTIONS` edge.
+- [ ] **T6b.2** Wire `PdfDocxEntityExtractor` into `GraphIngestionService`. **(S, modify)**
+  - File: `src/graph/ingestion/GraphIngestionService.ts`
+  - Branch on file extension: `.md` -> `DocEntityExtractor`; `.pdf`/`.docx` -> `PdfDocxEntityExtractor`; code extensions -> existing extractors. File-deletion path must remove `Document` and `MENTIONS` edges for that file.
+  - Acceptance: integration test ingests a PDF and a DOCX, asserts `Document` nodes appear and `MENTIONS` edges have `confidence: "low"`; deletion removes both.
+- [ ] **T6b.3** Update `docGraphCoverage` reporting. **(S, modify)**
+  - File: `src/repositories/types.ts`, `src/mcp/tools/list-indexed-repositories.ts`
+  - `docGraphCoverage: ("markdown" | "pdf" | "docx")[]` — populated based on which formats were actually encountered and processed during indexing.
+  - Acceptance: contract test verifies the field reflects actual coverage, not a hardcoded value.
+
+### PR 7 — Tests + docs
+
+- [ ] **T7.1** Test coverage uplift. **(L)** — see Section 4.
+- [ ] **T7.2** ADR-0007. **(S, new)**
+  - File: `docs/architecture/adr/0007-local-folder-as-repository.md`
+  - Captures: source discriminator decision, manifest design, doc-graph scope (markdown only in v1), watcher routing.
+- [ ] **T7.3** README + `feature-summary.md` updates. **(S)**
+- [ ] **T7.4** CLI help text + MCP tool descriptions polished. **(S)**
+
+---
+
+## 3. Data Model Changes
+
+### 3.1 `RepositoryInfo` additions
+
+```typescript
+// src/repositories/types.ts
+export interface RepositoryInfo {
+  // ... existing fields ...
+
+  /** NEW: source discriminator. Defaults to "git-remote" on read for back-compat. */
+  source: "git-remote" | "local-git" | "local-folder";
+
+  /** EXISTING but now nullable for local-folder */
+  url: string | null;
+
+  /** NEW: security tier. Defaults to "private". "public" refused for local-folder. */
+  tier?: "private" | "work" | "public";
+
+  /** NEW: pointer to per-repo manifest file. Only set when source="local-folder". */
+  lastManifestId?: string;
+
+  /** NEW: persisted watch state for local-folder repos */
+  watchEnabled?: boolean;
+
+  /** NEW: doc-graph coverage hint for clients. Reflects which doc formats actually
+   *  produced graph entities during indexing. PDF/DOCX entries carry lower-fidelity
+   *  MENTIONS edges (confidence="low"). */
+  docGraphCoverage?: ("markdown" | "pdf" | "docx")[];
+}
+```
+
+### 3.2 `UpdateHistoryEntry` relaxation
+
+```typescript
+// src/repositories/types.ts
+export interface UpdateHistoryEntry {
+  // ... existing fields ...
+
+  /** RELAXED: was 40-hex SHA, now also accepts "local-<isoDate>" markers */
+  previousCommit: string;
+  newCommit: string;
+}
+```
+
+### 3.3 New `FileManifest`
+
+```typescript
+// src/services/file-manifest-store.ts
+export interface FileManifestEntry {
+  sha256: string;     // 64-char hex
+  sizeBytes: number;
+  mtimeMs: number;    // POSIX milliseconds
+}
+
+export interface FileManifest {
+  version: "1.0";
+  repository: string;          // RepositoryInfo.name
+  generatedAt: string;         // ISO 8601
+  files: Record<string, FileManifestEntry>; // key = POSIX-normalized relative path
+}
+```
+
+Storage: `{DATA_PATH}/manifests/<sanitized-repo-name>.json`. Atomic write (temp + rename).
+
+### 3.4 Graph schema additions
+
+| Element | Type | Notes |
+|---|---|---|
+| `Document` (node label) | new | Properties: `id`, `repository`, `path`, `title`, `wordCount`, `format` (`"markdown"` \| `"pdf"` \| `"docx"`), `pageCount?` (PDF/DOCX only) |
+| `Section` (node label) | new | Properties: `id`, `documentId`, `level`, `title`, `anchor`, `startOffset`, `endOffset` |
+| `ExternalLink` (node label) | new | Properties: `id`, `url`, `firstSeenIn` (repository) |
+| `HAS_SECTION` (edge) | new | `Document -> Section` |
+| `CONTAINS_SECTION` (edge) | new | `Section -> Section` (for nesting) |
+| `LINKS_TO` (edge) | new | `Document -> Document` (intra-repo) or `Document -> ExternalLink` |
+| `MENTIONS` (edge) | new | `Document -> Function | Class | Module`. Resolution is exact-name, repo-scoped, case-sensitive. Carries property `confidence: "high" | "low"` — `"high"` for markdown code-fence/inline-code mentions, `"low"` for PDF/DOCX heuristic regex matches. |
+| Indexes | new | `Document.id`, `Document.repository`, `Section.documentId` |
+
+Migration: new `0002-doc-graph-schema.ts` migration file under `src/graph/migration/migrations/`.
+
+---
+
+## 4. Test Plan
+
+### 4.1 Unit tests (target: per-file 95%+ coverage)
+
+| Module | Test cases |
+|---|---|
+| `FileManifestStore` | round-trip save/load; atomic-write under concurrent writes; missing-file = empty manifest; corrupted-file = surfaces error |
+| `LocalFolderChangeDetector` | added file; modified content (size differs); modified content (mtime differs but size same); touch-only (mtime differs, hash same -> skipped); deleted file; mass change (1K files) under 200 ms |
+| `GitignoreFilter` | nested `.gitignore`; negation rules (`!keep.txt`); no `.gitignore` present; `.gitignore` containing patterns from outside repo root |
+| `LocalFolderUpdateCoordinator` | happy-path update; `localPath` missing -> `drift_detected`; manifest write atomic on partial pipeline failure; tier validation |
+| `DocEntityExtractor` | frontmatter title; H1 fallback title; nested heading -> `CONTAINS_SECTION`; relative link resolves to in-repo doc; broken relative link -> no edge; wikilink to title; wikilink to path stem; wikilink to section anchor; wikilink to code symbol; **wikilink precedence test: same name exists at title + path-stem + anchor + symbol; verify title wins**; code-fence symbol mention -> `MENTIONS` with `confidence: "high"`; mention of nonexistent symbol -> no edge |
+| `PdfDocxEntityExtractor` | PDF with outline -> `Document` + `Section` nodes; PDF without outline -> `Document` only; DOCX with heading styles -> `Document` + `Section`; DOCX without heading styles -> `Document` only; mention regex match against symbol table -> `MENTIONS` with `confidence: "low"`; minimum identifier length (3 chars) enforced; `--no-pdf-docx-graph` flag suppresses entity creation |
+| Markdown shared-parse refactor (T6.5) | **chunk-coverage invariant: indexed markdown corpus produces chunks whose unioned char-ranges (post-normalization) equal the full source-file char-ranges; no heading and no body paragraph is missing from the chunk set; sum of chunk char-ranges = total normalized file length** |
+| `FolderEventRouter` | event for known WatchedFolder routes to doc indexer; event for known local-folder repo routes to update coordinator; event for unknown folder dropped with warning |
+| Size guardrails | soft-warn at 10K files; hard-refuse at 100K; `--force` bypasses hard-refuse; same for byte limits |
+| Symlink policy | symlink to `/etc` skipped by default; `--follow-symlinks` follows in-repo symlinks; out-of-repo symlink rejected even with flag |
+| Tier refusal | `tier=public` rejected for `local-folder`; allowed for `git-remote` |
+| Collision rejection | name collision throws `RepositoryAlreadyExistsError`; path collision throws new `LocalFolderPathAlreadyRegisteredError` with existing-name in message |
+
+### 4.2 Integration tests (`tests/integration/`)
+
+- End-to-end: register non-git folder via CLI -> `list_indexed_repositories` shows it -> `semantic_search` returns hits -> `get_dependencies` works on a function in that folder.
+- Manifest -> incremental update: register folder, modify one file, run `trigger_incremental_update`, verify chunks updated and exactly one `UpdateHistoryEntry` appended.
+- Markdown doc-graph: register folder with markdown docs, verify `Document` and `Section` nodes; modify a link, verify `LINKS_TO` edge updated.
+- **Markdown chunk-coverage regression**: load a known multi-section markdown corpus, run full ingestion, assert every section heading and every body paragraph appears in at least one chunk and that the union of chunk char-ranges (post-normalization) equals the full file char-range. This test guards the shared-parse refactor (T6.5) against silent coverage regressions.
+- PDF/DOCX doc-graph: register folder containing a PDF with an outline and a DOCX with heading styles; verify `Document` nodes appear, `Section` nodes only when source provides them, and any `MENTIONS` edges carry `confidence: "low"`.
+- Mention confidence filtering: query the graph for `MENTIONS` edges with `confidence = "high"` and confirm only markdown-sourced edges return.
+- MENTIONS resolution: index a code repo + a docs folder pointing at it; verify `MENTIONS` edges created; delete the referenced class; verify edges cleaned up on next update.
+- Watcher: register folder with `--watch`, edit a file, wait for debounce + processing, verify chunks updated.
+
+### 4.3 Isolated tests (`tests/isolated/`)
+
+- `incremental-update-local-folder.test.ts` (mirrors the existing `incremental-update-local-git.test.ts` already in the working tree).
+- `watcher-restart-on-server-reboot.test.ts`.
+- Large-tree perf test: 10K-file folder, full first index under 5 min, incremental update of 10 files under 30 s.
+
+### 4.4 Coverage gates
+
+Per project standards, full suite must pass with ≥ 90% coverage. New code (PRs 1–7) targets ≥ 95% line coverage; the `DocEntityExtractor` mention-resolution path is the most failure-prone and gets the heaviest test coverage.
+
+---
+
+## 5. Risk Register
+
+| # | Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|---|
+| 1 | **Doc-graph MENTIONS resolution scope creep.** Markdown contains arbitrary text; matching every word against the symbol table will explode in noise. | High | High | Restrict v1 to: (a) symbols inside fenced code blocks and inline-code spans only, (b) exact-name match, (c) case-sensitive, (d) repo-scoped only. No fuzzy match. No cross-repo. Document this explicitly in the ADR. If users want broader linking, defer to v2. |
+| 2 | **`LocalFolderChangeDetector` mtime unreliability across filesystems.** SMB/network drives, Docker bind mounts, and some Windows configurations report imprecise or wrong mtimes. | Medium | Medium | Always recompute hash when `(size, mtime)` differ — never trust mtime alone for "modified". Add a `--paranoid` opt-in that hashes everything. Document known-bad filesystems. |
+| 3 | **Watcher fan-out under bulk operations** (e.g., user runs `git pull` inside a watched local-folder repo and 500 files change at once). | Medium | Medium | Per-repo debounce (2 s default). Coalesce events into a single update job. Cap concurrent updates at 1 per repo (existing pattern in `IngestionService._isIndexing`). |
+| 4 | **Symlink TOCTOU.** A symlink resolved at scan time can change before file read. | Low | High (security) | Use `realpath()` after `lstat()` and confirm the resolved path is still within the repo root before opening. Reject silently and log on mismatch. |
+| 5 | **PDF/DOCX text-extraction quality.** Extracted text from PDF/DOCX is often noisy: line breaks split identifiers, OCR artifacts produce false matches, layout-driven extraction can concatenate unrelated tokens. The regex/heuristic mention pass against the symbol table will produce false positives. | High | Medium | (a) Mark all PDF/DOCX `MENTIONS` edges with `confidence: "low"` so consumers can filter them out in queries. (b) Require minimum identifier length (≥3 chars) and exact case match to reduce noise. (c) Document the limitation prominently in README and in `list_indexed_repositories` output. (d) Surface a per-repo metric `lowConfidenceMentionsCount` so users can see how much noise their docs add. (e) Provide a CLI flag `--no-pdf-docx-graph` for users who find the noise unhelpful. |
+
+---
+
+## 5a. Deferred Features (Backlog)
+
+These are explicitly out of scope for v1 and tracked here for future planning. Each entry should become a GitHub issue at v1 ship time.
+
+| # | Feature | Rationale for deferral | Estimated size |
+|---|---|---|---|
+| D1 | **Cross-repository linking and MENTIONS resolution.** Allow markdown docs in repo A to resolve `[[Setup]]` and code-symbol mentions against repo B; expose `--cross-repo-mentions` opt-in flag. **User explicitly requested this be flagged: "we could flag a feature to add later about linking repositories/folders."** | Resolution ambiguity when same name exists in multiple repos; explosion of resolution cost; needs a precedence model across repos. | M–L |
+| D2 | **PDF/DOCX hyperlink extraction.** Emit `LINKS_TO` edges from PDF and DOCX hyperlinks. | Lower priority than mention extraction; PDF link extraction is library-quality-dependent. | S–M |
+| D3 | **Retroactive doc-graph for Phase 6 `WatchedFolder`.** Wire `DocEntityExtractor` and `PdfDocxEntityExtractor` into `FolderDocumentIndexingService`. | Decoupling discipline in v1 design (T6.2, T6b.1) keeps this small — likely a single PR plus migration of existing folder-collection data. | S–M |
+| D4 | **`Section` node surfacing in MCP tools.** Dedicated `get_document_outline` tool or `get_architecture` extension to expose document section hierarchy. | Internal-only in v1 to avoid bloating `get_architecture`; revisit once usage data shows demand. | S |
+| D5 | **`.pkmignore` support.** A pkm-specific ignore file alongside `.gitignore`. | Punted in original scoping; add only if a real user asks. | S |
+| D6 | **Cross-machine portability of local-folder repos.** Index data referencing absolute paths can't move hosts as-is. Needs a path-anchor strategy. | High cost, marginal value for current single-user, single-host model. | L |
+| D7 | **Rename detection** in `LocalFolderChangeDetector`. Currently a rename is processed as delete + add. | Adds complexity (content-hash bucketing across delete/add candidates). Acceptable in v1 because chunks are re-embedded under the new path; cost is wasted re-embedding only. | M |
+| D8 | **Higher-fidelity PDF/DOCX graph extraction**: layout-aware extraction, OCR confidence scoring, table-aware mention extraction. | v1 ships heuristic regex matching with `confidence: "low"`. Better extractors are available but expensive. | L |
+
+---
+
+## 6. Sequencing & Parallelization
+
+### 6.1 Critical path
+
+```
+PR 1 (data model + manifest) ──> PR 2 (initial scan) ──> PR 3 (incremental update)
+                                                              │
+                                                              ├──> PR 4 (CLI/MCP surface)
+                                                              │
+                                                              └──> PR 5 (watcher + router)
+                                  PR 6  (markdown doc-graph) ─────────────┘  (joins after PR 3)
+                                  PR 6b (PDF/DOCX doc-graph) ──────────── ┘  (joins after PR 6)
+                                                                              │
+                                                                              ▼
+                                                                            PR 7 (tests + docs)
+```
+
+### 6.2 Parallelizable
+
+- **PR 6 (markdown doc-graph)** can start as soon as PR 1 lands. It only depends on `RepositoryInfo.source` for its scoping. The `DocEntityExtractor` itself can be developed and unit-tested against fixture markdown files with no live graph database.
+- **PR 6b (PDF/DOCX doc-graph)** depends on PR 6 only for the shared `Document` node schema. Extractor work itself can be drafted in parallel with PR 6 once the schema (T6.1) is locked in.
+- **PR 4 (CLI)** can be developed in parallel with PR 3, mocking the coordinator initially.
+- **PR 5 (watcher)** depends on PR 3 (needs the coordinator to dispatch into) but can be drafted in parallel.
+
+### 6.3 Suggested PR order (single-developer path)
+
+1. PR 1 — Data model + manifest (foundation, blocks everything)
+2. PR 2 — Local-folder ingestion (initial scan)
+3. PR 3 — Change detection + incremental update coordinator
+4. PR 6.1–6.2 + T6.5 — Doc-graph schema + markdown extractor + shared-parse refactor
+5. PR 4 — CLI + MCP registration tool
+6. PR 6.3–6.4 — Wire markdown doc-graph into ingestion + two-pass mentions
+7. PR 6b — PDF/DOCX entity extractor + ingestion wiring + coverage reporting
+8. PR 5 — Watcher + FolderEventRouter
+9. PR 7 — Tests + ADR + README
+
+**Total: 8 PRs** (PR 1, PR 2, PR 3, PR 4, PR 5, PR 6, PR 6b, PR 7). Each PR independently passes `bun run typecheck` + `bun test` + `bun run build` per the mandatory pre-PR checklist.
+
+### 6.4 Estimated total size
+
+- Net new code: ~2,900–3,600 LoC across 8 PRs (PDF/DOCX adds ~400 LoC).
+- Modified code: ~450–650 LoC across existing files (the shared-parse refactor adds modest delta to `MarkdownParser` and `IngestionService`).
+- Test code: ~2,400+ LoC (PDF/DOCX adds ~400 LoC of tests + chunk-coverage regression test).
+
+---
+
+## 7. Resolved Technical Decisions (Doc-Graph Scoping)
+
+All six questions surfaced during doc-graph scoping have been resolved by the user. They are recorded here for traceability; no further input is required to begin implementation.
+
+1. **Cross-repo MENTIONS resolution — RESOLVED: intra-repo only in v1.** Cross-repository linking is tracked as deferred feature **D1** (Section 5a) per user request: "we could flag a feature to add later about linking repositories/folders."
+2. **Wikilink precedence — RESOLVED: doc title > path stem > section anchor > code symbol; first match wins.** Locked into T6.2 acceptance criteria.
+3. **`Section` node visibility — RESOLVED: internal-only in v1.** Not surfaced through `get_architecture` or any other MCP tool. Locked into T6.1 (schema) and T6.2 (extractor) acceptance. Future surfacing tracked as deferred feature **D4**.
+4. **`MarkdownParser` shared-parse reuse — RESOLVED: accepted with hard coverage constraint.** The shared parse must not omit any part of the document from chunk coverage. Locked into T6.5 acceptance criteria with byte-complete coverage assertion and a regression test in T7.1.
+5. **PDF/DOCX-graph extraction — RESOLVED: included in v1.** User overrode the architect's deferral recommendation. Implemented as PR 6b with `confidence: "low"` MENTIONS edges and the limitations documented. Higher-fidelity extraction tracked as deferred feature **D8**.
+6. **Phase 6 `WatchedFolder` retroactive doc-graph — RESOLVED: stays decoupled in v1, retroactive wiring tracked as deferred feature D3.** Decoupling discipline enforced by acceptance criteria on T6.2 and T6b.1: extractors take parsed-document input + repo context only, with no `RepositoryInfo.source` or local-folder-specific dependencies.
+
+---
+
+## 8. Cross-References
+
+- **Existing local-path code** (this plan's foundation): `src/utils/path-utils.ts::isLocalPath`, `src/services/ingestion-service.ts:244–295`, `src/services/incremental-update-coordinator.ts:451,759,775`, `src/cli/commands/index-command.ts`.
+- **Phase 6 infrastructure to reuse**: `src/services/folder-watcher-service.ts`, `src/services/watched-folder-store.ts`, `src/services/folder-document-indexing-service.ts`, `src/mcp/job-tracker.ts`.
+- **Pipeline seam**: `src/services/incremental-update-pipeline.ts::processChanges` — accepts `FileChange[]` regardless of source.
+- **Graph ingestion seam**: `src/graph/ingestion/GraphIngestionService.ts` — branches on file extension already; doc branch is additive.
+- **Markdown parsing**: `src/documents/extractors/MarkdownParser.ts` — already extracts sections + frontmatter; reuse, do not duplicate.
+- **In-flight test file** (signal that work has started): `tests/isolated/incremental-update-local-git.test.ts`.
+
+---
+
+*End of plan.*

--- a/docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md
+++ b/docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md
@@ -83,7 +83,20 @@
 
 ## 2. Component-by-Component Task Breakdown
 
-Tasks are grouped by PR (each targeting <400 LoC of diff per CLAUDE.md). Sizes: S ≤ 100 LoC, M ≤ 300, L ≤ 500, XL > 500 (must be split).
+Tasks are grouped below by PR for engineering granularity. **For delivery, the 8 PRs are bundled into 5 phases** tracked as GitHub issues — see Section 6.1. The PR-level groupings remain the unit of internal sequencing within each phase.
+
+Sizes: S ≤ 100 LoC, M ≤ 300, L ≤ 500, XL > 500 (must be split).
+
+| PR | Phase | Issue |
+| -- | ----- | ----- |
+| PR 1 | A — Foundation | [#564](https://github.com/sethships/PersonalKnowledgeMCP/issues/564) |
+| PR 2 | B — Local folder lifecycle | [#565](https://github.com/sethships/PersonalKnowledgeMCP/issues/565) |
+| PR 3 | B — Local folder lifecycle | [#565](https://github.com/sethships/PersonalKnowledgeMCP/issues/565) |
+| PR 4 | C — User-facing surface | [#566](https://github.com/sethships/PersonalKnowledgeMCP/issues/566) |
+| PR 5 | C — User-facing surface | [#566](https://github.com/sethships/PersonalKnowledgeMCP/issues/566) |
+| PR 6 | D — Document graph | [#567](https://github.com/sethships/PersonalKnowledgeMCP/issues/567) |
+| PR 6b | D — Document graph | [#567](https://github.com/sethships/PersonalKnowledgeMCP/issues/567) |
+| PR 7 | E — ADR + polish | [#568](https://github.com/sethships/PersonalKnowledgeMCP/issues/568) |
 
 ### PR 1 — Data model + manifest plumbing (foundation)
 
@@ -441,45 +454,54 @@ These are explicitly out of scope for v1 and tracked here for future planning. E
 
 ## 6. Sequencing & Parallelization
 
-### 6.1 Critical path
+### 6.1 Consolidated 5-phase delivery
+
+The 8 PRs in Section 2 are **delivered as 5 phases** to give reviewers complete vertical slices. Each phase is tracked by a GitHub issue; PRs cite their phase issue.
+
+| Phase | Issue | Bundles | Approx LoC |
+| ----- | ----- | ------- | ---------- |
+| **A — Foundation** | [#564](https://github.com/sethships/PersonalKnowledgeMCP/issues/564) | PR 1 (data model + manifest) | ~300–400 |
+| **B — Local folder lifecycle** | [#565](https://github.com/sethships/PersonalKnowledgeMCP/issues/565) | PR 2 (initial scan) + PR 3 (change detection + incremental update) | ~700–900 |
+| **C — User-facing surface** | [#566](https://github.com/sethships/PersonalKnowledgeMCP/issues/566) | PR 4 (CLI/MCP registration) + PR 5 (watcher + FolderEventRouter) | ~700–900 |
+| **D — Document graph** | [#567](https://github.com/sethships/PersonalKnowledgeMCP/issues/567) | PR 6 (markdown) + PR 6b (PDF/DOCX) | ~700–1100 |
+| **E — ADR + polish** | [#568](https://github.com/sethships/PersonalKnowledgeMCP/issues/568) | PR 7 (ADR-0007, README, CLI/MCP help) | ~150–300 |
+
+Phases B, C, and D **will exceed the 400-LoC project guideline**. Accepted because shipping each as a single coherent PR delivers a complete reviewable feature slice; reviewers should expect to load the design docs as context.
+
+### 6.2 Critical path
 
 ```
-PR 1 (data model + manifest) ──> PR 2 (initial scan) ──> PR 3 (incremental update)
-                                                              │
-                                                              ├──> PR 4 (CLI/MCP surface)
-                                                              │
-                                                              └──> PR 5 (watcher + router)
-                                  PR 6  (markdown doc-graph) ─────────────┘  (joins after PR 3)
-                                  PR 6b (PDF/DOCX doc-graph) ──────────── ┘  (joins after PR 6)
-                                                                              │
-                                                                              ▼
-                                                                            PR 7 (tests + docs)
+Phase A (#564 — types + manifest)
+   │
+   ├──> Phase B (#565 — lifecycle: scan + update)
+   │       │
+   │       └──> Phase C (#566 — CLI/MCP surface + watcher)
+   │
+   └──> Phase D (#567 — doc-graph: markdown + PDF/DOCX)
+                                 │
+                                 ▼
+                       Phase E (#568 — ADR + polish)
+                       (waits for A–D)
 ```
 
-### 6.2 Parallelizable
+### 6.3 Parallelizable
 
-- **PR 6 (markdown doc-graph)** can start as soon as PR 1 lands. It only depends on `RepositoryInfo.source` for its scoping. The `DocEntityExtractor` itself can be developed and unit-tested against fixture markdown files with no live graph database.
-- **PR 6b (PDF/DOCX doc-graph)** depends on PR 6 only for the shared `Document` node schema. Extractor work itself can be drafted in parallel with PR 6 once the schema (T6.1) is locked in.
-- **PR 4 (CLI)** can be developed in parallel with PR 3, mocking the coordinator initially.
-- **PR 5 (watcher)** depends on PR 3 (needs the coordinator to dispatch into) but can be drafted in parallel.
+- **Phase D (#567)** depends on Phase A only — graph schema additions sit on top of the type discriminator. The extractor is intentionally decoupled from the local-folder concept and can be developed and unit-tested against fixture documents with no live local-folder repo. Can run in parallel with B and C if reviewer bandwidth allows.
+- **Within Phase C**, the watcher (PR 5 work) depends on the coordinator landing in Phase B. The CLI/MCP registration (PR 4 work) can be drafted against a mocked coordinator.
 
-### 6.3 Suggested PR order (single-developer path)
+### 6.4 Suggested execution order (single-developer path)
 
-1. PR 1 — Data model + manifest (foundation, blocks everything)
-2. PR 2 — Local-folder ingestion (initial scan)
-3. PR 3 — Change detection + incremental update coordinator
-4. PR 6.1–6.2 + T6.5 — Doc-graph schema + markdown extractor + shared-parse refactor
-5. PR 4 — CLI + MCP registration tool
-6. PR 6.3–6.4 — Wire markdown doc-graph into ingestion + two-pass mentions
-7. PR 6b — PDF/DOCX entity extractor + ingestion wiring + coverage reporting
-8. PR 5 — Watcher + FolderEventRouter
-9. PR 7 — Tests + ADR + README
+1. Phase A — [#564](https://github.com/sethships/PersonalKnowledgeMCP/issues/564) — Foundation (blocks everything).
+2. Phase B — [#565](https://github.com/sethships/PersonalKnowledgeMCP/issues/565) — Lifecycle: scan + change detection + incremental update.
+3. Phase C — [#566](https://github.com/sethships/PersonalKnowledgeMCP/issues/566) — CLI/MCP surface + watcher.
+4. Phase D — [#567](https://github.com/sethships/PersonalKnowledgeMCP/issues/567) — Markdown + PDF/DOCX doc-graph.
+5. Phase E — [#568](https://github.com/sethships/PersonalKnowledgeMCP/issues/568) — ADR + README + CLI help polish.
 
-**Total: 8 PRs** (PR 1, PR 2, PR 3, PR 4, PR 5, PR 6, PR 6b, PR 7). Each PR independently passes `bun run typecheck` + `bun test` + `bun run build` per the mandatory pre-PR checklist.
+Each phase independently passes `bun run typecheck` + `bun test` + `bun run build` per the mandatory pre-PR checklist.
 
-### 6.4 Estimated total size
+### 6.5 Estimated total size
 
-- Net new code: ~2,900–3,600 LoC across 8 PRs (PDF/DOCX adds ~400 LoC).
+- Net new code: ~2,900–3,600 LoC across 5 phase PRs (PDF/DOCX adds ~400 LoC).
 - Modified code: ~450–650 LoC across existing files (the shared-parse refactor adds modest delta to `MarkdownParser` and `IngestionService`).
 - Test code: ~2,400+ LoC (PDF/DOCX adds ~400 LoC of tests + chunk-coverage regression test).
 

--- a/docs/pm/Local-Folder-As-Repository-PRD.md
+++ b/docs/pm/Local-Folder-As-Repository-PRD.md
@@ -1,0 +1,284 @@
+# Local Folder as First-Class Repository PRD - Personal Knowledge MCP
+
+**Version:** 1.0
+**Date:** May 4, 2026
+**Status:** Approved for Implementation
+**Author:** Product Team
+**Parent Document:** [High-level Personal Knowledge MCP PRD](../High-level-Personal-Knowledge-MCP-PRD.md)
+**Related Document:** [Phase 6: Unstructured Document Ingestion PRD](./Phase6-Document-Ingestion-PRD.md)
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Scope](#2-scope)
+3. [User Stories and Use Cases](#3-user-stories-and-use-cases)
+4. [Functional Requirements](#4-functional-requirements)
+5. [Non-Goals](#5-non-goals)
+6. [Decisions Log](#6-decisions-log)
+7. [Phasing](#7-phasing)
+8. [Open Items](#8-open-items)
+
+---
+
+## 1. Problem Statement
+
+In the user's own framing: *"I want to point the system at a local folder and have it behave like an indexed repository — same MCP tools, same lifecycle, same mental model. The source just happens to be a filesystem path instead of a git remote."*
+
+Today, "repository" in Personal Knowledge MCP is implicitly *a cloned git remote*. Users with a local working tree they have not pushed (a scratch project, a private monorepo checkout, a folder of design docs not under git, an Obsidian vault, a folder of mixed code and documentation) cannot achieve parity with the git-cloned experience.
+
+Phase 6 introduced a parallel concept — **WatchedFolder** — that intentionally targets unstructured documents (.md/.txt/.pdf/.docx) and is exposed via a separate `list_watched_folders` MCP surface. WatchedFolders are docs-only and do not flow through the AST/graph pipeline. The result is a **two-class citizen problem**: a local folder is either treated as documents-only (Phase 6) or it must be promoted to a git remote.
+
+This PRD defines a new capability — **Local Folder Source** — that registers a local folder as a first-class repository in the existing repository registry. It coexists with both git-sourced repositories and Phase 6 WatchedFolders without replacing either.
+
+---
+
+## 2. Scope
+
+### In scope
+
+- A new "local folder" source type for repositories. A registered local folder is **indistinguishable from a git-cloned repository** at the MCP tool layer: it appears in `list_indexed_repositories`, is searchable via `semantic_search` and `search_documents`, and is exposed to all graph tools (`get_dependencies`, `get_dependents`, `get_architecture`, `find_path`).
+- Mixed-content support: a single registered folder may contain source code, documentation, PDFs, and other indexable artifacts. Each file is routed to the appropriate ingestion pipeline.
+- **Graph extraction for documents, not just code.** The graph pipeline expands beyond AST-derived code relationships to include document-level relationships: markdown links, heading hierarchies, cross-references to code symbols, Obsidian-style `[[wikilinks]]`, and file-to-file mentions. Code retains AST-level precision; documents get link/reference-based extraction.
+- Filesystem watching for local-folder repositories, reusing Phase 6's `chokidar` infrastructure via a shared event router.
+- `.gitignore` honored when present at the folder root.
+- Soft and hard size guardrails to prevent accidental indexing of overly broad paths (e.g., a home directory or system root).
+- Drift detection when a registered folder is moved or deleted, surfaced through the existing `drift_detected` status.
+
+### Out of scope (future phases)
+
+- Cross-machine portability of a local-folder repository's index. Indexes are host-local.
+- A dedicated `.pkmignore` filter file. Users may supply include/exclude globs at registration.
+- Automatic migration of existing Phase 6 WatchedFolder entries into local-folder repositories.
+- Cloud / network-share folder sources (OneDrive, Google Drive, SMB shares).
+- Two-way sync or write-back to the source folder.
+
+### Relationship to Phase 6
+
+Phase 6's WatchedFolder remains the documents-only path with its own `list_watched_folders` surface. Local-folder repositories are a **new, parallel** abstraction that supports the full pipeline (code + docs + graph). Users wanting graph tools on a folder of notes should register it as a local-folder repository, not as a Phase 6 WatchedFolder. The two will coexist; no migration is provided. Doc-graph extraction is a forward-compatible capability that WatchedFolder may adopt later.
+
+---
+
+## 3. User Stories and Use Cases
+
+### US-1: Local code checkout (primary)
+**As a** developer with a local checkout that is not pushed to a remote
+**I want to** register `C:\src\my-project` as a repository
+**So that** `semantic_search`, `get_dependencies`, `get_dependents`, `get_architecture`, and `find_path` work on it identically to a cloned GitHub repository.
+
+**Acceptance criteria:**
+- Registration accepts an absolute folder path and optional `--name`.
+- Registered folder appears in `list_indexed_repositories` with `source: "local-folder"` and the absolute path.
+- All graph MCP tools return results filtered by the local-folder repository name.
+
+### US-2: Knowledge vault
+**As a** knowledge worker with an Obsidian vault at `D:\notes`
+**I want to** register the vault as a repository
+**So that** it is searchable via `semantic_search`, *and* internal links and `[[wikilinks]]` participate in the knowledge graph.
+
+**Acceptance criteria:**
+- Markdown files are parsed for inter-document links, headings, and cross-references.
+- `get_dependencies` on a notes file returns documents it links to.
+- `get_dependents` returns documents that link back.
+
+### US-3: Mixed-content folder
+**As a** researcher with a folder containing source code, PDFs, and markdown notes
+**I want to** register the folder once and have everything indexed appropriately
+**So that** code goes through the AST/graph pipeline and documents go through the document/graph pipeline, all under one repository identifier.
+
+### US-4: Lifecycle parity
+**As a** user of any local-folder repository
+**I want** `trigger_incremental_update` and `get_update_status` to work identically to git-sourced repositories.
+
+### US-5: Live editing
+**As an** active developer or writer
+**I want** the system to detect filesystem changes and update the index automatically
+**So that** I do not need to manually trigger updates during a normal work session.
+
+### US-6: Safety net for broad registrations
+**As a** user who might accidentally point the tool at a very large directory
+**I want** the system to warn or refuse before indexing tens of thousands of files
+**So that** I do not exhaust disk, memory, or embedding-provider quota by mistake.
+
+---
+
+## 4. Functional Requirements
+
+### 4.1 Registration
+
+- **FR-1.1** A single CLI verb registers a local folder as a repository: `cli index <path>`. The existing `cli index <url-or-path>` verb auto-detects whether the argument is a git URL or a local absolute path. **No separate `index-folder` verb is introduced.**
+- **FR-1.2** Registration is asynchronous and returns a job ID. Progress is observable via `get_update_status`.
+- **FR-1.3** The absolute, canonicalized path is the deduplication key. If a path is already registered, registration fails with a clear error.
+- **FR-1.4** The user-supplied `--name` (or a derived default from the leaf folder name) is the display key. Name collisions with any existing repository (git-sourced or local-folder) are rejected; the user must supply an explicit `--name`.
+- **FR-1.5** Symlinks are NOT followed by default. An opt-in `--follow-symlinks` flag enables traversal.
+- **FR-1.6** Registration requires an instance tier choice. Default is `private`. The `public` tier is **refused** for local-folder registrations; the user receives a clear error directing them to use `private` or `work`.
+
+### 4.2 Repository parity at the MCP layer
+
+- **FR-2.1** Registered local folders appear in `list_indexed_repositories` with at minimum: `name`, `source: "local-folder"`, `absolute_path`, `instance_tier`, `file_count`, `last_indexed_at`, and `status`.
+- **FR-2.2** All MCP tools that accept a `repository` filter MUST accept a local-folder repository name and behave identically to a git-sourced repository:
+  - `semantic_search`
+  - `search_documents`
+  - `get_dependencies`
+  - `get_dependents`
+  - `get_architecture`
+  - `find_path`
+  - `get_graph_metrics`
+  - `trigger_incremental_update`
+  - `get_update_status`
+- **FR-2.3** Update-history records relax their schema so that the commit SHA field is optional. Local-folder updates record a content fingerprint (path + mtime + size hash, or content hash) in lieu of a commit SHA.
+
+### 4.3 Ingestion routing
+
+- **FR-3.1** Each file in a registered folder is routed to the appropriate pipeline based on extension and detection:
+  - Source code in supported languages → AST parsing + graph population (code precision).
+  - Markdown / text / PDF / DOCX → document ingestion + graph extraction (link/reference precision).
+  - Other allowed extensions → text-only chunking and embedding, no graph entities.
+- **FR-3.2** Default include set is the existing `DEFAULT_EXTENSIONS` whitelist (the same set used for git-sourced repositories today). Users may override via `--include` and `--exclude` glob lists at registration.
+- **FR-3.3** If a `.gitignore` is present at the folder root (or in subdirectories), it MUST be honored. Patterns from `.gitignore` compose with user-supplied excludes.
+- **FR-3.4** No `.pkmignore` is introduced in v1. (See Open Items.)
+
+### 4.4 Graph extraction for documents
+
+- **FR-4.1** Markdown files contribute the following graph entities and relationships:
+  - **Entities:** documents, headings (with hierarchy), explicit anchors. Heading/section nodes are **internal-only in v1** — they participate in graph traversals but are NOT surfaced through `get_architecture`. (Future revisions may expose them.)
+  - **Relationships:** `LINKS_TO` (markdown links and `[[wikilinks]]`), `CONTAINS` (heading hierarchy), `MENTIONS` (cross-references to code symbols when detectable, e.g., `auth.ts::login`, `\`ClassName\``).
+- **FR-4.2** PDF and DOCX files participate in the graph with **minimum-viable extraction** in v1:
+  - **Entities:** the document itself as a graph node (with title/author metadata where available).
+  - **Relationships:** `MENTIONS` edges from the document to known code symbols when extracted text contains a recognizable match (e.g., a fully-qualified path-and-symbol reference, or an unambiguous bare symbol that resolves to exactly one in-repo node).
+  - **Quality caveat:** PDF/DOCX-graph resolution is documented as notably lower-quality than markdown-graph resolution. Plaintext extraction loses the explicit link semantics that markdown provides, so `MENTIONS` edges are best-effort and may exhibit lower recall and precision than equivalent markdown edges. Absence of relationships is not a failure.
+  - Plain-text (.txt) files follow the same minimum-viable approach as PDF/DOCX.
+- **FR-4.3** **Wikilink and reference resolution precedence** for `[[target]]` and similar references is, in order, first-match-wins:
+  1. Document title (front-matter title, or first H1).
+  2. Path stem (filename without extension, relative to the folder root).
+  3. Section anchor within any document.
+  4. Code symbol (qualified name in the repository's code graph).
+  An unresolved reference is recorded as a dangling `LINKS_TO` edge with no target; it is not a failure.
+- **FR-4.4** **Cross-repository / cross-folder resolution is out of scope in v1.** All `MENTIONS`, `LINKS_TO`, and wikilink resolution is **intra-repository only**. References that would resolve only by crossing into another indexed repository are recorded as dangling. (Cross-repo linking is captured as future work — see Section 5 / Section 7.)
+- **FR-4.5** Doc-graph extraction is implemented for local-folder repositories first. Phase 6 WatchedFolder is not retroactively migrated to the new extraction; it may adopt this capability in a later phase.
+- **FR-4.6** The graph schema accommodates both code-derived and document-derived relationships in the same repository's graph. Queries via existing graph MCP tools transparently traverse both.
+- **FR-4.7** **Shared markdown parse with chunker — coverage invariant.** The doc-graph extractor MAY share its markdown parse with the document chunker for performance, **but only if the entire document remains represented in the chunk/embedding output.** Sharing the parse MUST NOT cause any region of a markdown file to be omitted from semantic-search coverage. This is an explicit acceptance criterion: every byte / every section of every indexed markdown file must be represented by at least one chunk after the shared-parse refactor. A regression test is required (see FR-4.8).
+- **FR-4.8** **Coverage regression test (mandatory).** A test in the v1 deliverable MUST take a representative markdown corpus (including documents with code blocks, tables, frontmatter, deeply nested headings, and trailing content after the last heading) and assert that the union of indexed chunk byte-ranges fully covers each source document with no gaps. The test MUST run as part of CI and MUST fail if any document has uncovered regions.
+
+### 4.5 Watching
+
+- **FR-5.1** Filesystem watching is **enabled by default** for local-folder repositories in v1. Users may opt out at registration or disable per-folder afterward.
+- **FR-5.2** Watching reuses the Phase 6 `chokidar`-based infrastructure via a shared event router. The router inspects the folder ID on each event and dispatches to the appropriate pipeline (Phase 6 WatchedFolder docs-only path, or local-folder repository full path).
+- **FR-5.3** Debounce, batching, and queueing semantics match Phase 6's processing-queue defaults. Per-folder overrides are supported.
+- **FR-5.4** Watcher errors (permissions, ENOSPC on inotify watches, etc.) are surfaced in `get_update_status` and do not crash the MCP server.
+
+### 4.6 Incremental updates
+
+- **FR-6.1** `trigger_incremental_update` against a local-folder repository re-scans the folder, computes per-file fingerprints, and updates only changed/added/deleted files.
+- **FR-6.2** Deletions are detected and pruned from the index and graph.
+- **FR-6.3** Rate limiting (1 update per repository per 5 minutes) applies identically to local-folder repositories.
+
+### 4.7 Drift detection
+
+- **FR-7.1** If a registered folder's absolute path no longer exists or is no longer readable at update time, the repository's status is set to `drift_detected` (the existing status surface). The error message identifies the missing path and instructs the user to re-register.
+- **FR-7.2** Drift is reported via `get_update_status` and surfaced in `list_indexed_repositories`.
+
+### 4.8 Size guardrails
+
+- **FR-8.1** At registration, the system performs a fast count + size estimate of the candidate folder (respecting `.gitignore` and user-supplied excludes).
+- **FR-8.2** **Soft warning thresholds:** > 10,000 files OR > 1 GB total. The user is shown the estimate and prompted to confirm (CLI) or receives a warning in the registration job result (MCP).
+- **FR-8.3** **Hard refusal thresholds:** > 100,000 files OR > 10 GB total. Registration is refused unless `--force` is supplied.
+- **FR-8.4** Symlinks excluded from estimation when `--follow-symlinks` is off (default).
+
+---
+
+## 5. Non-Goals
+
+1. **Cross-machine portability.** A local-folder repository's index is valid only on the host that registered it. Sharing the index across machines is out of scope.
+2. **Two-way sync.** This is read-only ingestion; the system never writes to the source folder.
+3. **Replacing git-sourced repositories.** Both source types are first-class and coexist.
+4. **Auto-discovery.** No "scan my home directory and find code" behavior. Registration is always explicit.
+5. **Mid-flight repointing.** Moving a registered folder requires deregister + re-register. Drift detection covers the failure mode; in-place rename support is a future enhancement.
+6. **Cloud / network-share sources.** OneDrive, Google Drive, SMB, and other remote sources are deferred.
+7. **Automatic Phase 6 WatchedFolder migration.** WatchedFolders remain documents-only with their existing surface. Users who want graph tools on a folder must register it as a local-folder repository.
+8. **`.pkmignore` filter file.** Not in v1. Users use `--exclude` globs and `.gitignore`.
+9. **Public-tier local folders.** Refused at registration to prevent accidental disclosure of private content.
+10. **Cross-repository / cross-folder linking.** All wikilink, `LINKS_TO`, and `MENTIONS` resolution is intra-repository in v1. References that would only resolve by crossing into another indexed repository are recorded as dangling. Cross-repo linking is captured as an explicit future-roadmap item (see Section 7).
+
+---
+
+## 6. Decisions Log
+
+These are the closed decisions from the product/architect review pass. Each entry records the question, the decision, and the brief rationale.
+
+| # | Question | Decision | Rationale |
+|---|----------|----------|-----------|
+| 1 | Code only, or docs too? | **Both. Plus graph extraction applies to documents, not just code.** | User explicitly: *"Why wouldn't graph be able to index docs too? It isn't as structured as code but there are logical connections. If so then don't treat a folder differently."* Markdown links, heading hierarchies, wikilinks, and cross-references to code symbols are first-class graph relationships. Code retains AST precision; docs get link/reference extraction. |
+| 2 | Folder identity model | **Absolute path is the canonical dedup key; user-supplied name is the display key.** | Path is unambiguous and stable for a given host. Name remains user-friendly and is the handle used in MCP tool calls. |
+| 3 | Multi-machine portability | **Out of scope. Indexes are host-local.** | Local-folder paths are inherently host-bound; cross-machine sharing introduces complexity (path remapping, content hashing as identity) that is not justified for v1. |
+| 4 | Watching in v1 | **Yes. Included in v1.** Reuse Phase 6 chokidar via a shared event router that dispatches by folder ID. | User explicitly: *"do it now."* Phase 6 already has the watching infrastructure; the marginal cost is the routing layer. |
+| 5 | Filtering rules | **Honor `.gitignore` if present. No `.pkmignore` in v1. Default include set = existing `DEFAULT_EXTENSIONS`.** | Reuses an established mental model (`.gitignore`) and the existing extension whitelist. Avoids inventing a new filter mechanism prematurely. |
+| 6 | Phase 6 WatchedFolder reconciliation | **Option (a): keep both. No migration. Document the difference.** | Avoids a destabilizing data migration. Users who need graph tools on a folder re-register as a local-folder repository. WatchedFolder may adopt doc-graph extraction in a future phase. |
+| 7 | Security / instance tier | **Default `private`. `public` registration is refused.** | Local folders very often contain confidential or personal data. Refusing `public` is a safe default; users who genuinely want a public-tier folder are forced to make an explicit, deliberate choice in a future phase. |
+| 8 | Identifier collisions | **Reject. Require explicit `--name`.** | Auto-suffixing creates silent ambiguity. An explicit name keeps repository identifiers predictable across the MCP surface. |
+| 9 | Size guardrails | **Soft warn at 10K files / 1 GB. Hard refuse at 100K files / 10 GB unless `--force`.** | Protects users from accidentally indexing a home directory or system root, while leaving an escape hatch for legitimately large repositories. |
+| 10 | Registration behavior | **Asynchronous, returns a job ID; progress via `get_update_status`.** | Matches the existing git-clone registration pattern; consistency at the MCP surface. |
+| 11 | Drift surfacing | **Use the existing `drift_detected` status when a registered folder is moved or deleted.** | Reuses an established status surface; users do not need to learn a new error vocabulary. |
+| 12 | Symlinks | **Off by default. `--follow-symlinks` opt-in.** | Symlink loops, escapes from the folder root, and unbounded fan-out are real risks. Off-by-default is the safe choice. |
+| 13 | Update history schema | **Commit SHA field becomes optional; local-folder updates record a content fingerprint instead.** | The schema must accommodate both source types. Optional commit SHA is the minimal change. |
+| 14 | CLI surface | **Single verb. `cli index <path-or-url>` auto-detects.** | Avoids a parallel surface (`index-folder`) and matches the user's stated mental model: "a folder is just another kind of source." |
+| 15 | Cross-repo `MENTIONS` / wikilink resolution | **Intra-repo only in v1. Cross-repo linking added to future roadmap.** | User: *"we could flag a feature to add later about linking repositories/folders."* Keeps v1 resolver scope bounded; dangling references are recorded so future cross-repo resolution can backfill without re-ingesting. |
+| 16 | Wikilink resolution precedence | **Doc title → path stem → section anchor → code symbol. First match wins.** | Most-specific-to-least-specific ordering matches user mental models from tools like Obsidian. Deterministic and explainable. |
+| 17 | Section node visibility | **Internal-only in v1. Not surfaced through `get_architecture`.** | Section nodes are useful for traversal but would clutter architecture overviews. Defer surfacing until we have a UX answer for how to render heading hierarchies alongside code modules. |
+| 18 | Markdown parser reuse between chunker and graph extractor | **Allowed, with a hard coverage invariant: the entire document MUST remain represented in chunks.** A regression test asserting full byte/section coverage of every indexed markdown file is mandatory in v1. | User: *"so long as the entire doc is being indexed."* Performance win is real, but cannot come at the cost of dropping content from semantic search. |
+| 19 | PDF/DOCX-graph extraction in v1 | **In scope for v1 (user override of architect recommendation).** Minimum-viable: file-level entities + outbound `MENTIONS` to known code symbols. Documented quality caveat: notably lower resolution than markdown. | User: *"Add it anyway."* Architect estimated +~400 LoC / +1 PR. Doing it now keeps the doc-graph story coherent across formats from day one rather than leaving PDF/DOCX as a second-class citizen. |
+| 20 | Retroactive doc-graph for Phase 6 WatchedFolder | **Confirmed deferred. Not part of this PRD.** | Already covered by decision 6. Re-confirmed during final review. |
+
+---
+
+## 7. Phasing
+
+The user's decision to include watching in v1 collapses the originally proposed v1 / v1.1 split. There is a single v1 deliverable.
+
+### v1 (current scope)
+
+- Local-folder registration (CLI + MCP) with auto-detection in `cli index`.
+- Async registration with job ID and `get_update_status` progress.
+- Absolute-path dedup + user-supplied name as display key.
+- Full pipeline routing: code → AST/graph; docs → document/graph.
+- Markdown-graph extraction: documents, headings (internal-only), explicit anchors, `LINKS_TO` (markdown links + `[[wikilinks]]`), `CONTAINS` (heading hierarchy), `MENTIONS` (code-symbol cross-references).
+- Wikilink/reference resolution precedence: doc title → path stem → section anchor → code symbol; first match wins.
+- **PDF / DOCX / plaintext minimum-viable graph extraction:** file-level entities + outbound `MENTIONS` to known code symbols, with a documented quality caveat (lower resolution than markdown).
+- Cross-repository linking is **intra-repo only in v1**; unresolved cross-repo references are recorded as dangling for future backfill.
+- Shared markdown parse between chunker and doc-graph extractor is permitted, gated on a mandatory full-coverage regression test (every byte of every indexed markdown file represented by at least one chunk).
+- All graph MCP tools work against local-folder repositories.
+- `.gitignore` honored; user `--include` / `--exclude` globs; default `DEFAULT_EXTENSIONS` whitelist.
+- Filesystem watching enabled by default, reusing Phase 6 chokidar via a shared event router.
+- Incremental updates with content-fingerprint detection.
+- Drift detection via existing `drift_detected` status.
+- Soft and hard size guardrails (10K/1GB warn, 100K/10GB refuse without `--force`).
+- Default `private` tier; `public` refused.
+- Symlinks off by default; `--follow-symlinks` opt-in.
+- Update-history schema accepts optional commit SHA.
+
+### Future phases (deferred)
+
+- **Cross-repository / cross-folder linking.** Resolve `MENTIONS`, `LINKS_TO`, and wikilinks across repository boundaries so that, e.g., a note in one local-folder repository can graph-link to a code symbol in a separate git-sourced repository. v1 records unresolved cross-repo references as dangling so they can be backfilled without re-ingesting.
+- **Surfacing section/heading nodes in `get_architecture`.** Once we have a UX answer for blending document hierarchies with code module hierarchies.
+- **Higher-quality PDF/DOCX-graph extraction.** Layout-aware parsing, table-of-contents-derived hierarchy, citation extraction.
+- **Phase 6 WatchedFolder adoption of document-graph extraction** (retroactive uplift; explicitly deferred per Decision 20).
+- `.pkmignore` filter file.
+- Cross-machine index portability (likely via content-hash identity and path-remapping metadata).
+- In-place folder-rename detection (avoid forced re-registration).
+- Cloud / network-share sources (OneDrive, Google Drive, SMB).
+
+---
+
+## 8. Open Items
+
+All product-level questions raised during review have been answered (see Decisions Log entries 1–20). Items remaining for the architect to resolve in the technical design — none of which block PRD sign-off — are limited to:
+
+1. **Watcher event router design.** The shared router that dispatches between Phase 6 WatchedFolder and local-folder repositories is a new component. The architect should specify its placement, interface, and ownership of the chokidar instance.
+2. **Concurrency limits for very large registrations.** The hard cap (100K files) implies long-running ingest jobs. The architect should specify per-job concurrency limits and resumability behavior on process restart, consistent with the existing interrupted-update-recovery surface.
+
+(The previously open items on doc-graph extraction depth, wikilink/code-symbol resolution precedence, and PDF/DOCX scope have been resolved in Decisions Log entries 15–19 and reflected in FR-4.1 through FR-4.8.)
+
+---
+
+*This PRD is the product anchor for the Local Folder as Repository capability. The technical design follows in a companion architecture document.*

--- a/docs/pm/Local-Folder-As-Repository-PRD.md
+++ b/docs/pm/Local-Folder-As-Repository-PRD.md
@@ -234,7 +234,19 @@ These are the closed decisions from the product/architect review pass. Each entr
 
 ## 7. Phasing
 
-The user's decision to include watching in v1 collapses the originally proposed v1 / v1.1 split. There is a single v1 deliverable.
+The user's decision to include watching in v1 collapses the originally proposed v1 / v1.1 split. There is a single v1 deliverable, executed as **5 sequential phases** (consolidated from the 8-PR breakdown in the implementation plan to deliver coherent vertical slices per review).
+
+### Execution phases (in order)
+
+| Phase | Issue | Scope | Approx LoC |
+| ----- | ----- | ----- | ---------- |
+| **A — Foundation** | [#564](https://github.com/sethships/PersonalKnowledgeMCP/issues/564) | Data model (`source` discriminator, relaxed `UpdateHistoryEntry`) and `FileManifestStore`. | ~300–400 |
+| **B — Local folder lifecycle** | [#565](https://github.com/sethships/PersonalKnowledgeMCP/issues/565) | Initial scan + manifest build + change detection + incremental update. End-to-end programmatic lifecycle. | ~700–900 |
+| **C — User-facing surface** | [#566](https://github.com/sethships/PersonalKnowledgeMCP/issues/566) | CLI auto-detect + `register_local_folder` MCP tool + watcher + `FolderEventRouter`. | ~700–900 |
+| **D — Document graph** | [#567](https://github.com/sethships/PersonalKnowledgeMCP/issues/567) | Markdown graph (full fidelity) + PDF/DOCX graph (lower fidelity, `confidence: "low"` MENTIONS). | ~700–1100 |
+| **E — ADR + polish** | [#568](https://github.com/sethships/PersonalKnowledgeMCP/issues/568) | ADR-0007, README, `feature-summary.md`, CLI/MCP help text. | ~150–300 |
+
+Phases B, C, and D are expected to exceed the 400-LoC PR guideline, accepted because each phase delivers a complete reviewable vertical slice. Phase D may run in parallel with B and C if reviewer bandwidth allows; sequential execution is the default.
 
 ### v1 (current scope)
 


### PR DESCRIPTION
## Summary

Adds two design documents for a new capability: **letting a local filesystem folder register as a first-class repository**, with the same MCP tool surface, lifecycle, and graph parity as a git-cloned repository.

- `docs/pm/Local-Folder-As-Repository-PRD.md` — product requirements
- `docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md` — phased implementation plan (8 PRs)

No code changes in this PR. This is the planning artifact that the implementation PRs (PR 1–7 below) will reference.

## Key product decisions

- **New capability, not a Phase 6 extension.** Coexists with `WatchedFolder` (docs-only) without automatic migration.
- **Doc-graph extraction is in scope.** Markdown at full fidelity (`Document`, `Section`, `LINKS_TO`, `MENTIONS`); PDF/DOCX at lower fidelity (`MENTIONS` edges with `confidence: \"low\"` for filterability).
- **Watching is in v1.** New shared `FolderEventRouter` branches between `WatchedFolder` and local-folder-repository pipelines.
- **Tier:** default `private`; `public` registration is refused for local folders.
- **Filtering:** honor `.gitignore` if present; `.pkmignore` deferred.
- **Identity:** absolute path canonical for dedup; user-supplied `--name` is the display key.
- **Deferred:** cross-machine portability, cross-repo/folder linking, retroactive doc-graph for `WatchedFolder`.

## Implementation phasing — 8 PRs

| PR  | Scope                                             | Tasks                       |
| --- | ------------------------------------------------- | --------------------------- |
| 1   | Data model + manifest plumbing                    | T1.1–T1.4 (3×S, 1×M)        |
| 2   | Local-folder ingestion path (initial scan)        | T2.1–T2.6 (6×S)             |
| 3   | Change detection + incremental update             | T3.1–T3.4 (2×M, 2×S)        |
| 4   | CLI + MCP registration surface                    | T4.1–T4.4 (3×S, 1×M)        |
| 5   | Watcher + FolderEventRouter                       | T5.1–T5.4 (2×M, 2×S)        |
| 6   | Markdown doc-graph extraction                     | T6.1–T6.5 (3×M, 2×S)        |
| 6b  | PDF/DOCX doc-graph extraction (lower fidelity)    | T6b.1–T6b.3 (1×M, 2×S)      |
| 7   | Tests + ADR-0007 + README/CLI help                | T7.1 (L), T7.2–T7.4 (3×S)   |

Sizes: **S** ≤100 LoC · **M** ≤300 LoC · **L** ≤500 LoC. Each PR targets <400 LoC of diff per project standards.

## Notable acceptance criteria

- **Coverage invariant on markdown shared-parse refactor (T6.5):** the union of all chunk character-ranges, after whitespace normalization, must equal the full source-file character range. No section heading or body paragraph may be missing from the chunk set. Backed by a regression test (T7.1).
- **Wikilink resolution precedence:** doc title → path stem → section anchor → code symbol; first match wins. Subsequent matches logged at debug level.
- **Refuse `tier = \"public\"`** for `local-folder` source — surfaces a `LocalFolderPublicTierRefusedError`.
- **Symlinks off by default**; `--follow-symlinks` opt-in caps depth at 8 and requires targets to remain inside the repo root.
- **Drift detection:** if `localPath` is missing at update time, return existing `drift_detected` status (not a hard failure).

## Test plan

This PR contains documentation only; no executable changes.

- [x] PRD reviewed for product alignment with user decisions.
- [x] Implementation plan reviewed against current codebase seams (`src/services/ingestion-service.ts`, `src/services/incremental-update-coordinator.ts`, `src/services/folder-watcher-service.ts`).
- [ ] Reviewer to confirm the doc-graph schema additions (`Document`, `Section`, `ExternalLink`, `LINKS_TO`, `MENTIONS`, `HAS_SECTION`, `CONTAINS_SECTION`) are acceptable before PR 6 implementation begins.
- [ ] Reviewer to confirm phasing and PR boundaries before PR 1 implementation begins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)