### PR TITLE
feat(#564): Phase A — data model + manifest plumbing

### DIFF
--- a/src/cli/commands/graph-populate-all-command.ts
+++ b/src/cli/commands/graph-populate-all-command.ts
@@ -319,7 +319,9 @@ export async function graphPopulateAllCommand(
         // Ingest files
         const result = await ingestionService.ingestFiles(files, {
           repository: repo.name,
-          repositoryUrl: repo.url,
+          // Phase A: this command iterates over git-remote and local-git
+          // repos only; Phase B will skip local-folder repos entirely.
+          repositoryUrl: repo.url!,
           force,
           onProgress,
         });

--- a/src/cli/commands/graph-populate-command.ts
+++ b/src/cli/commands/graph-populate-command.ts
@@ -202,7 +202,10 @@ export async function graphPopulateCommand(
 
     const result = await ingestionService.ingestFiles(files, {
       repository: repositoryName,
-      repositoryUrl: repository.url,
+      // url is non-null for git-remote and local-git repos (the only sources
+      // that flow through this CLI command in Phase A). Phase B will branch
+      // on repository.source for local-folder repos.
+      repositoryUrl: repository.url!,
       force,
       onProgress,
     });

--- a/src/cli/commands/status-command.ts
+++ b/src/cli/commands/status-command.ts
@@ -146,8 +146,11 @@ async function checkRepositoryUpdates(
 
   for (const repo of repositories) {
     try {
-      // Parse git URL to extract owner/repo
-      const parsed = parseGitUrl(repo.url);
+      // Parse git URL to extract owner/repo.
+      // url is non-null for git-remote and local-git sources (the only sources
+      // that exist in Phase A). Phase B will branch on `repo.source` and skip
+      // git URL parsing entirely for `local-folder` repos.
+      const parsed = parseGitUrl(repo.url!);
 
       // If not a parseable git URL, mark as unknown
       if (!parsed) {

--- a/src/cli/commands/update-repository-command.ts
+++ b/src/cli/commands/update-repository-command.ts
@@ -171,7 +171,9 @@ export async function updateRepositoryCommand(
     }).start();
 
     try {
-      const result = await deps.ingestionService.indexRepository(repo.url, {
+      // url is non-null for git-remote and local-git sources. Phase B will
+      // dispatch to LocalFolderUpdateCoordinator for local-folder repos.
+      const result = await deps.ingestionService.indexRepository(repo.url!, {
         branch: repo.branch,
         force: true,
         onProgress: (progress) => {

--- a/src/mcp/tools/list-indexed-repositories.ts
+++ b/src/mcp/tools/list-indexed-repositories.ts
@@ -20,6 +20,16 @@ interface IndexedRepositoryResponse {
   /** Unique repository identifier */
   name: string;
   /**
+   * Origin of the indexed content.
+   *
+   * - `git-remote`: cloned from a remote git URL.
+   * - `local-git`: a path on the host machine that contains a `.git` directory.
+   * - `local-folder`: a path on the host machine with no git history; tracked
+   *   via per-file content fingerprints. Expect `url` to be `null` for this
+   *   source.
+   */
+  source: "git-remote" | "local-git" | "local-folder";
+  /**
    * Git clone URL.
    *
    * `null` when the repository was registered as a `local-folder` source
@@ -92,6 +102,7 @@ function formatListRepositoriesResponse(
   // Map each repository to external API format
   const formattedRepos: IndexedRepositoryResponse[] = repositories.map((repo) => ({
     name: repo.name,
+    source: repo.source,
     url: repo.url,
     collection_name: repo.collectionName,
     file_count: repo.fileCount,

--- a/src/mcp/tools/list-indexed-repositories.ts
+++ b/src/mcp/tools/list-indexed-repositories.ts
@@ -19,8 +19,14 @@ import type { ToolHandler } from "../types.js";
 interface IndexedRepositoryResponse {
   /** Unique repository identifier */
   name: string;
-  /** Git clone URL */
-  url: string;
+  /**
+   * Git clone URL.
+   *
+   * `null` when the repository was registered as a `local-folder` source
+   * (no clone URL exists). For `git-remote` and `local-git` sources this is
+   * the original clone URL.
+   */
+  url: string | null;
   /** ChromaDB collection name */
   collection_name: string;
   /** Number of files indexed */

--- a/src/repositories/metadata-store.ts
+++ b/src/repositories/metadata-store.ts
@@ -473,7 +473,7 @@ export class RepositoryMetadataStoreImpl implements RepositoryMetadataService {
         const persistedSource = (repo as { source?: unknown }).source;
         if (persistedSource === undefined) {
           metadata.repositories[key] = {
-            ...(repo as RepositoryInfo),
+            ...repo,
             source: "git-remote",
           };
         } else if (!VALID_SOURCES.includes(persistedSource as RepositoryInfo["source"])) {
@@ -485,7 +485,7 @@ export class RepositoryMetadataStoreImpl implements RepositoryMetadataService {
             "Unknown repository source value on read - quarantining as 'git-remote' for back-compat. Re-index the repository to clean up."
           );
           metadata.repositories[key] = {
-            ...(repo as RepositoryInfo),
+            ...repo,
             source: "git-remote",
           };
         }

--- a/src/repositories/metadata-store.ts
+++ b/src/repositories/metadata-store.ts
@@ -164,8 +164,31 @@ export class RepositoryMetadataStoreImpl implements RepositoryMetadataService {
         "VALIDATION_ERROR"
       );
     }
-    if (!info.url || typeof info.url !== "string") {
-      throw new RepositoryMetadataError("Repository URL is required", "VALIDATION_ERROR");
+    if (
+      info.source !== "git-remote" &&
+      info.source !== "local-git" &&
+      info.source !== "local-folder"
+    ) {
+      throw new RepositoryMetadataError(
+        `Repository source must be one of "git-remote", "local-git", or "local-folder" (got ${JSON.stringify(info.source)})`,
+        "VALIDATION_ERROR"
+      );
+    }
+    // url is required for git-sourced repositories; null is permitted only for "local-folder"
+    if (info.source === "local-folder") {
+      if (info.url !== null && typeof info.url !== "string") {
+        throw new RepositoryMetadataError(
+          "Repository URL must be a string or null for local-folder sources",
+          "VALIDATION_ERROR"
+        );
+      }
+    } else {
+      if (!info.url || typeof info.url !== "string") {
+        throw new RepositoryMetadataError(
+          "Repository URL is required for git-remote and local-git sources",
+          "VALIDATION_ERROR"
+        );
+      }
     }
     if (!info.collectionName || typeof info.collectionName !== "string") {
       throw new RepositoryMetadataError("Collection name is required", "VALIDATION_ERROR");
@@ -428,6 +451,16 @@ export class RepositoryMetadataStoreImpl implements RepositoryMetadataService {
       // Validate basic structure
       if (!metadata.version || !metadata.repositories) {
         throw new Error("Missing required fields: version or repositories");
+      }
+
+      // Back-compat: synthesize source="git-remote" for any persisted repository
+      // that predates the source discriminator. This must run BEFORE any caller
+      // sees the data so listRepositories() and getRepository() return the
+      // migrated shape.
+      for (const repo of Object.values(metadata.repositories)) {
+        if ((repo as { source?: unknown }).source === undefined) {
+          (repo as RepositoryInfo).source = "git-remote";
+        }
       }
 
       return metadata;

--- a/src/repositories/metadata-store.ts
+++ b/src/repositories/metadata-store.ts
@@ -453,13 +453,41 @@ export class RepositoryMetadataStoreImpl implements RepositoryMetadataService {
         throw new Error("Missing required fields: version or repositories");
       }
 
-      // Back-compat: synthesize source="git-remote" for any persisted repository
-      // that predates the source discriminator. This must run BEFORE any caller
-      // sees the data so listRepositories() and getRepository() return the
-      // migrated shape.
-      for (const repo of Object.values(metadata.repositories)) {
-        if ((repo as { source?: unknown }).source === undefined) {
-          (repo as RepositoryInfo).source = "git-remote";
+      // Back-compat + defensive read: synthesize source="git-remote" for any
+      // persisted repository that predates the source discriminator (undefined
+      // value), and quarantine any persisted source value that is not one of
+      // the three known discriminators (e.g. produced by a manual edit, a
+      // partial migration, or a future-version downgrade). Both cases run
+      // BEFORE any caller sees the data so listRepositories() and
+      // getRepository() return the migrated shape.
+      //
+      // Spread-replace the entry rather than mutating in place so future
+      // callers that introduce a load-cache cannot observe shared mutable
+      // state (Issue #9 from PR #569 review).
+      const VALID_SOURCES: readonly RepositoryInfo["source"][] = [
+        "git-remote",
+        "local-git",
+        "local-folder",
+      ];
+      for (const [key, repo] of Object.entries(metadata.repositories)) {
+        const persistedSource = (repo as { source?: unknown }).source;
+        if (persistedSource === undefined) {
+          metadata.repositories[key] = {
+            ...(repo as RepositoryInfo),
+            source: "git-remote",
+          };
+        } else if (!VALID_SOURCES.includes(persistedSource as RepositoryInfo["source"])) {
+          this.logger.warn(
+            {
+              repository: (repo as { name?: string }).name ?? key,
+              persistedSource,
+            },
+            "Unknown repository source value on read - quarantining as 'git-remote' for back-compat. Re-index the repository to clean up."
+          );
+          metadata.repositories[key] = {
+            ...(repo as RepositoryInfo),
+            source: "git-remote",
+          };
         }
       }
 

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -57,15 +57,31 @@ export interface RepositoryInfo {
   name: string;
 
   /**
-   * Original git clone URL
+   * Origin of the indexed content.
    *
-   * The URL used to clone the repository.
-   * Can be HTTPS or SSH format.
+   * - `git-remote`: cloned from a remote git URL (default for legacy data on read for back-compat).
+   * - `local-git`: a path on the host machine that contains a `.git` directory.
+   * - `local-folder`: a path on the host machine with no git history; tracked via per-file content fingerprints.
+   *
+   * Persisted records that predate this field are migrated to `"git-remote"` on read.
+   *
+   * @example "git-remote", "local-git", "local-folder"
+   */
+  source: "git-remote" | "local-git" | "local-folder";
+
+  /**
+   * Original git clone URL.
+   *
+   * The URL used to clone the repository. Can be HTTPS or SSH format.
+   *
+   * `null` is permitted only when `source === "local-folder"` — folders without git history
+   * have no clone URL. For `git-remote` and `local-git` sources this MUST be a non-empty string.
    *
    * @example "https://github.com/user/repo.git"
    * @example "git@github.com:user/repo.git"
+   * @example null  // when source === "local-folder"
    */
-  url: string;
+  url: string | null;
 
   /**
    * Absolute path where repository is cloned locally
@@ -286,6 +302,31 @@ export interface RepositoryInfo {
    * @example "2024-12-14T15:30:00.000Z"
    */
   updateStartedAt?: string;
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Local Folder + Multi-tier Fields (Optional — Phase A foundation)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Security tier this repository belongs to.
+   *
+   * Defaults to `"private"` when not set. Registration-time enforcement (refusing
+   * `"public"` for `local-folder` sources) is added in a later phase; the metadata
+   * store accepts any of the three values for round-trip safety.
+   *
+   * @example "private", "work", "public"
+   */
+  tier?: "private" | "work" | "public";
+
+  /**
+   * Pointer to the file-manifest record for this repository.
+   *
+   * Only set when `source === "local-folder"`. Identifies the manifest entry
+   * stored by `FileManifestStore` (typically the sanitized repository name used
+   * as the manifest filename). Used by the local-folder change detector to
+   * correlate the registry entry with its persisted per-file fingerprints.
+   */
+  lastManifestId?: string;
 }
 
 /**
@@ -320,20 +361,30 @@ export interface UpdateHistoryEntry {
   timestamp: string;
 
   /**
-   * Git commit SHA before the update (40 characters)
+   * Identifier for the indexed state before this update.
    *
-   * The commit that was indexed prior to this update operation.
+   * - For `git-remote` and `local-git` repositories: the 40-character git commit SHA
+   *   that was indexed prior to this update operation.
+   * - For `local-folder` repositories: a synthetic marker of the form
+   *   `local-<isoDate>` corresponding to the timestamp of the previously stored
+   *   `FileManifest`. This is not validated as a 40-hex SHA.
    *
    * @example "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+   * @example "local-2026-05-05T10:30:00.000Z"
    */
   previousCommit: string;
 
   /**
-   * Git commit SHA after the update (40 characters)
+   * Identifier for the indexed state after this update.
    *
-   * The new HEAD commit that was indexed by this update operation.
+   * - For `git-remote` and `local-git` repositories: the 40-character git HEAD SHA
+   *   that was indexed by this update operation.
+   * - For `local-folder` repositories: a synthetic marker of the form
+   *   `local-<isoDate>` corresponding to the timestamp of the newly written
+   *   `FileManifest`. This is not validated as a 40-hex SHA.
    *
    * @example "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3"
+   * @example "local-2026-05-05T11:45:12.000Z"
    */
   newCommit: string;
 

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -319,12 +319,15 @@ export interface RepositoryInfo {
   tier?: "private" | "work" | "public";
 
   /**
-   * Pointer to the file-manifest record for this repository.
+   * Opaque pointer to the file-manifest record for this repository.
    *
-   * Only set when `source === "local-folder"`. Identifies the manifest entry
-   * stored by `FileManifestStore` (typically the sanitized repository name used
-   * as the manifest filename). Used by the local-folder change detector to
-   * correlate the registry entry with its persisted per-file fingerprints.
+   * Only set when `source === "local-folder"`. Holds the value returned by
+   * `FileManifestStore.computeManifestId(repo.name)` and is passed back to
+   * `FileManifestStore.loadManifest`/`saveManifest` to correlate the
+   * registry entry with its persisted per-file fingerprints. Treat as
+   * opaque — do not parse it; the store owns the mapping between this
+   * identifier and the on-disk filename, which may include a hash suffix to
+   * avoid case-collisions across distinct repository names.
    */
   lastManifestId?: string;
 }

--- a/src/services/file-manifest-store.ts
+++ b/src/services/file-manifest-store.ts
@@ -1,0 +1,320 @@
+/**
+ * File Manifest Store Implementation
+ *
+ * Per-repository content fingerprint storage. For `local-folder` repositories
+ * (Phase A foundation, issue #564) the manifest captures sha256 + size + mtime
+ * for every indexed file, enabling a future change detector to produce
+ * `FileChange[]` for the existing incremental update pipeline.
+ *
+ * Mirrors the singleton + atomic-write + serialized-write-queue pattern from
+ * `watched-folder-store.ts`. Each repository gets its own manifest file under
+ * `{DATA_PATH}/manifests/<sanitized-repo-name>.json`.
+ *
+ * @module services/file-manifest-store
+ */
+
+import { join, dirname } from "path";
+import { rename, unlink, mkdir } from "fs/promises";
+import type { Logger } from "pino";
+import { z } from "zod";
+import { getComponentLogger } from "../logging/index.js";
+import { sanitizeCollectionName } from "../repositories/metadata-store.js";
+
+/**
+ * Per-file fingerprint record stored in a manifest.
+ *
+ * Captures enough state to detect content changes without re-hashing every file
+ * on every scan: a fast `(size, mtimeMs)` pair short-circuits unchanged files;
+ * sha256 is consulted only when size or mtime differs.
+ */
+export interface FileManifestEntry {
+  /** SHA-256 hex digest of the file's contents (64 lowercase hex chars). */
+  sha256: string;
+  /** File size in bytes. */
+  sizeBytes: number;
+  /** POSIX modification time in milliseconds. */
+  mtimeMs: number;
+}
+
+/**
+ * Persisted manifest for a single repository.
+ *
+ * Stored at `{DATA_PATH}/manifests/<sanitized-repo-name>.json`. The `version`
+ * field is a literal `"1.0"` to enable future schema migrations.
+ */
+export interface FileManifest {
+  /** Schema version. Always `"1.0"` in this release. */
+  version: "1.0";
+  /** Repository name this manifest belongs to (echoed back from caller). */
+  repository: string;
+  /** ISO 8601 timestamp of when this manifest snapshot was generated. */
+  generatedAt: string;
+  /**
+   * Map of POSIX-normalized relative file paths (relative to the repository
+   * root) to their fingerprints. Empty when the repository has no indexed
+   * files yet.
+   */
+  files: Record<string, FileManifestEntry>;
+}
+
+/**
+ * Service interface for persisting per-repository file manifests.
+ */
+export interface FileManifestStoreService {
+  /**
+   * Load the manifest for a repository.
+   *
+   * Returns an in-memory empty manifest if the manifest file does not exist;
+   * the empty manifest is NOT written to disk by this call.
+   *
+   * @param repository - Repository name (matches `RepositoryInfo.name`).
+   */
+  loadManifest(repository: string): Promise<FileManifest>;
+
+  /**
+   * Persist a manifest for a repository using an atomic temp-file + rename.
+   *
+   * Concurrent calls are serialized through the internal write queue, so the
+   * final on-disk state reflects the last-queued payload.
+   *
+   * @param repository - Repository name (matches `RepositoryInfo.name`).
+   * @param manifest - Manifest payload to persist. The `repository` property of
+   *                    the manifest is overridden with the `repository` argument
+   *                    to keep storage and payload consistent.
+   */
+  saveManifest(repository: string, manifest: FileManifest): Promise<void>;
+
+  /**
+   * Remove the manifest for a repository.
+   *
+   * Idempotent — succeeds with no error when the manifest file does not exist.
+   */
+  deleteManifest(repository: string): Promise<void>;
+}
+
+/** Zod schema for a single fingerprint entry (validated on read). */
+const FileManifestEntrySchema = z.object({
+  sha256: z.string(),
+  sizeBytes: z.number(),
+  mtimeMs: z.number(),
+});
+
+/** Zod schema for the persisted manifest file format (validated on read). */
+const FileManifestSchema = z.object({
+  version: z.literal("1.0"),
+  repository: z.string(),
+  generatedAt: z.string(),
+  files: z.record(z.string(), FileManifestEntrySchema),
+});
+
+/**
+ * Singleton implementation of the file manifest store.
+ *
+ * Manages per-repository manifest persistence under `{DATA_PATH}/manifests/`.
+ * Follows the same singleton + atomic-write + serialized-write-queue pattern
+ * as `WatchedFolderStoreImpl`.
+ */
+export class FileManifestStoreImpl implements FileManifestStoreService {
+  private static instance: FileManifestStoreImpl | null = null;
+
+  private readonly manifestsDir: string;
+  private _logger: Logger | null = null;
+
+  /** In-memory cache keyed by repository name. */
+  private readonly cache: Map<string, FileManifest> = new Map();
+
+  /** Serialized promise queue to prevent concurrent read-modify-write races. */
+  private writeQueue: Promise<void> = Promise.resolve();
+
+  private constructor(dataPath: string) {
+    this.manifestsDir = join(dataPath, "manifests");
+  }
+
+  /** Lazy-initialized component logger. */
+  private get logger(): Logger {
+    if (!this._logger) {
+      this._logger = getComponentLogger("services:file-manifest-store");
+    }
+    return this._logger;
+  }
+
+  /**
+   * Get the singleton instance of the manifest store.
+   *
+   * @param dataPath - Optional data directory (defaults to `process.env.DATA_PATH || "./data"`).
+   */
+  public static getInstance(dataPath?: string): FileManifestStoreImpl {
+    if (!FileManifestStoreImpl.instance) {
+      const resolvedPath = dataPath || process.env["DATA_PATH"] || "./data";
+      FileManifestStoreImpl.instance = new FileManifestStoreImpl(resolvedPath);
+    } else if (dataPath !== undefined) {
+      const logger = getComponentLogger("services:file-manifest-store");
+      logger.warn(
+        { requestedPath: dataPath },
+        "getInstance called with dataPath after singleton already initialized - ignoring new path"
+      );
+    }
+    return FileManifestStoreImpl.instance;
+  }
+
+  /**
+   * Reset the singleton instance.
+   *
+   * **FOR TESTING ONLY**.
+   *
+   * @internal
+   */
+  public static resetInstance(): void {
+    FileManifestStoreImpl.instance = null;
+  }
+
+  /**
+   * Resolve the on-disk path for a repository's manifest file.
+   *
+   * Uses `sanitizeCollectionName` to produce a filesystem-safe basename
+   * consistent with ChromaDB collection naming.
+   */
+  public getManifestPath(repository: string): string {
+    return join(this.manifestsDir, `${sanitizeCollectionName(repository)}.json`);
+  }
+
+  async loadManifest(repository: string): Promise<FileManifest> {
+    const cached = this.cache.get(repository);
+    if (cached) {
+      return cloneManifest(cached);
+    }
+
+    const filePath = this.getManifestPath(repository);
+    const file = Bun.file(filePath);
+    const exists = await file.exists();
+
+    if (!exists) {
+      this.logger.debug(
+        { filePath, repository },
+        "Manifest file not found - returning empty manifest"
+      );
+      return emptyManifest(repository);
+    }
+
+    try {
+      const content = await file.text();
+      const parsed: unknown = JSON.parse(content);
+      const manifest = FileManifestSchema.parse(parsed);
+      this.cache.set(repository, manifest);
+      this.logger.debug(
+        { filePath, repository, fileCount: Object.keys(manifest.files).length },
+        "Manifest loaded from disk"
+      );
+      return cloneManifest(manifest);
+    } catch (error) {
+      this.logger.error(
+        {
+          filePath,
+          repository,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to load manifest"
+      );
+      throw error;
+    }
+  }
+
+  async saveManifest(repository: string, manifest: FileManifest): Promise<void> {
+    this.writeQueue = this.writeQueue.then(() => this.saveManifestInternal(repository, manifest));
+    await this.writeQueue;
+  }
+
+  async deleteManifest(repository: string): Promise<void> {
+    this.writeQueue = this.writeQueue.then(() => this.deleteManifestInternal(repository));
+    await this.writeQueue;
+  }
+
+  private async saveManifestInternal(
+    repository: string,
+    manifest: FileManifest
+  ): Promise<void> {
+    const filePath = this.getManifestPath(repository);
+    const tempPath = `${filePath}.tmp`;
+
+    // Ensure manifests/ directory exists
+    await mkdir(dirname(filePath), { recursive: true });
+
+    const payload: FileManifest = {
+      version: "1.0",
+      repository,
+      generatedAt: manifest.generatedAt,
+      files: { ...manifest.files },
+    };
+
+    try {
+      const content = JSON.stringify(payload, null, 2);
+      await Bun.write(tempPath, content);
+      await rename(tempPath, filePath);
+      this.cache.set(repository, payload);
+      this.logger.debug(
+        { filePath, repository, fileCount: Object.keys(payload.files).length },
+        "Manifest saved to disk"
+      );
+    } catch (error) {
+      try {
+        await unlink(tempPath);
+      } catch {
+        // Ignore cleanup errors
+      }
+      this.logger.error(
+        {
+          filePath,
+          repository,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "Failed to save manifest"
+      );
+      throw error;
+    }
+  }
+
+  private async deleteManifestInternal(repository: string): Promise<void> {
+    const filePath = this.getManifestPath(repository);
+    try {
+      await unlink(filePath);
+      this.logger.debug({ filePath, repository }, "Manifest deleted");
+    } catch (error) {
+      // Idempotent: missing file is not an error
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        this.logger.debug({ filePath, repository }, "Manifest already absent - no-op");
+      } else {
+        this.logger.error(
+          {
+            filePath,
+            repository,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Failed to delete manifest"
+        );
+        throw error;
+      }
+    } finally {
+      this.cache.delete(repository);
+    }
+  }
+}
+
+/** Construct an empty in-memory manifest for a repository. */
+function emptyManifest(repository: string): FileManifest {
+  return {
+    version: "1.0",
+    repository,
+    generatedAt: new Date().toISOString(),
+    files: {},
+  };
+}
+
+/** Deep-copy a manifest so callers can mutate the result without polluting the cache. */
+function cloneManifest(manifest: FileManifest): FileManifest {
+  return {
+    version: manifest.version,
+    repository: manifest.repository,
+    generatedAt: manifest.generatedAt,
+    files: { ...manifest.files },
+  };
+}

--- a/src/services/file-manifest-store.ts
+++ b/src/services/file-manifest-store.ts
@@ -28,7 +28,7 @@ import { sanitizeCollectionName } from "../repositories/metadata-store.js";
  * and the migration logic — the type and schema follow automatically (Issue
  * #11 from PR #569 review).
  */
-export const FILE_MANIFEST_VERSION = "1.0" as const;
+export const FILE_MANIFEST_VERSION = "1.0";
 export type FileManifestVersion = typeof FILE_MANIFEST_VERSION;
 
 /**
@@ -293,10 +293,7 @@ export class FileManifestStoreImpl implements FileManifestStoreService {
     await next;
   }
 
-  private async saveManifestInternal(
-    repository: string,
-    manifest: FileManifest
-  ): Promise<void> {
+  private async saveManifestInternal(repository: string, manifest: FileManifest): Promise<void> {
     const filePath = this.getManifestPath(repository);
     const tempPath = `${filePath}.tmp`;
 

--- a/src/services/file-manifest-store.ts
+++ b/src/services/file-manifest-store.ts
@@ -21,6 +21,30 @@ import { getComponentLogger } from "../logging/index.js";
 import { sanitizeCollectionName } from "../repositories/metadata-store.js";
 
 /**
+ * Schema version literal for persisted manifests.
+ *
+ * Centralized so the TypeScript type, the zod runtime schema, and the on-disk
+ * payload stay in lockstep. When bumping the schema, update only this constant
+ * and the migration logic — the type and schema follow automatically (Issue
+ * #11 from PR #569 review).
+ */
+export const FILE_MANIFEST_VERSION = "1.0" as const;
+export type FileManifestVersion = typeof FILE_MANIFEST_VERSION;
+
+/**
+ * Sentinel `generatedAt` value returned by `loadManifest` for repositories
+ * with no persisted manifest.
+ *
+ * Callers can compare against this value to detect "never persisted" without
+ * incurring a separate "exists" call. Using a fixed Unix-epoch ISO string
+ * guarantees deterministic reads — two consecutive `loadManifest("missing")`
+ * calls produce identical results, which matters for code that derives
+ * `local-<isoDate>` markers from manifest timestamps (Issue #7 from PR #569
+ * review).
+ */
+export const FILE_MANIFEST_EMPTY_GENERATED_AT = "1970-01-01T00:00:00.000Z";
+
+/**
  * Per-file fingerprint record stored in a manifest.
  *
  * Captures enough state to detect content changes without re-hashing every file
@@ -43,8 +67,8 @@ export interface FileManifestEntry {
  * field is a literal `"1.0"` to enable future schema migrations.
  */
 export interface FileManifest {
-  /** Schema version. Always `"1.0"` in this release. */
-  version: "1.0";
+  /** Schema version. Always `"1.0"` in this release (see `FILE_MANIFEST_VERSION`). */
+  version: FileManifestVersion;
   /** Repository name this manifest belongs to (echoed back from caller). */
   repository: string;
   /** ISO 8601 timestamp of when this manifest snapshot was generated. */
@@ -65,7 +89,11 @@ export interface FileManifestStoreService {
    * Load the manifest for a repository.
    *
    * Returns an in-memory empty manifest if the manifest file does not exist;
-   * the empty manifest is NOT written to disk by this call.
+   * the empty manifest is NOT written to disk by this call. The empty
+   * manifest's `generatedAt` is a deterministic sentinel
+   * (`FILE_MANIFEST_EMPTY_GENERATED_AT`, the Unix epoch ISO string) so two
+   * consecutive misses return byte-identical results — callers can compare
+   * against the sentinel to detect "never persisted".
    *
    * @param repository - Repository name (matches `RepositoryInfo.name`).
    */
@@ -101,7 +129,7 @@ const FileManifestEntrySchema = z.object({
 
 /** Zod schema for the persisted manifest file format (validated on read). */
 const FileManifestSchema = z.object({
-  version: z.literal("1.0"),
+  version: z.literal(FILE_MANIFEST_VERSION),
   repository: z.string(),
   generatedAt: z.string(),
   files: z.record(z.string(), FileManifestEntrySchema),
@@ -172,10 +200,32 @@ export class FileManifestStoreImpl implements FileManifestStoreService {
    * Resolve the on-disk path for a repository's manifest file.
    *
    * Uses `sanitizeCollectionName` to produce a filesystem-safe basename
-   * consistent with ChromaDB collection naming.
+   * consistent with ChromaDB collection naming, then suffixes with an 8-char
+   * hash of the original (case-preserved) repository name. The suffix is
+   * required because `sanitizeCollectionName` lowercases and collapses
+   * non-alphanumerics, so two distinct repository names (e.g. `"Foo"` vs
+   * `"foo"`) would otherwise collide on a single manifest file even though
+   * the metadata store treats them as distinct entries.
    */
   public getManifestPath(repository: string): string {
-    return join(this.manifestsDir, `${sanitizeCollectionName(repository)}.json`);
+    const base = sanitizeCollectionName(repository);
+    const suffix = Bun.hash(repository).toString(16).padStart(16, "0").substring(0, 8);
+    return join(this.manifestsDir, `${base}_${suffix}.json`);
+  }
+
+  /**
+   * Compute the stable manifest identifier for a repository.
+   *
+   * Phase B callers MUST persist this exact value in
+   * `RepositoryInfo.lastManifestId` and pass it back to subsequent
+   * `loadManifest`/`saveManifest` calls. The string is opaque — do not parse
+   * it; treat it as a key. Today this is simply the repository name itself,
+   * which is also the cache key used internally; that may change as the
+   * store evolves, so consumers should always go through this method
+   * (Issue #10 from PR #569 review).
+   */
+  public computeManifestId(repository: string): string {
+    return repository;
   }
 
   async loadManifest(repository: string): Promise<FileManifest> {
@@ -220,13 +270,27 @@ export class FileManifestStoreImpl implements FileManifestStoreService {
   }
 
   async saveManifest(repository: string, manifest: FileManifest): Promise<void> {
-    this.writeQueue = this.writeQueue.then(() => this.saveManifestInternal(repository, manifest));
-    await this.writeQueue;
+    const next = this.writeQueue.then(
+      () => this.saveManifestInternal(repository, manifest),
+      // Run regardless of whether the previous queued write succeeded or
+      // failed. The previous failure was already surfaced to its own caller,
+      // and we don't want one bad write to permanently poison the queue
+      // (Issue #4 from PR #569 review).
+      () => this.saveManifestInternal(repository, manifest)
+    );
+    // Keep the queue head a resolved promise so future enqueues stay ordered
+    // but don't re-throw the failure of past tasks.
+    this.writeQueue = next.catch(() => undefined);
+    await next;
   }
 
   async deleteManifest(repository: string): Promise<void> {
-    this.writeQueue = this.writeQueue.then(() => this.deleteManifestInternal(repository));
-    await this.writeQueue;
+    const next = this.writeQueue.then(
+      () => this.deleteManifestInternal(repository),
+      () => this.deleteManifestInternal(repository)
+    );
+    this.writeQueue = next.catch(() => undefined);
+    await next;
   }
 
   private async saveManifestInternal(
@@ -240,7 +304,7 @@ export class FileManifestStoreImpl implements FileManifestStoreService {
     await mkdir(dirname(filePath), { recursive: true });
 
     const payload: FileManifest = {
-      version: "1.0",
+      version: FILE_MANIFEST_VERSION,
       repository,
       generatedAt: manifest.generatedAt,
       files: { ...manifest.files },
@@ -299,12 +363,19 @@ export class FileManifestStoreImpl implements FileManifestStoreService {
   }
 }
 
-/** Construct an empty in-memory manifest for a repository. */
+/**
+ * Construct an empty in-memory manifest for a repository.
+ *
+ * The `generatedAt` field is the deterministic sentinel
+ * `FILE_MANIFEST_EMPTY_GENERATED_AT`, NOT the current time, so two
+ * consecutive `loadManifest` calls for a missing repository return
+ * byte-identical results (Issue #7 from PR #569 review).
+ */
 function emptyManifest(repository: string): FileManifest {
   return {
-    version: "1.0",
+    version: FILE_MANIFEST_VERSION,
     repository,
-    generatedAt: new Date().toISOString(),
+    generatedAt: FILE_MANIFEST_EMPTY_GENERATED_AT,
     files: {},
   };
 }

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -271,7 +271,10 @@ export class IncrementalUpdateCoordinator {
 
       // Step 2-5: Detect changes — via GitHub API for github.com repos,
       // or via local git diff for all other hosts and local paths.
-      const parsedUrl = parseGitUrl(repo.url);
+      // url is non-null for git-remote and local-git sources. Phase B will
+      // route local-folder repos to LocalFolderUpdateCoordinator before this
+      // path runs.
+      const parsedUrl = parseGitUrl(repo.url!);
       const isGitHub = parsedUrl?.isGitHub === true;
 
       let headCommit: CommitInfo;
@@ -379,7 +382,7 @@ export class IncrementalUpdateCoordinator {
           repo.localPath,
           repo.branch,
           repo.lastIndexedCommitSha,
-          repo.url,
+          repo.url!,
           logger
         );
 
@@ -448,7 +451,7 @@ export class IncrementalUpdateCoordinator {
 
       // Step 7: Update local clone (git pull).
       // Skipped for local-path repos — the directory is managed by the user, not cloned.
-      if (!isLocalPath(repo.url)) {
+      if (!isLocalPath(repo.url!)) {
         await this.updateLocalClone(repo.localPath, repo.branch);
         logger.info(
           { repository: repositoryName, localPath: repo.localPath },

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -1106,6 +1106,9 @@ export class IngestionService {
   }): RepositoryInfo {
     return {
       name: params.name,
+      // Phase A: this factory is only called from the git-clone path.
+      // Phase B will add a parallel local-folder construction site.
+      source: "git-remote",
       url: params.url,
       branch: params.cloneResult.branch,
       localPath: params.cloneResult.path,

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -1106,9 +1106,12 @@ export class IngestionService {
   }): RepositoryInfo {
     return {
       name: params.name,
-      // Phase A: this factory is only called from the git-clone path.
-      // Phase B will add a parallel local-folder construction site.
-      source: "git-remote",
+      // Phase A: distinguish remote clones from local-git paths. Local-folder
+      // sources (no .git) will be added in Phase B via a parallel construction
+      // site. `isLocalPath` mirrors the same gate used in `indexRepository` at
+      // the clone-vs-resolve fork (see ~line 244), so the discriminator we
+      // persist here matches the path that actually produced the index.
+      source: isLocalPath(params.url) ? "local-git" : "git-remote",
       url: params.url,
       branch: params.cloneResult.branch,
       localPath: params.cloneResult.path,

--- a/src/services/interrupted-update-recovery.ts
+++ b/src/services/interrupted-update-recovery.ts
@@ -425,8 +425,11 @@ async function executeFullReindexRecovery(
   await clearInterruptedUpdateFlag(deps.repositoryService, repositoryName);
   logger.debug({ repository: repositoryName }, "Cleared interrupted update flag");
 
-  // Perform full re-index
-  const result = await deps.ingestionService.indexRepository(repository.url, {
+  // Perform full re-index.
+  // url is non-null for git-remote and local-git sources. Local-folder repos
+  // dispatch through LocalFolderUpdateCoordinator (Phase B) and never reach
+  // this code path.
+  const result = await deps.ingestionService.indexRepository(repository.url!, {
     branch: repository.branch,
     force: true,
   });

--- a/tests/cli/commands/history-command.test.ts
+++ b/tests/cli/commands/history-command.test.ts
@@ -37,6 +37,7 @@ describe("History Command", () => {
 
   const mockRepositoryInfo: RepositoryInfo = {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/test/test-repo.git",
     collectionName: "test-repo",
     localPath: "/tmp/test-repo",

--- a/tests/cli/commands/migrate-extensions-command.test.ts
+++ b/tests/cli/commands/migrate-extensions-command.test.ts
@@ -18,6 +18,7 @@ import type { RepositoryInfo, RepositoryMetadataService } from "../../../src/rep
 function createMockRepo(overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
   return {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/user/test-repo.git",
     localPath: "./data/repos/test-repo",
     collectionName: "repo_test_repo",

--- a/tests/cli/commands/providers-command.test.ts
+++ b/tests/cli/commands/providers-command.test.ts
@@ -46,6 +46,7 @@ function createMockRepositoryService(
 function createTestRepository(overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
   return {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/user/test-repo.git",
     localPath: "./data/repos/test-repo",
     collectionName: "repo_test_repo",
@@ -331,6 +332,7 @@ describe("Providers Formatters", () => {
       const repos: RepositoryInfo[] = [
         {
           name: "test-1",
+          source: "git-remote",
           url: "https://github.com/user/test-1.git",
           localPath: "./data/repos/test-1",
           collectionName: "repo_test_1",
@@ -363,6 +365,7 @@ describe("Providers Formatters", () => {
       const repos: RepositoryInfo[] = [
         {
           name: "test-repo",
+          source: "git-remote",
           url: "https://github.com/user/test-repo.git",
           localPath: "./data/repos/test-repo",
           collectionName: "repo_test_repo",

--- a/tests/cli/commands/tables-command.test.ts
+++ b/tests/cli/commands/tables-command.test.ts
@@ -71,6 +71,7 @@ function createTableChunk(
 
 const mockRepo: RepositoryInfo = {
   name: "test-repo",
+  source: "git-remote",
   url: "https://github.com/test/test-repo.git",
   collectionName: "repo_test_repo",
   localPath: "/tmp/test-repo",
@@ -87,6 +88,7 @@ const mockRepo: RepositoryInfo = {
 
 const mockRepo2: RepositoryInfo = {
   name: "docs-repo",
+  source: "git-remote",
   url: "https://github.com/test/docs-repo.git",
   collectionName: "repo_docs_repo",
   localPath: "/tmp/docs-repo",

--- a/tests/cli/commands/update-all-command.test.ts
+++ b/tests/cli/commands/update-all-command.test.ts
@@ -42,6 +42,7 @@ describe("Update All Command", () => {
   // Sample repositories for testing
   const createSampleRepo = (name: string, status: string = "ready"): RepositoryInfo => ({
     name,
+    source: "git-remote",
     url: `https://github.com/test/${name}.git`,
     localPath: `/repos/${name}`,
     branch: "main",

--- a/tests/cli/commands/update-repository-command.test.ts
+++ b/tests/cli/commands/update-repository-command.test.ts
@@ -41,6 +41,7 @@ describe("Update Repository Command", () => {
   // Sample repository for testing
   const sampleRepo: RepositoryInfo = {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/test/repo.git",
     localPath: "/repos/test-repo",
     branch: "main",

--- a/tests/cli/output/formatters.test.ts
+++ b/tests/cli/output/formatters.test.ts
@@ -18,6 +18,7 @@ describe("Formatters", () => {
       const repos: RepositoryInfo[] = [
         {
           name: "test-repo",
+          source: "git-remote",
           url: "https://github.com/user/test-repo.git",
           localPath: "/data/repos/test-repo",
           collectionName: "test-repo",
@@ -86,6 +87,7 @@ describe("Formatters", () => {
       const repos: RepositoryInfo[] = [
         {
           name: "test-repo",
+          source: "git-remote",
           url: "https://github.com/user/test-repo.git",
           localPath: "/data/repos/test-repo",
           collectionName: "test-repo",

--- a/tests/fixtures/repository-fixtures.ts
+++ b/tests/fixtures/repository-fixtures.ts
@@ -43,6 +43,7 @@ export function createTestRepositoryInfo(
 
   return {
     name,
+    source: "git-remote",
     url: defaultUrl,
     localPath: defaultLocalPath,
     collectionName: defaultCollectionName,

--- a/tests/integration/logging/update-operations.test.ts
+++ b/tests/integration/logging/update-operations.test.ts
@@ -35,6 +35,7 @@ describe("Update Operations Logging Integration", () => {
   // Test fixture: Repository metadata
   const testRepo: RepositoryInfo = {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/owner/test-repo.git",
     localPath: "/repos/test-repo",
     collectionName: "repo_test_repo",

--- a/tests/integration/mcp-protocol.test.ts
+++ b/tests/integration/mcp-protocol.test.ts
@@ -401,6 +401,7 @@ describe("MCP Protocol Integration", () => {
       const mockRepos: RepositoryInfo[] = [
         {
           name: "PersonalKnowledgeMCP",
+          source: "git-remote",
           url: "https://github.com/sethb75/PersonalKnowledgeMCP",
           localPath: "/path/to/PersonalKnowledgeMCP",
           collectionName: "repo-personalknowledgemcp",
@@ -415,6 +416,7 @@ describe("MCP Protocol Integration", () => {
         },
         {
           name: "my-api",
+          source: "git-remote",
           url: "https://github.com/user/my-api",
           localPath: "/path/to/my-api",
           collectionName: "repo-my-api",
@@ -486,6 +488,7 @@ describe("MCP Protocol Integration", () => {
     it("should format repository metadata with snake_case fields", async () => {
       const mockRepo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo",
         localPath: "/path/to/test-repo",
         collectionName: "repo-test-repo",
@@ -520,6 +523,7 @@ describe("MCP Protocol Integration", () => {
     it("should include repositories with error status", async () => {
       const mockRepo: RepositoryInfo = {
         name: "failed-repo",
+        source: "git-remote",
         url: "https://github.com/test/failed",
         localPath: "/path/to/failed",
         collectionName: "repo-failed-repo",

--- a/tests/integration/mcp/tools/search-documents.integration.test.ts
+++ b/tests/integration/mcp/tools/search-documents.integration.test.ts
@@ -247,6 +247,7 @@ describeIntegration("search_documents MCP Tool Integration Tests", () => {
     // Register repository as "ready"
     await repositoryService.updateRepository({
       name: repoName,
+      source: "git-remote",
       url: `file:///test/${repoName}`,
       localPath: path.join(os.tmpdir(), repoName),
       collectionName,

--- a/tests/integration/mcp/tools/semantic-search-documents.integration.test.ts
+++ b/tests/integration/mcp/tools/semantic-search-documents.integration.test.ts
@@ -215,6 +215,7 @@ describeIntegration("semantic_search MCP Tool with include_documents Integration
     // Register repository metadata
     await repositoryService.updateRepository({
       name: repoName,
+      source: "git-remote",
       url: `https://github.com/test/${repoName}`,
       localPath: path.join(os.tmpdir(), repoName),
       collectionName,
@@ -287,6 +288,7 @@ describeIntegration("semantic_search MCP Tool with include_documents Integration
     // Document folders are stored as repositories in the metadata service
     await repositoryService.updateRepository({
       name: folderName,
+      source: "git-remote",
       url: `file://${folderName}`,
       localPath: path.join(os.tmpdir(), folderName),
       collectionName,

--- a/tests/integration/repositories/metadata-backward-compat.test.ts
+++ b/tests/integration/repositories/metadata-backward-compat.test.ts
@@ -136,6 +136,7 @@ describe("Backward Compatibility - Incremental Update Fields", () => {
 
       const repoWithNewFields: RepositoryInfo = {
         name: "new-repo",
+        source: "git-remote",
         url: "https://github.com/test/new.git",
         localPath: "./data/repos/new-repo",
         collectionName: "repo_new_repo",
@@ -170,6 +171,7 @@ describe("Backward Compatibility - Incremental Update Fields", () => {
 
       const repoWithShaOnly: RepositoryInfo = {
         name: "sha-only-repo",
+        source: "git-remote",
         url: "https://github.com/test/sha-only.git",
         localPath: "./data/repos/sha-only-repo",
         collectionName: "repo_sha_only_repo",
@@ -206,6 +208,7 @@ describe("Backward Compatibility - Incremental Update Fields", () => {
       // Create repo with new fields
       const original: RepositoryInfo = {
         name: "update-test",
+        source: "git-remote",
         url: "https://github.com/test/update.git",
         localPath: "./data/repos/update-test",
         collectionName: "repo_update_test",
@@ -324,6 +327,7 @@ describe("Backward Compatibility - Incremental Update Fields", () => {
 
       const newRepo: RepositoryInfo = {
         name: "modern-project",
+        source: "git-remote",
         url: "https://github.com/test/modern-project.git",
         localPath: "./data/repos/modern-project",
         collectionName: "repo_modern_project",
@@ -365,6 +369,7 @@ describe("Backward Compatibility - Incremental Update Fields", () => {
 
       const repo: RepositoryInfo = {
         name: "json-test",
+        source: "git-remote",
         url: "https://github.com/test/json-test.git",
         localPath: "./data/repos/json-test",
         collectionName: "repo_json_test",
@@ -399,6 +404,7 @@ describe("Backward Compatibility - Incremental Update Fields", () => {
 
       const repo: RepositoryInfo = {
         name: "no-optional",
+        source: "git-remote",
         url: "https://github.com/test/no-optional.git",
         localPath: "./data/repos/no-optional",
         collectionName: "repo_no_optional",

--- a/tests/integration/search-service.integration.test.ts
+++ b/tests/integration/search-service.integration.test.ts
@@ -314,6 +314,7 @@ describeIntegration("SearchService Integration Tests", () => {
     it("should handle repository with no indexed chunks", async () => {
       await repositoryService.updateRepository({
         name: "empty-repo",
+        source: "git-remote",
         url: "https://github.com/test/empty",
         localPath: path.join(os.tmpdir(), "empty"),
         collectionName: "repo_empty",
@@ -380,6 +381,7 @@ describeIntegration("SearchService Integration Tests", () => {
     // Add repository metadata
     await repositoryService.updateRepository({
       name: repoName,
+      source: "git-remote",
       url: `https://github.com/test/${repoName}`,
       localPath: path.join(os.tmpdir(), repoName),
       collectionName,

--- a/tests/integration/services/error-handling-comprehensive.test.ts
+++ b/tests/integration/services/error-handling-comprehensive.test.ts
@@ -100,6 +100,7 @@ describe("Comprehensive Error Handling Integration Tests", () => {
 
       const testRepo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/owner/test-repo.git",
         localPath: tempDir,
         collectionName: "repo_test_repo",
@@ -181,6 +182,7 @@ describe("Comprehensive Error Handling Integration Tests", () => {
 
       const testRepo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/owner/test-repo.git",
         localPath: tempDir,
         collectionName: "repo_test_repo",
@@ -254,6 +256,7 @@ describe("Comprehensive Error Handling Integration Tests", () => {
 
       const baseRepo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/owner/test-repo.git",
         localPath: tempDir,
         collectionName: "repo_test_repo",
@@ -382,6 +385,7 @@ describe("Comprehensive Error Handling Integration Tests", () => {
 
       const testRepo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/owner/test-repo.git",
         localPath: tempDir,
         collectionName: "repo_test_repo",
@@ -462,6 +466,7 @@ describe("Comprehensive Error Handling Integration Tests", () => {
 
       const testRepo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/owner/test-repo.git",
         localPath: tempDir,
         collectionName: "repo_test_repo",

--- a/tests/isolated/graph-populate-command.test.ts
+++ b/tests/isolated/graph-populate-command.test.ts
@@ -60,6 +60,7 @@ describe("Graph Populate Command", () => {
 
   const mockRepositoryInfo: RepositoryInfo = {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/test/test-repo.git",
     collectionName: "test-repo",
     localPath: "/tmp/test-repo",

--- a/tests/mcp/server.test.ts
+++ b/tests/mcp/server.test.ts
@@ -384,6 +384,7 @@ describe("PersonalKnowledgeMCPServer", () => {
       const mockRepos: RepositoryInfo[] = [
         {
           name: "test-repo",
+          source: "git-remote",
           url: "https://github.com/test/repo",
           localPath: "/path/to/repo",
           collectionName: "repo-test-repo",

--- a/tests/mcp/tools/list-indexed-repositories.test.ts
+++ b/tests/mcp/tools/list-indexed-repositories.test.ts
@@ -76,6 +76,7 @@ function createMockRepo(
 ): RepositoryInfo {
   return {
     name,
+    source: "git-remote",
     url: `https://github.com/user/${name}.git`,
     localPath: `/data/repos/${name}`,
     collectionName: `repo_${name}`,

--- a/tests/mcp/tools/list-indexed-repositories.test.ts
+++ b/tests/mcp/tools/list-indexed-repositories.test.ts
@@ -42,7 +42,8 @@ function getTextContent(content: unknown): string {
 interface ParsedListResponse {
   repositories: Array<{
     name: string;
-    url: string;
+    source: "git-remote" | "local-git" | "local-folder";
+    url: string | null;
     collection_name: string;
     file_count: number;
     chunk_count: number;
@@ -177,6 +178,7 @@ describe("createListRepositoriesHandler", () => {
       expect(response.repositories).toHaveLength(1);
       expect(response.repositories[0]).toEqual({
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/user/test-repo.git",
         collection_name: "repo_test-repo",
         file_count: 42,
@@ -321,6 +323,27 @@ describe("createListRepositoriesHandler", () => {
       expect(repo).not.toHaveProperty("branch");
       expect(repo).not.toHaveProperty("includeExtensions");
       expect(repo).not.toHaveProperty("excludePatterns");
+    });
+
+    it("surfaces the source discriminator on the response (Issue #6)", async () => {
+      const remote = createMockRepo("remote-repo", 1, 1, { source: "git-remote" });
+      const local = createMockRepo("local-repo", 1, 1, {
+        source: "local-folder",
+        url: null,
+      });
+      mockRepositoryService.listRepositories = mock(() => Promise.resolve([remote, local]));
+
+      const result = await handler({});
+      expect(result.isError).toBe(false);
+      const response = parseResponse(getTextContent(result.content));
+
+      const remoteResp = response.repositories.find((r) => r.name === "remote-repo");
+      const localResp = response.repositories.find((r) => r.name === "local-repo");
+
+      expect(remoteResp?.source).toBe("git-remote");
+      expect(remoteResp?.url).toBe("https://github.com/user/remote-repo.git");
+      expect(localResp?.source).toBe("local-folder");
+      expect(localResp?.url).toBeNull();
     });
   });
 

--- a/tests/mcp/tools/trigger-incremental-update-completeness.test.ts
+++ b/tests/mcp/tools/trigger-incremental-update-completeness.test.ts
@@ -52,6 +52,7 @@ function parseResponse(content: unknown): SyncSuccessResponse {
 describe("trigger_incremental_update - Completeness Fields", () => {
   const testRepo: RepositoryInfo = {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/owner/test-repo.git",
     localPath: "/repos/test-repo",
     collectionName: "repo_test_repo",

--- a/tests/mcp/tools/trigger-incremental-update.test.ts
+++ b/tests/mcp/tools/trigger-incremental-update.test.ts
@@ -88,6 +88,7 @@ function getTextContent(content: unknown): string {
 function createMockRepo(name: string): RepositoryInfo {
   return {
     name,
+    source: "git-remote",
     url: `https://github.com/user/${name}.git`,
     localPath: `/data/repos/${name}`,
     collectionName: `repo_${name}`,

--- a/tests/services/incremental-update-coordinator-completeness.test.ts
+++ b/tests/services/incremental-update-coordinator-completeness.test.ts
@@ -29,6 +29,7 @@ describe("IncrementalUpdateCoordinator - Completeness Integration", () => {
   // Test fixture: Repository metadata
   const testRepo: RepositoryInfo = {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/owner/test-repo.git",
     localPath: "/repos/test-repo",
     collectionName: "repo_test_repo",
@@ -490,6 +491,7 @@ describe("IncrementalUpdateCoordinator - Completeness Integration", () => {
       const localRepo: RepositoryInfo = {
         ...testRepo,
         name: "local-repo",
+        source: "git-remote",
         url: "C:/local/path/to/repo",
         localPath: "C:/local/path/to/repo",
         lastIndexedCommitSha: baseSha,

--- a/tests/services/incremental-update-coordinator.test.ts
+++ b/tests/services/incremental-update-coordinator.test.ts
@@ -36,6 +36,7 @@ describe("IncrementalUpdateCoordinator", () => {
   // Test fixture: Repository metadata
   const testRepo: RepositoryInfo = {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/owner/test-repo.git",
     localPath: "/repos/test-repo",
     collectionName: "repo_test_repo",

--- a/tests/services/index-completeness-checker.test.ts
+++ b/tests/services/index-completeness-checker.test.ts
@@ -51,6 +51,7 @@ function createErrorFileScanner(errorMessage: string): FileScanner {
 function createTestRepo(fileCount: number): RepositoryInfo {
   return {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/owner/test-repo.git",
     localPath: "/repos/test-repo",
     collectionName: "repo_test_repo",

--- a/tests/services/metrics-calculator.test.ts
+++ b/tests/services/metrics-calculator.test.ts
@@ -36,6 +36,7 @@ function createMockHistoryEntry(overrides?: Partial<UpdateHistoryEntry>): Update
 function createMockRepository(overrides?: Partial<RepositoryInfo>): RepositoryInfo {
   return {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/test/repo.git",
     localPath: "/data/repos/test-repo",
     collectionName: "repo_test_repo",

--- a/tests/services/search-service.test.ts
+++ b/tests/services/search-service.test.ts
@@ -608,6 +608,7 @@ describe("SearchServiceImpl", () => {
 function createMockRepo(name: string, status: "ready" | "indexing" | "error"): RepositoryInfo {
   return {
     name,
+    source: "git-remote",
     url: `https://github.com/test/${name}`,
     localPath: `/tmp/${name}`,
     collectionName: `repo_${name}`,

--- a/tests/unit/repositories/metadata-store.test.ts
+++ b/tests/unit/repositories/metadata-store.test.ts
@@ -671,6 +671,31 @@ describe("source discriminator + back-compat round-trip", () => {
       "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
     );
   });
+
+  test("quarantines an unknown persisted source value to git-remote on read (Issue #3)", async () => {
+    // Hand-write a repositories.json with a corrupt `source` value that
+    // doesn't match any of the three known discriminators.
+    const corrupt = {
+      version: "1.0",
+      repositories: {
+        "bogus-repo": {
+          ...buildLegacyRepoRecord("bogus-repo"),
+          source: "from-the-future",
+        },
+      },
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, "repositories.json"),
+      JSON.stringify(corrupt, null, 2),
+      "utf-8"
+    );
+
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    // Must not throw — read-side quarantine treats it as git-remote.
+    const reloaded = await store.getRepository("bogus-repo");
+    expect(reloaded).not.toBeNull();
+    expect(reloaded?.source).toBe("git-remote");
+  });
 });
 
 /**

--- a/tests/unit/repositories/metadata-store.test.ts
+++ b/tests/unit/repositories/metadata-store.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { expect, test, describe, beforeEach, afterEach } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
 import {
   RepositoryMetadataStoreImpl,
   sanitizeCollectionName,
@@ -19,8 +22,14 @@ import {
   FileOperationError,
   InvalidMetadataFormatError,
 } from "../../../src/repositories/errors.js";
-import type { UpdateHistoryEntry } from "../../../src/repositories/types.js";
-import { edgeCaseRepositoryNames } from "../../fixtures/repository-fixtures.js";
+import type {
+  RepositoryInfo,
+  UpdateHistoryEntry,
+} from "../../../src/repositories/types.js";
+import {
+  createTestRepositoryInfo,
+  edgeCaseRepositoryNames,
+} from "../../fixtures/repository-fixtures.js";
 import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
 
 describe("RepositoryMetadataStoreImpl", () => {
@@ -426,3 +435,262 @@ describe("RepositoryMetadataStoreImpl", () => {
 // Note: CRUD operation tests are covered by integration tests
 // Unit tests with mocked file I/O are not feasible in Bun due to readonly global.Bun
 // Integration tests provide more value by testing real file operations
+
+describe("source discriminator + back-compat round-trip", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    initializeLogger({ level: "silent", format: "json" });
+    RepositoryMetadataStoreImpl.resetInstance();
+    tmpDir = path.join(
+      os.tmpdir(),
+      `metadata-store-source-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    );
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    RepositoryMetadataStoreImpl.resetInstance();
+    resetLogger();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  test.each(["git-remote", "local-git", "local-folder"] as const)(
+    "round-trips source value %s",
+    async (source) => {
+      const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+      const repo = createTestRepositoryInfo("rt-source", {
+        source,
+        url: source === "local-folder" ? null : "https://github.com/x/y.git",
+      });
+
+      await store.updateRepository(repo);
+
+      // Reset singleton to force a re-read from disk
+      RepositoryMetadataStoreImpl.resetInstance();
+      const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+      const reloaded = await store2.getRepository("rt-source");
+
+      expect(reloaded).not.toBeNull();
+      expect(reloaded?.source).toBe(source);
+      expect(reloaded?.url).toBe(source === "local-folder" ? null : "https://github.com/x/y.git");
+    }
+  );
+
+  test("synthesizes source=git-remote when persisted record has no source field", async () => {
+    // Hand-write a legacy-shape repositories.json (pre-source-discriminator)
+    const legacyFile = {
+      version: "1.0",
+      repositories: {
+        "legacy-repo": {
+          name: "legacy-repo",
+          // NB: no `source` field — simulates data persisted before T1.1
+          url: "https://github.com/legacy/repo.git",
+          localPath: "./data/repos/legacy-repo",
+          collectionName: "repo_legacy_repo",
+          fileCount: 50,
+          chunkCount: 200,
+          lastIndexedAt: "2024-01-01T00:00:00.000Z",
+          indexDurationMs: 1000,
+          status: "ready",
+          branch: "main",
+          includeExtensions: [".ts"],
+          excludePatterns: ["node_modules/**"],
+        },
+      },
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, "repositories.json"),
+      JSON.stringify(legacyFile, null, 2),
+      "utf-8"
+    );
+
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const reloaded = await store.getRepository("legacy-repo");
+
+    expect(reloaded).not.toBeNull();
+    expect(reloaded?.source).toBe("git-remote");
+    expect(reloaded?.url).toBe("https://github.com/legacy/repo.git");
+  });
+
+  test("synthesizes source on listRepositories too", async () => {
+    const legacyFile = {
+      version: "1.0",
+      repositories: {
+        "a": { ...buildLegacyRepoRecord("a") },
+        "b": { ...buildLegacyRepoRecord("b") },
+      },
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, "repositories.json"),
+      JSON.stringify(legacyFile, null, 2),
+      "utf-8"
+    );
+
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const all = await store.listRepositories();
+
+    expect(all).toHaveLength(2);
+    for (const repo of all) {
+      expect(repo.source).toBe("git-remote");
+    }
+  });
+
+  test("round-trips url=null when source is local-folder", async () => {
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const repo = createTestRepositoryInfo("local-folder-repo", {
+      source: "local-folder",
+      url: null,
+      lastManifestId: "repo_local_folder_repo",
+    });
+
+    await store.updateRepository(repo);
+    RepositoryMetadataStoreImpl.resetInstance();
+    const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const reloaded = await store2.getRepository("local-folder-repo");
+
+    expect(reloaded?.source).toBe("local-folder");
+    expect(reloaded?.url).toBeNull();
+    expect(reloaded?.lastManifestId).toBe("repo_local_folder_repo");
+  });
+
+  test("validation rejects url=null when source is git-remote", async () => {
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const repo = createTestRepositoryInfo("bad-repo", {
+      source: "git-remote",
+      // Cast: deliberately violating the type contract to exercise the runtime guard
+      url: null as unknown as string,
+    });
+
+    await expect(store.updateRepository(repo)).rejects.toThrow(RepositoryMetadataError);
+  });
+
+  test("validation rejects an unknown source value", async () => {
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const repo = createTestRepositoryInfo("bad-source", {
+      // Cast: deliberately violating the type contract to exercise the runtime guard
+      source: "bogus" as unknown as RepositoryInfo["source"],
+    });
+
+    await expect(store.updateRepository(repo)).rejects.toThrow(RepositoryMetadataError);
+  });
+
+  test.each(["private", "work", "public"] as const)(
+    "round-trips tier value %s",
+    async (tier) => {
+      const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+      const repo = createTestRepositoryInfo("tier-repo", { tier });
+      await store.updateRepository(repo);
+
+      RepositoryMetadataStoreImpl.resetInstance();
+      const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+      const reloaded = await store2.getRepository("tier-repo");
+
+      expect(reloaded?.tier).toBe(tier);
+    }
+  );
+
+  test("round-trips tier=undefined as undefined (omitted)", async () => {
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const repo = createTestRepositoryInfo("no-tier-repo");
+    await store.updateRepository(repo);
+
+    RepositoryMetadataStoreImpl.resetInstance();
+    const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const reloaded = await store2.getRepository("no-tier-repo");
+
+    expect(reloaded?.tier).toBeUndefined();
+  });
+
+  test("round-trips lastManifestId", async () => {
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const repo = createTestRepositoryInfo("manifest-id-repo", {
+      source: "local-folder",
+      url: null,
+      lastManifestId: "repo_manifest_id_repo",
+    });
+    await store.updateRepository(repo);
+
+    RepositoryMetadataStoreImpl.resetInstance();
+    const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const reloaded = await store2.getRepository("manifest-id-repo");
+
+    expect(reloaded?.lastManifestId).toBe("repo_manifest_id_repo");
+  });
+
+  test("UpdateHistoryEntry preserves both 40-hex SHAs and local- markers", async () => {
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+
+    const gitEntry: UpdateHistoryEntry = {
+      timestamp: "2026-05-05T10:00:00.000Z",
+      previousCommit: "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      newCommit: "b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3",
+      filesAdded: 1,
+      filesModified: 0,
+      filesDeleted: 0,
+      chunksUpserted: 5,
+      chunksDeleted: 0,
+      durationMs: 100,
+      errorCount: 0,
+      status: "success",
+    };
+
+    const localEntry: UpdateHistoryEntry = {
+      timestamp: "2026-05-05T11:00:00.000Z",
+      previousCommit: "local-2026-05-05T10:30:00.000Z",
+      newCommit: "local-2026-05-05T11:00:00.000Z",
+      filesAdded: 0,
+      filesModified: 1,
+      filesDeleted: 0,
+      chunksUpserted: 2,
+      chunksDeleted: 0,
+      durationMs: 50,
+      errorCount: 0,
+      status: "success",
+    };
+
+    const repo = createTestRepositoryInfo("history-repo", {
+      source: "local-folder",
+      url: null,
+      updateHistory: [localEntry, gitEntry],
+    });
+    await store.updateRepository(repo);
+
+    RepositoryMetadataStoreImpl.resetInstance();
+    const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const reloaded = await store2.getRepository("history-repo");
+
+    expect(reloaded?.updateHistory).toHaveLength(2);
+    expect(reloaded?.updateHistory?.[0]?.previousCommit).toBe("local-2026-05-05T10:30:00.000Z");
+    expect(reloaded?.updateHistory?.[0]?.newCommit).toBe("local-2026-05-05T11:00:00.000Z");
+    expect(reloaded?.updateHistory?.[1]?.previousCommit).toBe(
+      "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+    );
+  });
+});
+
+/**
+ * Helper to construct a legacy-shape (pre-source-discriminator) repository
+ * record for synthesis tests. Returns a plain object — NOT typed as
+ * `RepositoryInfo`, since the whole point is that `source` is missing.
+ */
+function buildLegacyRepoRecord(name: string): Record<string, unknown> {
+  return {
+    name,
+    url: `https://github.com/legacy/${name}.git`,
+    localPath: `./data/repos/${name}`,
+    collectionName: `repo_${name}`,
+    fileCount: 1,
+    chunkCount: 1,
+    lastIndexedAt: "2024-01-01T00:00:00.000Z",
+    indexDurationMs: 1,
+    status: "ready",
+    branch: "main",
+    includeExtensions: [".ts"],
+    excludePatterns: [],
+  };
+}

--- a/tests/unit/repositories/metadata-store.test.ts
+++ b/tests/unit/repositories/metadata-store.test.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/await-thenable */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
 /**
  * Unit tests for RepositoryMetadataStoreImpl
  *
@@ -22,10 +26,7 @@ import {
   FileOperationError,
   InvalidMetadataFormatError,
 } from "../../../src/repositories/errors.js";
-import type {
-  RepositoryInfo,
-  UpdateHistoryEntry,
-} from "../../../src/repositories/types.js";
+import type { RepositoryInfo, UpdateHistoryEntry } from "../../../src/repositories/types.js";
 import {
   createTestRepositoryInfo,
   edgeCaseRepositoryNames,
@@ -521,8 +522,8 @@ describe("source discriminator + back-compat round-trip", () => {
     const legacyFile = {
       version: "1.0",
       repositories: {
-        "a": { ...buildLegacyRepoRecord("a") },
-        "b": { ...buildLegacyRepoRecord("b") },
+        a: { ...buildLegacyRepoRecord("a") },
+        b: { ...buildLegacyRepoRecord("b") },
       },
     };
     fs.writeFileSync(
@@ -579,20 +580,17 @@ describe("source discriminator + back-compat round-trip", () => {
     await expect(store.updateRepository(repo)).rejects.toThrow(RepositoryMetadataError);
   });
 
-  test.each(["private", "work", "public"] as const)(
-    "round-trips tier value %s",
-    async (tier) => {
-      const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
-      const repo = createTestRepositoryInfo("tier-repo", { tier });
-      await store.updateRepository(repo);
+  test.each(["private", "work", "public"] as const)("round-trips tier value %s", async (tier) => {
+    const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const repo = createTestRepositoryInfo("tier-repo", { tier });
+    await store.updateRepository(repo);
 
-      RepositoryMetadataStoreImpl.resetInstance();
-      const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
-      const reloaded = await store2.getRepository("tier-repo");
+    RepositoryMetadataStoreImpl.resetInstance();
+    const store2 = RepositoryMetadataStoreImpl.getInstance(tmpDir);
+    const reloaded = await store2.getRepository("tier-repo");
 
-      expect(reloaded?.tier).toBe(tier);
-    }
-  );
+    expect(reloaded?.tier).toBe(tier);
+  });
 
   test("round-trips tier=undefined as undefined (omitted)", async () => {
     const store = RepositoryMetadataStoreImpl.getInstance(tmpDir);

--- a/tests/unit/repositories/types.test.ts
+++ b/tests/unit/repositories/types.test.ts
@@ -16,6 +16,7 @@ describe("RepositoryInfo Type", () => {
       // This test validates TypeScript compilation - if it compiles, types are correct
       const repo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/test-repo",
         collectionName: "repo_test_repo",
@@ -50,6 +51,7 @@ describe("RepositoryInfo Type", () => {
       statuses.forEach((status) => {
         const repo: RepositoryInfo = {
           name: "test-repo",
+          source: "git-remote",
           url: "https://github.com/test/repo.git",
           localPath: "./data/repos/test-repo",
           collectionName: "repo_test_repo",
@@ -72,6 +74,7 @@ describe("RepositoryInfo Type", () => {
     test("should allow errorMessage when status is error", () => {
       const repo: RepositoryInfo = {
         name: "failed-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/failed-repo",
         collectionName: "repo_failed_repo",
@@ -93,6 +96,7 @@ describe("RepositoryInfo Type", () => {
     test("should allow omitting errorMessage", () => {
       const repo: RepositoryInfo = {
         name: "test-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/test-repo",
         collectionName: "repo_test_repo",
@@ -116,6 +120,7 @@ describe("RepositoryInfo Type", () => {
       // This validates backward compatibility
       const repo: RepositoryInfo = {
         name: "legacy-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/legacy-repo",
         collectionName: "repo_legacy_repo",
@@ -141,6 +146,7 @@ describe("RepositoryInfo Type", () => {
 
       const repo: RepositoryInfo = {
         name: "active-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/active-repo",
         collectionName: "repo_active_repo",
@@ -166,6 +172,7 @@ describe("RepositoryInfo Type", () => {
       // After initial full index, only SHA is set
       const repo: RepositoryInfo = {
         name: "fresh-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/fresh-repo",
         collectionName: "repo_fresh_repo",
@@ -189,6 +196,7 @@ describe("RepositoryInfo Type", () => {
       // Edge case: count set but timestamp not (shouldn't happen in practice)
       const repo: RepositoryInfo = {
         name: "edge-case-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/edge-case-repo",
         collectionName: "repo_edge_case_repo",
@@ -212,6 +220,7 @@ describe("RepositoryInfo Type", () => {
     test("should handle zero incremental update count", () => {
       const repo: RepositoryInfo = {
         name: "zero-count-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/zero-count-repo",
         collectionName: "repo_zero_count_repo",
@@ -234,6 +243,7 @@ describe("RepositoryInfo Type", () => {
       // Simulate a repository with many incremental updates
       const repo: RepositoryInfo = {
         name: "high-update-repo",
+        source: "git-remote",
         url: "https://github.com/test/repo.git",
         localPath: "./data/repos/high-update-repo",
         collectionName: "repo_high_update_repo",

--- a/tests/unit/services/document-search-service.test.ts
+++ b/tests/unit/services/document-search-service.test.ts
@@ -102,6 +102,7 @@ class MockEmbeddingProviderFactory {
 function createMockRepo(overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
   return {
     name: "test-folder",
+    source: "git-remote",
     url: "file:///docs",
     localPath: "/data/repos/test-folder",
     collectionName: "repo_test_folder",

--- a/tests/unit/services/file-manifest-store.test.ts
+++ b/tests/unit/services/file-manifest-store.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Unit tests for FileManifestStoreImpl
+ *
+ * Real-disk tests using a per-test tmpdir, mirroring the watched-folder-store
+ * unit-test pattern. The acceptance criterion in issue #564 is 100% line
+ * coverage for the manifest store, including the concurrent-write
+ * serialization path.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "bun:test";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as fs from "node:fs";
+import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
+import {
+  FileManifestStoreImpl,
+  type FileManifest,
+  type FileManifestEntry,
+} from "../../../src/services/file-manifest-store.js";
+
+beforeAll(() => {
+  initializeLogger({ level: "silent", format: "json" });
+});
+
+afterAll(() => {
+  resetLogger();
+});
+
+describe("FileManifestStoreImpl", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    FileManifestStoreImpl.resetInstance();
+    tmpDir = path.join(
+      os.tmpdir(),
+      `file-manifest-store-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+    );
+    fs.mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    FileManifestStoreImpl.resetInstance();
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  describe("Singleton Pattern", () => {
+    it("returns same instance on multiple getInstance calls", () => {
+      const a = FileManifestStoreImpl.getInstance(tmpDir);
+      const b = FileManifestStoreImpl.getInstance(tmpDir);
+      expect(a).toBe(b);
+    });
+
+    it("uses default DATA_PATH when no path provided", () => {
+      const instance = FileManifestStoreImpl.getInstance();
+      expect(instance).toBeDefined();
+    });
+
+    it("ignores subsequent dataPath after init (warns)", () => {
+      const first = FileManifestStoreImpl.getInstance(tmpDir);
+      const second = FileManifestStoreImpl.getInstance(`${tmpDir}-other`);
+      expect(second).toBe(first);
+    });
+
+    it("resetInstance() clears the singleton", () => {
+      const a = FileManifestStoreImpl.getInstance(tmpDir);
+      FileManifestStoreImpl.resetInstance();
+      const b = FileManifestStoreImpl.getInstance(tmpDir);
+      expect(a).not.toBe(b);
+    });
+  });
+
+  describe("getManifestPath", () => {
+    it("uses sanitizeCollectionName for filesystem-safe filenames", () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const filePath = store.getManifestPath("My-API");
+      expect(filePath).toBe(path.join(tmpDir, "manifests", "repo_my_api.json"));
+    });
+  });
+
+  describe("loadManifest", () => {
+    it("returns an empty manifest when no file exists (does NOT create the file)", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const manifest = await store.loadManifest("missing-repo");
+
+      expect(manifest.version).toBe("1.0");
+      expect(manifest.repository).toBe("missing-repo");
+      expect(manifest.files).toEqual({});
+      expect(typeof manifest.generatedAt).toBe("string");
+
+      // Confirm we did NOT write a manifest file as a side effect
+      expect(fs.existsSync(store.getManifestPath("missing-repo"))).toBe(false);
+    });
+
+    it("loads a previously saved manifest from disk", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const original = buildManifest("alpha", {
+        "src/index.ts": { sha256: "a".repeat(64), sizeBytes: 100, mtimeMs: 1234 },
+      });
+      await store.saveManifest("alpha", original);
+
+      // Reset the singleton so the in-memory cache doesn't short-circuit the read
+      FileManifestStoreImpl.resetInstance();
+      const store2 = FileManifestStoreImpl.getInstance(tmpDir);
+      const reloaded = await store2.loadManifest("alpha");
+
+      expect(reloaded.repository).toBe("alpha");
+      expect(reloaded.files["src/index.ts"]).toEqual({
+        sha256: "a".repeat(64),
+        sizeBytes: 100,
+        mtimeMs: 1234,
+      });
+    });
+
+    it("hits the in-memory cache on second load", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const m = buildManifest("cached-repo", {
+        "a.ts": { sha256: "b".repeat(64), sizeBytes: 1, mtimeMs: 1 },
+      });
+      await store.saveManifest("cached-repo", m);
+
+      // First load populates from save; delete the on-disk file to prove the
+      // second load returns the cached copy without touching disk.
+      const filePath = store.getManifestPath("cached-repo");
+      fs.unlinkSync(filePath);
+
+      const reloaded = await store.loadManifest("cached-repo");
+      expect(reloaded.files["a.ts"]?.sha256).toBe("b".repeat(64));
+    });
+
+    it("surfaces an error when the manifest file contains malformed JSON", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const filePath = store.getManifestPath("broken");
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(filePath, "{ this is not JSON }", "utf-8");
+
+      await expect(store.loadManifest("broken")).rejects.toThrow();
+    });
+
+    it("surfaces an error when the manifest fails schema validation", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const filePath = store.getManifestPath("schema-bad");
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify({ version: "0.9", repository: "schema-bad", files: {} }),
+        "utf-8"
+      );
+
+      await expect(store.loadManifest("schema-bad")).rejects.toThrow();
+    });
+
+    it("returns a deep-copied manifest so mutation does not pollute the cache", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      await store.saveManifest(
+        "iso",
+        buildManifest("iso", {
+          "a.ts": { sha256: "c".repeat(64), sizeBytes: 1, mtimeMs: 1 },
+        })
+      );
+      const first = await store.loadManifest("iso");
+      first.files["evil.ts"] = { sha256: "x".repeat(64), sizeBytes: 0, mtimeMs: 0 };
+
+      const second = await store.loadManifest("iso");
+      expect(second.files["evil.ts"]).toBeUndefined();
+    });
+  });
+
+  describe("saveManifest", () => {
+    it("auto-creates the manifests/ directory and writes a JSON file", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const filePath = store.getManifestPath("auto-dir");
+
+      // Manifests directory should NOT exist before the first save
+      expect(fs.existsSync(path.dirname(filePath))).toBe(false);
+
+      await store.saveManifest("auto-dir", buildManifest("auto-dir", {}));
+
+      expect(fs.existsSync(path.dirname(filePath))).toBe(true);
+      expect(fs.existsSync(filePath)).toBe(true);
+    });
+
+    it("persists the full manifest schema verbatim", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const manifest = buildManifest("schema", {
+        "lib/util.ts": { sha256: "d".repeat(64), sizeBytes: 42, mtimeMs: 9999 },
+        "src/main.ts": { sha256: "e".repeat(64), sizeBytes: 1024, mtimeMs: 1700000000000 },
+      });
+      manifest.generatedAt = "2026-05-05T12:00:00.000Z";
+
+      await store.saveManifest("schema", manifest);
+
+      const onDisk = JSON.parse(fs.readFileSync(store.getManifestPath("schema"), "utf-8"));
+      expect(onDisk).toEqual({
+        version: "1.0",
+        repository: "schema",
+        generatedAt: "2026-05-05T12:00:00.000Z",
+        files: {
+          "lib/util.ts": { sha256: "d".repeat(64), sizeBytes: 42, mtimeMs: 9999 },
+          "src/main.ts": { sha256: "e".repeat(64), sizeBytes: 1024, mtimeMs: 1700000000000 },
+        },
+      });
+    });
+
+    it("forces the persisted repository field to match the argument (storage authority)", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const manifest = buildManifest("WRONG-REPO", {});
+
+      await store.saveManifest("right-repo", manifest);
+
+      const onDisk = JSON.parse(fs.readFileSync(store.getManifestPath("right-repo"), "utf-8"));
+      expect(onDisk.repository).toBe("right-repo");
+    });
+
+    it("does not leave a .tmp file behind on success", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      await store.saveManifest("clean", buildManifest("clean", {}));
+
+      const filePath = store.getManifestPath("clean");
+      expect(fs.existsSync(`${filePath}.tmp`)).toBe(false);
+    });
+
+    it("cleans up the temp file when rename fails (target path is a directory)", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const filePath = store.getManifestPath("rename-fail");
+
+      // Pre-create the manifests/ directory plus a directory at the target
+      // file path. The rename in saveManifestInternal will fail because the
+      // destination is a directory, exercising the catch-block cleanup.
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.mkdirSync(filePath, { recursive: true });
+
+      await expect(
+        store.saveManifest("rename-fail", buildManifest("rename-fail", {}))
+      ).rejects.toThrow();
+
+      // Temp file should be gone (catch-block unlink ran)
+      expect(fs.existsSync(`${filePath}.tmp`)).toBe(false);
+      // Destination directory still exists (we didn't rmdir it)
+      expect(fs.statSync(filePath).isDirectory()).toBe(true);
+
+      // Clean up the directory we created so afterEach can remove tmpDir
+      fs.rmdirSync(filePath);
+    });
+  });
+
+  describe("deleteManifest", () => {
+    it("removes the manifest file and clears the cache", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      await store.saveManifest(
+        "to-delete",
+        buildManifest("to-delete", {
+          "a.ts": { sha256: "f".repeat(64), sizeBytes: 1, mtimeMs: 1 },
+        })
+      );
+      const filePath = store.getManifestPath("to-delete");
+      expect(fs.existsSync(filePath)).toBe(true);
+
+      await store.deleteManifest("to-delete");
+
+      expect(fs.existsSync(filePath)).toBe(false);
+
+      // After delete, loading returns the empty in-memory shape (cache cleared)
+      const reloaded = await store.loadManifest("to-delete");
+      expect(reloaded.files).toEqual({});
+    });
+
+    it("is idempotent when the manifest file does not exist", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      await expect(store.deleteManifest("never-existed")).resolves.toBeUndefined();
+    });
+
+    it("propagates non-ENOENT errors (target path is a directory)", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const filePath = store.getManifestPath("perm-denied");
+
+      // unlink on a directory throws EISDIR/EPERM (NOT ENOENT), so the
+      // store's catch block must propagate the error rather than swallow it.
+      fs.mkdirSync(path.dirname(filePath), { recursive: true });
+      fs.mkdirSync(filePath, { recursive: true });
+
+      await expect(store.deleteManifest("perm-denied")).rejects.toThrow();
+
+      // Clean up before afterEach
+      fs.rmdirSync(filePath);
+    });
+  });
+
+  describe("Concurrent-write serialization", () => {
+    it("serializes many parallel saves so the final file is the last queued payload", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const total = 50;
+
+      const writes: Promise<void>[] = [];
+      for (let i = 0; i < total; i++) {
+        writes.push(
+          store.saveManifest(
+            "concurrent",
+            buildManifest("concurrent", {
+              "a.ts": {
+                sha256: i.toString().padStart(64, "0"),
+                sizeBytes: i,
+                mtimeMs: i,
+              },
+            })
+          )
+        );
+      }
+      await Promise.all(writes);
+
+      // Re-read from disk by clearing the in-memory cache
+      FileManifestStoreImpl.resetInstance();
+      const store2 = FileManifestStoreImpl.getInstance(tmpDir);
+      const final = await store2.loadManifest("concurrent");
+
+      expect(final.files["a.ts"]?.sizeBytes).toBe(total - 1);
+      expect(final.files["a.ts"]?.sha256).toBe((total - 1).toString().padStart(64, "0"));
+    });
+  });
+
+  describe("Cross-repo isolation", () => {
+    it("writes to repo A do not affect repo B", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const aFile: FileManifestEntry = { sha256: "a".repeat(64), sizeBytes: 10, mtimeMs: 1 };
+      const bFile: FileManifestEntry = { sha256: "b".repeat(64), sizeBytes: 20, mtimeMs: 2 };
+
+      await store.saveManifest("alpha", buildManifest("alpha", { "x.ts": aFile }));
+      await store.saveManifest("beta", buildManifest("beta", { "y.ts": bFile }));
+
+      const alpha = await store.loadManifest("alpha");
+      const beta = await store.loadManifest("beta");
+
+      expect(alpha.files["x.ts"]).toEqual(aFile);
+      expect(alpha.files["y.ts"]).toBeUndefined();
+      expect(beta.files["y.ts"]).toEqual(bFile);
+      expect(beta.files["x.ts"]).toBeUndefined();
+    });
+  });
+});
+
+function buildManifest(
+  repository: string,
+  files: Record<string, FileManifestEntry>
+): FileManifest {
+  return {
+    version: "1.0",
+    repository,
+    generatedAt: new Date("2026-05-05T00:00:00.000Z").toISOString(),
+    files,
+  };
+}

--- a/tests/unit/services/file-manifest-store.test.ts
+++ b/tests/unit/services/file-manifest-store.test.ts
@@ -14,6 +14,7 @@ import * as fs from "node:fs";
 import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
 import {
   FileManifestStoreImpl,
+  FILE_MANIFEST_EMPTY_GENERATED_AT,
   type FileManifest,
   type FileManifestEntry,
 } from "../../../src/services/file-manifest-store.js";
@@ -74,10 +75,29 @@ describe("FileManifestStoreImpl", () => {
   });
 
   describe("getManifestPath", () => {
-    it("uses sanitizeCollectionName for filesystem-safe filenames", () => {
+    it("uses sanitizeCollectionName plus a hash suffix for filesystem-safe filenames", () => {
       const store = FileManifestStoreImpl.getInstance(tmpDir);
       const filePath = store.getManifestPath("My-API");
-      expect(filePath).toBe(path.join(tmpDir, "manifests", "repo_my_api.json"));
+      // Expected shape: <manifestsDir>/repo_my_api_<8-hex-hash>.json. The
+      // hash suffix is required to avoid collisions across case-distinct names
+      // (see "case-distinct names produce distinct manifest files" below).
+      expect(filePath).toMatch(
+        new RegExp(
+          `^${path
+            .join(tmpDir, "manifests", "repo_my_api_")
+            .replace(/\\/g, "\\\\")
+            .replace(/[.*+?^${}()|[\]/]/g, "\\$&")}[0-9a-f]{8}\\.json$`
+        )
+      );
+    });
+
+    it("case-distinct names produce distinct manifest files (Issue #2 regression)", () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const upper = store.getManifestPath("Foo");
+      const lower = store.getManifestPath("foo");
+      // sanitizeCollectionName lowercases both to repo_foo, but the hash
+      // suffix is computed over the original name, so the two files diverge.
+      expect(upper).not.toBe(lower);
     });
   });
 
@@ -224,6 +244,13 @@ describe("FileManifestStoreImpl", () => {
     });
 
     it("cleans up the temp file when rename fails (target path is a directory)", async () => {
+      // Cross-platform note: this test relies on `rename(tmp, dir)` rejecting
+      // with both POSIX-family errnos (EISDIR / ENOTDIR / EEXIST) and Windows
+      // errnos (EPERM / EACCES). All of those hit the same catch block in
+      // `saveManifestInternal`, so the cleanup assertion below is platform-
+      // agnostic. If a future runtime ever returns a successful rename here
+      // (Bun's underlying fs changing behavior), this test will silently pass
+      // for the wrong reason — keep an eye on it on first cross-platform CI.
       const store = FileManifestStoreImpl.getInstance(tmpDir);
       const filePath = store.getManifestPath("rename-fail");
 
@@ -338,6 +365,121 @@ describe("FileManifestStoreImpl", () => {
       expect(beta.files["y.ts"]).toEqual(bFile);
       expect(beta.files["x.ts"]).toBeUndefined();
     });
+
+    it("case-distinct repository names persist as distinct manifests on disk (Issue #2 regression)", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const upperFile: FileManifestEntry = {
+        sha256: "1".repeat(64),
+        sizeBytes: 1,
+        mtimeMs: 1,
+      };
+      const lowerFile: FileManifestEntry = {
+        sha256: "2".repeat(64),
+        sizeBytes: 2,
+        mtimeMs: 2,
+      };
+
+      await store.saveManifest("Foo", buildManifest("Foo", { "a.ts": upperFile }));
+      await store.saveManifest("foo", buildManifest("foo", { "a.ts": lowerFile }));
+
+      // Distinct on-disk files
+      const upperPath = store.getManifestPath("Foo");
+      const lowerPath = store.getManifestPath("foo");
+      expect(upperPath).not.toBe(lowerPath);
+      expect(fs.existsSync(upperPath)).toBe(true);
+      expect(fs.existsSync(lowerPath)).toBe(true);
+
+      // Each load returns the correct payload
+      FileManifestStoreImpl.resetInstance();
+      const reloaded = FileManifestStoreImpl.getInstance(tmpDir);
+      const upper = await reloaded.loadManifest("Foo");
+      const lower = await reloaded.loadManifest("foo");
+
+      expect(upper.files["a.ts"]?.sha256).toBe("1".repeat(64));
+      expect(lower.files["a.ts"]?.sha256).toBe("2".repeat(64));
+    });
+  });
+
+  describe("loadManifest sentinel timestamp (Issue #7)", () => {
+    it("returns the deterministic FILE_MANIFEST_EMPTY_GENERATED_AT sentinel when no manifest exists", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+
+      const first = await store.loadManifest("never-saved");
+      const second = await store.loadManifest("never-saved");
+
+      expect(first.generatedAt).toBe(FILE_MANIFEST_EMPTY_GENERATED_AT);
+      expect(second.generatedAt).toBe(FILE_MANIFEST_EMPTY_GENERATED_AT);
+      expect(first.generatedAt).toBe(second.generatedAt);
+    });
+  });
+
+  describe("computeManifestId (Issue #10)", () => {
+    it("returns a stable identifier round-tripped through save/load", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+      const id = store.computeManifestId("my-repo");
+      // The identifier MUST work as the lookup key — saving with the repo
+      // name and loading with computeManifestId(name) returns the same data.
+      await store.saveManifest("my-repo", buildManifest("my-repo", {
+        "a.ts": { sha256: "f".repeat(64), sizeBytes: 1, mtimeMs: 1 },
+      }));
+      const loaded = await store.loadManifest(id);
+      expect(loaded.files["a.ts"]?.sha256).toBe("f".repeat(64));
+    });
+  });
+
+  describe("Write-queue resilience (Issue #4)", () => {
+    it("a failed save does not poison the queue for subsequent saves", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+
+      // Force the first save to fail by pre-creating a directory at its
+      // destination (same trick used by the rename-fail test).
+      const failPath = store.getManifestPath("queue-fail");
+      fs.mkdirSync(path.dirname(failPath), { recursive: true });
+      fs.mkdirSync(failPath, { recursive: true });
+
+      await expect(
+        store.saveManifest("queue-fail", buildManifest("queue-fail", {}))
+      ).rejects.toThrow();
+
+      // The next save (different repo, different path) MUST succeed even
+      // though the queue head was previously rejected.
+      const okEntry: FileManifestEntry = { sha256: "9".repeat(64), sizeBytes: 1, mtimeMs: 1 };
+      await store.saveManifest(
+        "queue-ok",
+        buildManifest("queue-ok", { "a.ts": okEntry })
+      );
+
+      const reloaded = await store.loadManifest("queue-ok");
+      expect(reloaded.files["a.ts"]).toEqual(okEntry);
+
+      // Clean up the directory we created so afterEach can remove tmpDir
+      fs.rmdirSync(failPath);
+    });
+
+    it("a failed delete does not poison the queue for subsequent deletes", async () => {
+      const store = FileManifestStoreImpl.getInstance(tmpDir);
+
+      // Create a manifest, then make its on-disk path a directory so the
+      // unlink in deleteManifestInternal throws a non-ENOENT error.
+      await store.saveManifest(
+        "del-poison",
+        buildManifest("del-poison", {
+          "a.ts": { sha256: "a".repeat(64), sizeBytes: 1, mtimeMs: 1 },
+        })
+      );
+      const filePath = store.getManifestPath("del-poison");
+      fs.unlinkSync(filePath);
+      fs.mkdirSync(filePath);
+
+      await expect(store.deleteManifest("del-poison")).rejects.toThrow();
+
+      // A subsequent delete on a different (non-existent) repo MUST succeed
+      // (idempotent missing-file path) instead of inheriting the rejection.
+      await expect(store.deleteManifest("never-existed")).resolves.toBeUndefined();
+
+      // Clean up the directory we created so afterEach can remove tmpDir
+      fs.rmdirSync(filePath);
+    });
   });
 });
 
@@ -346,7 +488,7 @@ function buildManifest(
   files: Record<string, FileManifestEntry>
 ): FileManifest {
   return {
-    version: "1.0",
+    version: "1.0" as const,
     repository,
     generatedAt: new Date("2026-05-05T00:00:00.000Z").toISOString(),
     files,

--- a/tests/unit/services/file-manifest-store.test.ts
+++ b/tests/unit/services/file-manifest-store.test.ts
@@ -1,3 +1,7 @@
+/* eslint-disable @typescript-eslint/await-thenable */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
 /**
  * Unit tests for FileManifestStoreImpl
  *
@@ -419,9 +423,12 @@ describe("FileManifestStoreImpl", () => {
       const id = store.computeManifestId("my-repo");
       // The identifier MUST work as the lookup key — saving with the repo
       // name and loading with computeManifestId(name) returns the same data.
-      await store.saveManifest("my-repo", buildManifest("my-repo", {
-        "a.ts": { sha256: "f".repeat(64), sizeBytes: 1, mtimeMs: 1 },
-      }));
+      await store.saveManifest(
+        "my-repo",
+        buildManifest("my-repo", {
+          "a.ts": { sha256: "f".repeat(64), sizeBytes: 1, mtimeMs: 1 },
+        })
+      );
       const loaded = await store.loadManifest(id);
       expect(loaded.files["a.ts"]?.sha256).toBe("f".repeat(64));
     });
@@ -444,10 +451,7 @@ describe("FileManifestStoreImpl", () => {
       // The next save (different repo, different path) MUST succeed even
       // though the queue head was previously rejected.
       const okEntry: FileManifestEntry = { sha256: "9".repeat(64), sizeBytes: 1, mtimeMs: 1 };
-      await store.saveManifest(
-        "queue-ok",
-        buildManifest("queue-ok", { "a.ts": okEntry })
-      );
+      await store.saveManifest("queue-ok", buildManifest("queue-ok", { "a.ts": okEntry }));
 
       const reloaded = await store.loadManifest("queue-ok");
       expect(reloaded.files["a.ts"]).toEqual(okEntry);
@@ -483,10 +487,7 @@ describe("FileManifestStoreImpl", () => {
   });
 });
 
-function buildManifest(
-  repository: string,
-  files: Record<string, FileManifestEntry>
-): FileManifest {
+function buildManifest(repository: string, files: Record<string, FileManifestEntry>): FileManifest {
   return {
     version: "1.0" as const,
     repository,

--- a/tests/unit/services/interrupted-update-detector.test.ts
+++ b/tests/unit/services/interrupted-update-detector.test.ts
@@ -27,6 +27,7 @@ afterAll(() => {
 function createMockRepo(overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
   return {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/test/test-repo.git",
     localPath: "/data/repos/test-repo",
     collectionName: "repo_test_repo",

--- a/tests/unit/services/interrupted-update-recovery.test.ts
+++ b/tests/unit/services/interrupted-update-recovery.test.ts
@@ -31,6 +31,7 @@ afterAll(() => {
 function createMockRepo(overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
   return {
     name: "test-repo",
+    source: "git-remote",
     url: "https://github.com/test/test-repo.git",
     localPath: process.cwd(),
     collectionName: "repo_test_repo",


### PR DESCRIPTION
## Summary

Re-targets the Phase A foundation work for [#564](https://github.com/sethships/PersonalKnowledgeMCP/issues/564) at `main`. This is a clean replay of the two non-merge commits originally landed via PR #569 — those got merged into the `docs/local-folder-as-repository` branch instead of `main`, which polluted the docs PR (#563) with code. See #563 for the cleanup context.

Closes #564.

## Commits

- `feat(#564): Phase A foundation — data model + manifest plumbing` (cherry-pick of `a9a4022`)
- `fix(#564): apply review fixes from PR #569` (cherry-pick of `54a5c0c`)

Both were already reviewed under PR #569; the 11 reviewer findings from that thread are addressed in the second commit.

## What landed

**T1.1** — `RepositoryInfo` discriminator: `source: "git-remote" | "local-git" | "local-folder"`, nullable `url` (only when `source === "local-folder"`), optional `tier` and `lastManifestId`. Legacy records synthesize `source: "git-remote"` on read.

**T1.2** — `metadata-store.ts` read/write paths: discriminator validation, nullable url accepted only for local-folder, round-trip tests for all three source values.

**T1.3** — `UpdateHistoryEntry` JSDoc relaxed to document `local-<isoDate>` synthetic markers as a valid alternative to 40-hex SHAs (no runtime change).

**T1.4** — New `src/services/file-manifest-store.ts`: singleton + atomic-write + serialized-write-queue + per-repo cache, mirroring `watched-folder-store.ts`. 100% line + function coverage.

**Consumer adjustments** — 7 production sites patched with non-null assertions on `url` at the boundary (Phase B will replace these with proper guards once `LocalFolderUpdateCoordinator` is wired in).

## Verification

- `bun run typecheck` clean (against the cherry-picked content; pre-existing local WIP file excluded)
- `bun run build` clean
- Full suite was green on PR #569 prior to merge

## Follow-ups already filed

- #570 — discriminated union refactor for Phase B
- #571 — watched-folder-store write-queue sibling fix

## Note on PR #569

PR #569 will be commented to point reviewers/history at this PR. It remains as a historical artifact of the original review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)