### PR TITLE
feat(#565): Phase B — local folder lifecycle (initial scan + incremental update)

### DIFF
--- a/src/cli/commands/reset-update-command.ts
+++ b/src/cli/commands/reset-update-command.ts
@@ -160,6 +160,7 @@ export async function resetUpdateCommand(
         repositoryService: deps.repositoryService,
         ingestionService: deps.ingestionService,
         updateCoordinator: deps.updateCoordinator,
+        localFolderCoordinator: deps.localFolderCoordinator,
       }
     );
 
@@ -221,6 +222,7 @@ export async function resetUpdateCommand(
       repositoryService: deps.repositoryService,
       ingestionService: deps.ingestionService,
       updateCoordinator: deps.updateCoordinator,
+      localFolderCoordinator: deps.localFolderCoordinator,
     });
 
     if (result.success) {

--- a/src/cli/commands/update-all-command.ts
+++ b/src/cli/commands/update-all-command.ts
@@ -11,6 +11,7 @@ import ora from "ora";
 import Table from "cli-table3";
 import type { CliDependencies } from "../utils/dependency-init.js";
 import type { CoordinatorResult } from "../../services/incremental-update-coordinator-types.js";
+import { dispatchCoordinator } from "../../services/update-coordinator-dispatch.js";
 
 /**
  * Update all repositories command options
@@ -166,7 +167,26 @@ export async function updateAllCommand(
     }).start();
 
     try {
-      const result = await deps.updateCoordinator.updateRepository(repo.name);
+      // Phase B: dispatch by source so local-folder repos use their manifest-based
+      // coordinator instead of the git coordinator.
+      const coordinator = dispatchCoordinator(
+        repo,
+        deps.updateCoordinator,
+        deps.localFolderCoordinator
+      );
+      if (!coordinator) {
+        spinner.fail(
+          chalk.red(
+            `${repo.name}: source='${repo.source}' but no local-folder coordinator configured`
+          )
+        );
+        results.push({
+          repository: repo.name,
+          error: "Local-folder coordinator not configured on this build",
+        });
+        continue;
+      }
+      const result = await coordinator.updateRepository(repo.name);
 
       // Stop spinner based on result
       if (result.status === "no_changes") {

--- a/src/cli/commands/update-repository-command.ts
+++ b/src/cli/commands/update-repository-command.ts
@@ -11,6 +11,7 @@ import ora from "ora";
 import type { CliDependencies } from "../utils/dependency-init.js";
 import type { CoordinatorResult } from "../../services/incremental-update-coordinator-types.js";
 import type { FileProcessingError } from "../../services/incremental-update-types.js";
+import { dispatchCoordinator } from "../../services/update-coordinator-dispatch.js";
 import {
   clearInterruptedUpdateFlag,
   formatElapsedTime,
@@ -171,11 +172,19 @@ export async function updateRepositoryCommand(
     }).start();
 
     try {
-      // url is non-null for git-remote and local-git sources. Phase B will
-      // dispatch to LocalFolderUpdateCoordinator for local-folder repos.
-      const result = await deps.ingestionService.indexRepository(repo.url!, {
+      // For git-remote and local-git, force re-index from the original URL /
+      // local path. For local-folder, the registered `localPath` IS the source —
+      // `repo.url` is null by design, so passing `repo.url!` would crash in
+      // `validateUrl`. `isLocalPath` accepts the localPath in both cases, so
+      // re-running indexRepository against it correctly hits the local-path
+      // branch and the source detection (.git presence) will reaffirm the
+      // existing source discriminator.
+      const sourceForReindex = repo.url ?? repo.localPath;
+      const result = await deps.ingestionService.indexRepository(sourceForReindex, {
+        name: repo.name,
         branch: repo.branch,
         force: true,
+        tier: repo.tier,
         onProgress: (progress) => {
           spinner.text = `Force re-indexing ${chalk.cyan(repositoryName)} - ${progress.phase}...`;
         },
@@ -232,7 +241,19 @@ export async function updateRepositoryCommand(
   }).start();
 
   try {
-    const result = await deps.updateCoordinator.updateRepository(repositoryName);
+    // Phase B: dispatch by source so local-folder repos use their manifest-based
+    // coordinator instead of the git coordinator (which requires lastIndexedCommitSha).
+    const coordinator = dispatchCoordinator(
+      repo,
+      deps.updateCoordinator,
+      deps.localFolderCoordinator
+    );
+    if (!coordinator) {
+      throw new Error(
+        `Cannot update '${repositoryName}': repository has source '${repo.source}' but no local-folder coordinator is configured.`
+      );
+    }
+    const result = await coordinator.updateRepository(repositoryName);
 
     // Handle no changes
     if (result.status === "no_changes") {

--- a/src/cli/utils/dependency-init.ts
+++ b/src/cli/utils/dependency-init.ts
@@ -40,6 +40,8 @@ import { DocumentChunker } from "../../documents/DocumentChunker.js";
 import { DocumentTypeDetector } from "../../documents/DocumentTypeDetector.js";
 import { WatchedFolderStoreImpl } from "../../services/watched-folder-store.js";
 import type { WatchedFolderStoreService } from "../../services/watched-folder-store.js";
+import { FileManifestStoreImpl } from "../../services/file-manifest-store.js";
+import { pruneOrphanManifests } from "../../services/orphan-manifest-reaper.js";
 
 /**
  * Parse integer from environment variable with validation
@@ -266,6 +268,16 @@ export async function initializeDependencies(
     // Step 5: Initialize repository metadata service (singleton)
     const repositoryService = RepositoryMetadataStoreImpl.getInstance(config.data.path);
     logger.debug("Repository metadata service initialized");
+
+    // Step 5a: Reap orphan FileManifests (PR #573 review M-2). Best-effort —
+    // a failure here doesn't block CLI bootstrap. Mirrors the wiring in
+    // src/index.ts so MCP boot and CLI boot share the same hygiene.
+    try {
+      const manifestStore = FileManifestStoreImpl.getInstance(config.data.path);
+      await pruneOrphanManifests(repositoryService, manifestStore);
+    } catch (err) {
+      logger.warn({ err }, "Orphan manifest reaper failed (continuing CLI bootstrap)");
+    }
 
     // Step 6: Initialize search service
     const searchService = new SearchServiceImpl(

--- a/src/cli/utils/dependency-init.ts
+++ b/src/cli/utils/dependency-init.ts
@@ -26,6 +26,7 @@ import { FileChunker } from "../../ingestion/file-chunker.js";
 import { GitHubClientImpl } from "../../services/github-client.js";
 import { IncrementalUpdatePipeline } from "../../services/incremental-update-pipeline.js";
 import { IncrementalUpdateCoordinator } from "../../services/incremental-update-coordinator.js";
+import { LocalFolderUpdateCoordinator } from "../../services/local-folder-update-coordinator.js";
 import { IndexCompletenessChecker } from "../../services/index-completeness-checker.js";
 import { TokenServiceImpl } from "../../auth/token-service.js";
 import { TokenStoreImpl } from "../../auth/token-store.js";
@@ -93,6 +94,8 @@ export interface CliDependencies {
   githubClient: GitHubClient;
   updatePipeline: IncrementalUpdatePipeline;
   updateCoordinator: IncrementalUpdateCoordinator;
+  /** Coordinator for `local-folder` source repos (used by trigger_incremental_update). */
+  localFolderCoordinator: LocalFolderUpdateCoordinator;
   tokenService: TokenService;
   /** Optional graph adapter for graph database operations (only if configured) */
   graphAdapter?: GraphStorageAdapter;
@@ -431,6 +434,17 @@ export async function initializeDependencies(
       "Incremental update coordinator initialized"
     );
 
+    // Local-folder coordinator shares the metadata service + pipeline; it owns
+    // its own change detector and uses the FileManifestStore singleton.
+    const localFolderCoordinator = new LocalFolderUpdateCoordinator(
+      repositoryService,
+      updatePipeline,
+      undefined,
+      undefined,
+      { updateHistoryLimit }
+    );
+    logger.debug("Local folder update coordinator initialized");
+
     return {
       embeddingProvider,
       chromaClient,
@@ -440,6 +454,7 @@ export async function initializeDependencies(
       githubClient,
       updatePipeline,
       updateCoordinator,
+      localFolderCoordinator,
       tokenService,
       graphAdapter,
       graphIngestionService,

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import { FileScanner } from "./ingestion/file-scanner.js";
 import { GitHubClientImpl } from "./services/github-client.js";
 import { IncrementalUpdatePipeline } from "./services/incremental-update-pipeline.js";
 import { IncrementalUpdateCoordinator } from "./services/incremental-update-coordinator.js";
+import { LocalFolderUpdateCoordinator } from "./services/local-folder-update-coordinator.js";
 import { IndexCompletenessChecker } from "./services/index-completeness-checker.js";
 import { MCPRateLimiter } from "./mcp/rate-limiter.js";
 import { JobTracker } from "./mcp/job-tracker.js";
@@ -339,6 +340,7 @@ async function main(): Promise<void> {
 
     // Step 5b: Initialize incremental update dependencies (optional - requires GITHUB_PAT)
     let updateCoordinator: IncrementalUpdateCoordinator | undefined;
+    let localFolderCoordinator: LocalFolderUpdateCoordinator | undefined;
     let rateLimiter: MCPRateLimiter | undefined;
     let jobTracker: JobTracker | undefined;
     let updateToolsUnavailableReason: string | undefined;
@@ -400,6 +402,12 @@ async function main(): Promise<void> {
           { completenessChecker }
         );
 
+        // Local-folder coordinator shares the metadata service + pipeline.
+        localFolderCoordinator = new LocalFolderUpdateCoordinator(
+          repositoryService,
+          updatePipeline
+        );
+
         // Create rate limiter (2-second cooldown by default, configurable via UPDATE_RATE_LIMIT_MS)
         rateLimiter = new MCPRateLimiter();
 
@@ -415,6 +423,7 @@ async function main(): Promise<void> {
           "Incremental update initialization failed - MCP update tools will be unavailable"
         );
         updateCoordinator = undefined;
+        localFolderCoordinator = undefined;
         rateLimiter = undefined;
         jobTracker = undefined;
         updateToolsUnavailableReason = `Initialization failed: ${errorMsg}`;
@@ -439,6 +448,7 @@ async function main(): Promise<void> {
       {
         graphService,
         updateCoordinator,
+        localFolderCoordinator,
         rateLimiter,
         jobTracker,
         documentSearchService,

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,8 @@ import {
   formatElapsedTime,
 } from "./services/interrupted-update-detector.js";
 import { evaluateRecoveryStrategy } from "./services/interrupted-update-recovery.js";
+import { pruneOrphanManifests } from "./services/orphan-manifest-reaper.js";
+import { FileManifestStoreImpl } from "./services/file-manifest-store.js";
 import {
   createHttpApp,
   startHttpServer,
@@ -201,6 +203,17 @@ async function main(): Promise<void> {
     logger.info("Initializing repository metadata service");
     const repositoryService = RepositoryMetadataStoreImpl.getInstance(config.data.path);
     logger.info("Repository metadata service initialized");
+
+    // Step 4a: Reap orphan FileManifests left behind by crashed registrations.
+    // A `local-folder` registration that crashes between manifest write and
+    // metadata write would otherwise leave a manifest the metadata store has
+    // no knowledge of. Best-effort, non-fatal — boot continues on failure.
+    try {
+      const manifestStore = FileManifestStoreImpl.getInstance(config.data.path);
+      await pruneOrphanManifests(repositoryService, manifestStore);
+    } catch (err) {
+      logger.warn({ err }, "Orphan manifest reaper failed (continuing startup)");
+    }
 
     // Step 4b: Check for interrupted updates from previous service crashes
     logger.debug("Checking for interrupted updates");

--- a/src/ingestion/file-eligibility.ts
+++ b/src/ingestion/file-eligibility.ts
@@ -1,0 +1,209 @@
+/**
+ * Shared file/directory eligibility predicates for local-folder traversals.
+ *
+ * Three call sites previously walked the local-folder tree with three slightly
+ * different filter chains:
+ *
+ *   1. `FileScanner` (the actual indexing scan) — applies `GitignoreFilter`,
+ *      extension whitelist, `DEFAULT_EXCLUSIONS`, glob's `dot: false`, AND a
+ *      1 MiB size cap.
+ *   2. `LocalFolderChangeDetector` (per-update diff) — applied only the
+ *      gitignore filter + extension whitelist.
+ *   3. `IngestionService.enforceLocalFolderSizeGuardrails` (size pre-scan) —
+ *      same as the change detector.
+ *
+ * The divergence produced two real correctness bugs (PR #573 review H-1+H-2):
+ * change detection emitted spurious `added` events for files the scanner
+ * subsequently discarded (size, dotfiles, default exclusions), and the size
+ * guard tripped its hard refusal on files the scanner would never touch.
+ *
+ * This module centralizes the per-entry rules so all three callers agree:
+ *
+ *   - `shouldDescendDir(absDir, dirName, gitignore)` decides whether to walk
+ *     INTO a directory entry.
+ *   - `shouldIncludeFile(absPath, ent, opts)` decides whether to report a file.
+ *
+ * Notably, `shouldDescendDir` hard-skips standard VCS metadata directories
+ * (`.git`, `.hg`, `.svn`, `.bzr`, `_darcs`) — addresses review L-1.
+ *
+ * @module ingestion/file-eligibility
+ */
+
+import { stat as fsStat } from "node:fs/promises";
+import type { Stats } from "node:fs";
+import type { GitignoreFilter } from "./gitignore-filter.js";
+
+/**
+ * Default per-pattern exclusions applied by `FileScanner`. Mirrored here so
+ * the local-folder change detector and the size guardrail respect the same
+ * set without re-running glob.
+ *
+ * Patterns are intentionally simple and matched as POSIX path segments rather
+ * than via a full glob engine — `FileScanner` already filtered through `glob`
+ * by the time these are evaluated, but the change detector and size guard
+ * walk the raw filesystem and need a cheap predicate.
+ */
+export const DEFAULT_EXCLUSION_DIR_NAMES: ReadonlySet<string> = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  "bin",
+  "obj",
+]);
+
+/**
+ * Filename patterns that the scanner's `DEFAULT_EXCLUSIONS` reject regardless
+ * of their parent directory. Stored as a literal-name set (no globs needed —
+ * these are exact basenames or single-suffix matches handled inline).
+ */
+export const DEFAULT_EXCLUSION_FILE_NAMES: ReadonlySet<string> = new Set([
+  "package-lock.json",
+  "yarn.lock",
+]);
+
+/**
+ * Standard VCS metadata directories. These are always skipped during walks —
+ * they contain no source content the indexer cares about and may include
+ * arbitrarily large object stores.
+ */
+export const VCS_METADATA_DIR_NAMES: ReadonlySet<string> = new Set([
+  ".git",
+  ".hg",
+  ".svn",
+  ".bzr",
+  "_darcs",
+]);
+
+/**
+ * Default maximum file size for indexable content (1 MiB).
+ *
+ * Mirrors `FileScanner.MAX_FILE_SIZE_BYTES`. Surfaced here so the change
+ * detector and size guardrail can apply the same ceiling without depending
+ * on `FileScanner` (which would create a cyclic-ish dependency through
+ * `services/`).
+ */
+export const DEFAULT_MAX_FILE_SIZE_BYTES = 1_048_576;
+
+/** Lightweight directory entry shape, decoupled from `fs.Dirent`. */
+export interface DirEntryLike {
+  name: string;
+  isDir: boolean;
+  isSymlink: boolean;
+}
+
+/** Options accepted by {@link shouldIncludeFile}. */
+export interface FileEligibilityOptions {
+  /** Pre-loaded nested .gitignore filter rooted at the folder's root. */
+  gitignore: GitignoreFilter;
+  /**
+   * Lowercased extension whitelist (each entry must include a leading dot,
+   * e.g. `".ts"`). Empty set means "include nothing"; callers should populate
+   * with `DEFAULT_EXTENSIONS` when no override is configured.
+   */
+  extensions: ReadonlySet<string>;
+  /**
+   * Maximum file size in bytes. Files at or below this size pass; files above
+   * are excluded. Match the scanner's 1 MiB ceiling unless callers have a
+   * specific reason to deviate.
+   */
+  maxSizeBytes: number;
+  /**
+   * Optional injection hook for `fs.stat`. Defaults to `node:fs/promises.stat`.
+   * Tests pass in fakes here; production callers should leave undefined.
+   */
+  stat?: (path: string) => Promise<Stats>;
+}
+
+/**
+ * Decide whether a directory entry should be descended into during a walk.
+ *
+ * Hard-skips:
+ *   - VCS metadata dirs ({@link VCS_METADATA_DIR_NAMES})
+ *   - dependency / build artifact directories
+ *     ({@link DEFAULT_EXCLUSION_DIR_NAMES})
+ *   - dotfile-prefixed directories (matches `glob`'s `dot: false`)
+ *   - directories the {@link GitignoreFilter} reports as ignored
+ *
+ * Symlink-resolved directories are NOT covered here; callers must
+ * pre-filter `entry.isSymbolicLink()` since walking a symlink risks cycles
+ * and out-of-tree escape.
+ *
+ * @param absDirPath Absolute path of the directory being considered.
+ * @param dirName Basename of the directory.
+ * @param gitignore Pre-loaded nested .gitignore filter.
+ */
+export function shouldDescendDir(
+  absDirPath: string,
+  dirName: string,
+  gitignore: GitignoreFilter
+): boolean {
+  if (VCS_METADATA_DIR_NAMES.has(dirName)) return false;
+  if (DEFAULT_EXCLUSION_DIR_NAMES.has(dirName)) return false;
+  // Match glob's `dot: false`: dot-prefixed directories are not traversed.
+  if (dirName.startsWith(".")) return false;
+  if (gitignore.isIgnored(absDirPath)) return false;
+  return true;
+}
+
+/**
+ * Decide whether a file entry should be included by a walk.
+ *
+ * Mirrors `FileScanner.collectFileMetadata` exactly:
+ *   - skip symlinks (cycle / escape risk)
+ *   - skip dot-prefixed file names (glob `dot: false` parity)
+ *   - skip per-pattern excluded basenames (`package-lock.json`, `*.min.js`,
+ *     `*.min.css`, `yarn.lock`)
+ *   - apply the gitignore filter
+ *   - require the file extension to be in the whitelist
+ *   - reject files larger than `maxSizeBytes`
+ *
+ * `stat` is invoked only after the cheap predicates pass (extension and name
+ * checks), to avoid an `fs.stat` per ineligible file.
+ *
+ * @returns A {@link FileEligibilityResult} describing whether the file is
+ *   eligible and, when it is, the file's `Stats`. Returning the stats lets
+ *   callers reuse them without a second syscall.
+ */
+export interface FileEligibilityResult {
+  eligible: boolean;
+  /** Populated only when `eligible === true`. */
+  stats?: Stats;
+}
+
+export async function shouldIncludeFile(
+  absPath: string,
+  ent: DirEntryLike,
+  opts: FileEligibilityOptions
+): Promise<FileEligibilityResult> {
+  // Symlinks: never (cycle / out-of-tree escape).
+  if (ent.isSymlink) return { eligible: false };
+  // Dot-prefixed filenames mirror glob's `dot: false`.
+  if (ent.name.startsWith(".")) return { eligible: false };
+  // Default exclusion basenames (lockfiles, minified builds).
+  if (DEFAULT_EXCLUSION_FILE_NAMES.has(ent.name)) return { eligible: false };
+  if (ent.name.endsWith(".min.js") || ent.name.endsWith(".min.css")) {
+    return { eligible: false };
+  }
+
+  // Extension whitelist (lowercased lookup, must include leading dot).
+  const dotIdx = ent.name.lastIndexOf(".");
+  const ext = dotIdx >= 0 ? ent.name.substring(dotIdx).toLowerCase() : "";
+  if (!opts.extensions.has(ext)) return { eligible: false };
+
+  // .gitignore is evaluated before stat() to avoid a syscall on ignored files.
+  if (opts.gitignore.isIgnored(absPath)) return { eligible: false };
+
+  const stat = opts.stat ?? fsStat;
+  let st: Stats;
+  try {
+    st = await stat(absPath);
+  } catch {
+    return { eligible: false };
+  }
+
+  // Defensive: reject anything that isn't a regular file.
+  if (!st.isFile()) return { eligible: false };
+  if (st.size > opts.maxSizeBytes) return { eligible: false };
+
+  return { eligible: true, stats: st };
+}

--- a/src/ingestion/file-scanner.ts
+++ b/src/ingestion/file-scanner.ts
@@ -17,6 +17,7 @@ import { getComponentLogger } from "../logging/index.js";
 import type { ScanOptions, FileInfo, FileScannerConfig } from "./types.js";
 import { ValidationError, FileScanError } from "./errors.js";
 import { DEFAULT_EXTENSIONS } from "./default-extensions.js";
+import { GitignoreFilter } from "./gitignore-filter.js";
 
 /**
  * Scans repository directories to identify files for indexing.
@@ -140,8 +141,13 @@ export class FileScanner {
       // 1. Validate and normalize repository path
       const normalizedRepoPath = await this.validateRepoPath(repoPath);
 
-      // 2. Load .gitignore rules
-      const gitignore = await this.loadGitignore(normalizedRepoPath);
+      // 2. Load .gitignore rules. For nested mode (local-folder / local-git),
+      //    walk the tree to merge every .gitignore; otherwise use the cheap
+      //    root-only loader that has shipped since before this feature.
+      const nestedFilter = options.respectNestedGitignore
+        ? await GitignoreFilter.load(normalizedRepoPath)
+        : null;
+      const gitignore = nestedFilter ? null : await this.loadGitignore(normalizedRepoPath);
 
       // 3. Determine extensions and exclusions
       const extensions = options.includeExtensions ?? [...DEFAULT_EXTENSIONS];
@@ -153,7 +159,9 @@ export class FileScanner {
       this.logger.debug({ count: matchedPaths.length }, "Glob scan complete, applying gitignore");
 
       // 5. Apply gitignore filtering
-      const filteredPaths = this.applyGitignoreFilter(matchedPaths, gitignore);
+      const filteredPaths = nestedFilter
+        ? this.applyNestedGitignoreFilter(normalizedRepoPath, matchedPaths, nestedFilter)
+        : this.applyGitignoreFilter(matchedPaths, gitignore!);
 
       this.logger.debug(
         { before: matchedPaths.length, after: filteredPaths.length },
@@ -360,6 +368,25 @@ export class FileScanner {
   private applyGitignoreFilter(paths: string[], gitignore: ReturnType<typeof ignore>): string[] {
     // The ignore library's filter() method returns paths NOT ignored
     return gitignore.filter(paths);
+  }
+
+  /**
+   * Apply nested .gitignore filtering using the GitignoreFilter.
+   *
+   * Each candidate path is evaluated against every .gitignore from the repo
+   * root down to the file's directory; deeper rules override shallower ones.
+   *
+   * @param repoPath - Absolute repo root (paths are relative to this)
+   * @param paths - Repo-relative file paths from the glob scan
+   * @param filter - Pre-loaded nested filter
+   * @returns Repo-relative paths that survive the filter
+   */
+  private applyNestedGitignoreFilter(
+    repoPath: string,
+    paths: string[],
+    filter: GitignoreFilter
+  ): string[] {
+    return paths.filter((rel) => !filter.isIgnored(join(repoPath, rel)));
   }
 
   /**

--- a/src/ingestion/gitignore-filter.ts
+++ b/src/ingestion/gitignore-filter.ts
@@ -153,9 +153,7 @@ export class GitignoreFilter {
     for (let i = this.rules.length - 1; i >= 0; i--) {
       const rule = this.rules[i]!;
       if (!GitignoreFilter.isWithin(rule.dir, abs)) continue;
-      const relToRule = posix.normalize(
-        relative(rule.dir, abs).split(sep).join(posix.sep)
-      );
+      const relToRule = posix.normalize(relative(rule.dir, abs).split(sep).join(posix.sep));
       if (!relToRule || relToRule.startsWith("..")) continue;
       const verdict = rule.ig.test(relToRule);
       if (verdict.ignored || verdict.unignored) {

--- a/src/ingestion/gitignore-filter.ts
+++ b/src/ingestion/gitignore-filter.ts
@@ -145,13 +145,23 @@ export class GitignoreFilter {
       return true;
     }
 
-    for (const rule of this.rules) {
+    // Git semantics: rules are evaluated from shallowest .gitignore down to
+    // deepest, and the LAST .gitignore with an explicit verdict wins. A
+    // negation (`!keep.txt`) in a nested .gitignore therefore overrides a
+    // matching rule from a shallower one. Walk in reverse (deepest first) and
+    // return as soon as some .gitignore has an explicit opinion on the file.
+    for (let i = this.rules.length - 1; i >= 0; i--) {
+      const rule = this.rules[i]!;
       if (!GitignoreFilter.isWithin(rule.dir, abs)) continue;
       const relToRule = posix.normalize(
         relative(rule.dir, abs).split(sep).join(posix.sep)
       );
       if (!relToRule || relToRule.startsWith("..")) continue;
-      if (rule.ig.ignores(relToRule)) return true;
+      const verdict = rule.ig.test(relToRule);
+      if (verdict.ignored || verdict.unignored) {
+        // unignored=true means a `!pattern` matched — keep the file.
+        return verdict.ignored && !verdict.unignored;
+      }
     }
     return false;
   }

--- a/src/ingestion/gitignore-filter.ts
+++ b/src/ingestion/gitignore-filter.ts
@@ -1,0 +1,182 @@
+/**
+ * Nested .gitignore filter for local-folder repositories.
+ *
+ * Walks the directory tree from a root path and collects every `.gitignore`
+ * found, then exposes an `isIgnored(absoluteFilePath)` predicate that applies
+ * each `.gitignore`'s rules with the same scoping git itself uses: a rule from
+ * `<root>/.gitignore` matches paths relative to `<root>`, while a rule from
+ * `<root>/sub/dir/.gitignore` matches paths relative to `<root>/sub/dir`. Rules
+ * from a more deeply nested `.gitignore` take precedence over an ancestor's,
+ * including support for negation (`!keep.txt`).
+ *
+ * The root-only `.gitignore` loader on `FileScanner` is preserved unchanged for
+ * git-remote callers; this filter is opted into via
+ * `ScanOptions.respectNestedGitignore` and is intended for `local-folder` and
+ * `local-git` sources where users routinely have nested `.gitignore` files.
+ *
+ * Implementation note: each `.gitignore` produces its own `ignore()` instance
+ * so we can evaluate them in deepest-first order without re-implementing
+ * git's pattern semantics. Performance scales linearly with depth, which is
+ * acceptable because local-folder trees are walked exactly twice per
+ * registration / update (size pre-scan + actual scan).
+ *
+ * @module ingestion/gitignore-filter
+ */
+
+import ignore, { type Ignore } from "ignore";
+import { readFile, readdir, stat } from "fs/promises";
+import { join, resolve, relative, sep } from "path";
+import { posix } from "path";
+import { getComponentLogger } from "../logging/index.js";
+
+interface NestedRule {
+  /** Absolute path of the directory containing the .gitignore. */
+  dir: string;
+  /** Configured ignore() instance loaded with that file's rules. */
+  ig: Ignore;
+}
+
+/**
+ * Predicate-style filter that honors every `.gitignore` from a tree root
+ * down to each candidate file.
+ *
+ * Construct with the static {@link load} factory; the constructor itself is
+ * private (accessed via the factory). All path arguments to {@link isIgnored}
+ * must be absolute and on the platform's native separator — the filter
+ * normalizes internally.
+ */
+export class GitignoreFilter {
+  private readonly rootPath: string;
+  /**
+   * Rules ordered from shallowest (root) to deepest. Evaluation walks this
+   * list in order so deeper rules override shallower ones, matching git's
+   * "last matching pattern wins" semantics within a directory and the
+   * "deeper file overrides" semantics across directories.
+   */
+  private readonly rules: ReadonlyArray<NestedRule>;
+
+  private constructor(rootPath: string, rules: ReadonlyArray<NestedRule>) {
+    this.rootPath = rootPath;
+    this.rules = rules;
+  }
+
+  /**
+   * Walk `rootPath` discovering every `.gitignore` and load its rules.
+   *
+   * Directories whose own `.gitignore` already excludes them by their parent
+   * are still traversed — an outer `.gitignore` ignoring `node_modules/` does
+   * NOT prevent us from reading a `.gitignore` inside `node_modules`. The
+   * skip happens at filtering time, not at discovery time. (We still skip
+   * the literal `.git` directory because it has special semantics and never
+   * carries a `.gitignore` we need to honor.)
+   *
+   * @param rootPath - Absolute path to the repository / folder root.
+   */
+  static async load(rootPath: string): Promise<GitignoreFilter> {
+    const root = resolve(rootPath);
+    const rules: NestedRule[] = [];
+    await GitignoreFilter.collectRules(root, root, rules);
+    rules.sort((a, b) => a.dir.length - b.dir.length);
+    return new GitignoreFilter(root, rules);
+  }
+
+  /**
+   * Recursively collect `.gitignore` rules under `currentDir`.
+   *
+   * Errors reading a single `.gitignore` (permissions, malformed UTF-8) are
+   * logged and skipped — partial coverage is preferable to refusing to
+   * scan the repo at all.
+   */
+  private static async collectRules(
+    rootPath: string,
+    currentDir: string,
+    out: NestedRule[]
+  ): Promise<void> {
+    const gitignorePath = join(currentDir, ".gitignore");
+    try {
+      const content = await readFile(gitignorePath, "utf-8");
+      const ig = ignore().add(content);
+      out.push({ dir: currentDir, ig });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "ENOENT" && code !== "EISDIR") {
+        // Log and continue — do not throw; absent / unreadable .gitignore is fine.
+        getComponentLogger("ingestion:gitignore-filter").debug(
+          { gitignorePath, err },
+          "Could not read .gitignore (continuing without it)"
+        );
+      }
+    }
+
+    let entries: string[];
+    try {
+      entries = await readdir(currentDir);
+    } catch {
+      return;
+    }
+
+    for (const name of entries) {
+      if (name === ".git") continue;
+      const childPath = join(currentDir, name);
+      let isDir = false;
+      try {
+        const st = await stat(childPath);
+        isDir = st.isDirectory();
+      } catch {
+        continue;
+      }
+      if (isDir) {
+        await GitignoreFilter.collectRules(rootPath, childPath, out);
+      }
+    }
+  }
+
+  /**
+   * Return `true` if `absoluteFilePath` is ignored by any `.gitignore` from
+   * the root down to the file's directory.
+   *
+   * Paths outside `rootPath` are rejected as ignored — defense against
+   * symlink escapes. Trailing-slash semantics for directory-only patterns
+   * (`build/`) are delegated to the `ignore` package.
+   */
+  isIgnored(absoluteFilePath: string): boolean {
+    const abs = resolve(absoluteFilePath);
+    if (!GitignoreFilter.isWithin(this.rootPath, abs)) {
+      return true;
+    }
+
+    for (const rule of this.rules) {
+      if (!GitignoreFilter.isWithin(rule.dir, abs)) continue;
+      const relToRule = posix.normalize(
+        relative(rule.dir, abs).split(sep).join(posix.sep)
+      );
+      if (!relToRule || relToRule.startsWith("..")) continue;
+      if (rule.ig.ignores(relToRule)) return true;
+    }
+    return false;
+  }
+
+  /**
+   * Filter an array of absolute file paths to those NOT ignored.
+   *
+   * Convenience for callers (FileScanner, size guard) that already have a
+   * batch in hand. Equivalent to `paths.filter((p) => !this.isIgnored(p))`.
+   */
+  filterAbsolute(absolutePaths: readonly string[]): string[] {
+    return absolutePaths.filter((p) => !this.isIgnored(p));
+  }
+
+  /**
+   * Number of `.gitignore` files discovered. Exposed for diagnostics and
+   * tests; not part of any public contract.
+   */
+  get ruleFileCount(): number {
+    return this.rules.length;
+  }
+
+  private static isWithin(parent: string, child: string): boolean {
+    if (parent === child) return true;
+    const rel = relative(parent, child);
+    return Boolean(rel) && !rel.startsWith("..") && !rel.startsWith(`..${sep}`);
+  }
+}

--- a/src/ingestion/sha256-stream.ts
+++ b/src/ingestion/sha256-stream.ts
@@ -1,0 +1,35 @@
+/**
+ * Streaming SHA-256 helper for files.
+ *
+ * Extracted from `IngestionService` and `LocalFolderChangeDetector` (PR #573
+ * review L-2). The two call sites previously duplicated the same Promise-
+ * wrapped Node stream pattern; this module is the single source of truth.
+ *
+ * Streaming (rather than `readFile` → `createHash().update`) keeps memory flat
+ * regardless of file size, which matters because the manifest writer hashes
+ * every indexed file at registration and large generated assets occasionally
+ * appear in user folders.
+ *
+ * @module ingestion/sha256-stream
+ */
+
+import { createReadStream } from "node:fs";
+import { createHash } from "node:crypto";
+
+/**
+ * Compute the streaming SHA-256 of a file. Returns a 64-character lowercase
+ * hex digest.
+ *
+ * @param absolutePath Absolute path to the file.
+ * @returns Promise resolving to the hex digest. Rejects with the underlying
+ *   filesystem error if the file cannot be read.
+ */
+export function streamSha256(absolutePath: string): Promise<string> {
+  return new Promise<string>((resolveHash, rejectHash) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(absolutePath);
+    stream.on("data", (chunk: string | Buffer) => hash.update(chunk));
+    stream.on("end", () => resolveHash(hash.digest("hex")));
+    stream.on("error", rejectHash);
+  });
+}

--- a/src/ingestion/types.ts
+++ b/src/ingestion/types.ts
@@ -197,6 +197,22 @@ export interface ScanOptions {
    * ```
    */
   onProgress?: (scanned: number, total: number) => void;
+
+  /**
+   * When `true`, honor every `.gitignore` discovered in the tree, not just the
+   * root one. Rules from a nested `.gitignore` are scoped to its containing
+   * directory and override ancestor rules (matching git's semantics, including
+   * negation via `!keep.txt`).
+   *
+   * Used by `local-folder` and `local-git` ingestion paths where users
+   * routinely have nested `.gitignore` files (monorepos, vendored docs,
+   * build directories with their own ignore rules). For `git-remote` shallow
+   * clones the default `false` is fine because the remote already excluded
+   * ignored files at clone time.
+   *
+   * @default false
+   */
+  respectNestedGitignore?: boolean;
 }
 
 /**

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -94,6 +94,7 @@ export class PersonalKnowledgeMCPServer {
         searchService,
         repositoryService,
         updateCoordinator: optionalDeps.updateCoordinator,
+        localFolderCoordinator: optionalDeps.localFolderCoordinator,
         rateLimiter: optionalDeps.rateLimiter,
         jobTracker: optionalDeps.jobTracker,
         graphService: optionalDeps.graphService,

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -9,6 +9,7 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { SearchService } from "../../services/types.js";
 import type { RepositoryMetadataService } from "../../repositories/types.js";
 import type { IncrementalUpdateCoordinator } from "../../services/incremental-update-coordinator.js";
+import type { LocalFolderUpdateCoordinator } from "../../services/local-folder-update-coordinator.js";
 import type { MCPRateLimiter } from "../rate-limiter.js";
 import type { JobTracker } from "../job-tracker.js";
 import type { GraphService } from "../../services/graph-service-types.js";
@@ -57,6 +58,12 @@ export interface ToolRegistryDependencies {
   repositoryService: RepositoryMetadataService;
   /** Optional: Update coordinator for trigger_incremental_update tool */
   updateCoordinator?: IncrementalUpdateCoordinator;
+  /**
+   * Optional: Local-folder update coordinator. Used by trigger_incremental_update
+   * when `repo.source === "local-folder"`. Required only if local-folder repos
+   * are registered; otherwise the git-flavored coordinator handles every repo.
+   */
+  localFolderCoordinator?: LocalFolderUpdateCoordinator;
   /** Optional: Rate limiter for trigger_incremental_update tool */
   rateLimiter?: MCPRateLimiter;
   /** Optional: Job tracker for async update operations */
@@ -162,13 +169,17 @@ export function createToolRegistry(
     },
   };
 
-  // Always register update tools — use real handlers when deps are available, stubs otherwise
+  // Always register update tools — use real handlers when deps are available, stubs otherwise.
+  // The local-folder coordinator is optional: when missing, trigger_incremental_update
+  // returns a `service_unavailable` error for local-folder repos and continues to work
+  // for git-remote / local-git repos.
   if (deps.updateCoordinator && deps.rateLimiter && deps.jobTracker) {
     registry["trigger_incremental_update"] = {
       definition: triggerIncrementalUpdateToolDefinition,
       handler: createTriggerUpdateHandler({
         repositoryService: deps.repositoryService,
         updateCoordinator: deps.updateCoordinator,
+        localFolderCoordinator: deps.localFolderCoordinator,
         rateLimiter: deps.rateLimiter,
         jobTracker: deps.jobTracker,
       }),

--- a/src/mcp/tools/list-indexed-repositories.ts
+++ b/src/mcp/tools/list-indexed-repositories.ts
@@ -51,6 +51,14 @@ interface IndexedRepositoryResponse {
   index_duration_ms: number;
   /** Error message if status is "error" */
   error_message?: string;
+  /**
+   * Absolute filesystem path of the indexed repository.
+   *
+   * Present for `local-git` and `local-folder` sources (where `url` is null
+   * or only of historical interest). Omitted for `git-remote` repositories,
+   * where the local clone path is an internal cache detail.
+   */
+  local_path?: string;
 }
 
 /**
@@ -111,6 +119,12 @@ function formatListRepositoriesResponse(
     status: repo.status,
     index_duration_ms: repo.indexDurationMs,
     ...(repo.errorMessage && { error_message: repo.errorMessage }),
+    // Surface the on-disk path for non-git-remote sources so callers know
+    // where the user-registered folder actually lives. For git-remote
+    // repositories the localPath is an internal clone-cache directory and
+    // exposing it would invite users to edit it (which would race with the
+    // next git fetch + reset --hard).
+    ...(repo.source !== "git-remote" && repo.localPath && { local_path: repo.localPath }),
   }));
 
   // Calculate summary statistics

--- a/src/mcp/tools/trigger-incremental-update.ts
+++ b/src/mcp/tools/trigger-incremental-update.ts
@@ -18,17 +18,10 @@ import type { RepositoryMetadataService } from "../../repositories/types.js";
 import type { IncrementalUpdateCoordinator } from "../../services/incremental-update-coordinator.js";
 import type { LocalFolderUpdateCoordinator } from "../../services/local-folder-update-coordinator.js";
 import type { CoordinatorResult } from "../../services/incremental-update-coordinator-types.js";
-
-/**
- * Minimal structural interface satisfied by both `IncrementalUpdateCoordinator`
- * (git-remote / local-git) and `LocalFolderUpdateCoordinator` (local-folder).
- *
- * Used by `executeWithTimeout` so the dispatch in the handler can pick a
- * coordinator without the timeout helper caring which concrete class it has.
- */
-interface UpdateCoordinator {
-  updateRepository(repositoryName: string): Promise<CoordinatorResult>;
-}
+import {
+  dispatchCoordinator,
+  type UpdateCoordinatorLike,
+} from "../../services/update-coordinator-dispatch.js";
 import { mapToMCPError } from "../errors.js";
 import { getComponentLogger } from "../../logging/index.js";
 import type { ToolHandler } from "../types.js";
@@ -226,7 +219,12 @@ function formatSyncSuccessResponse(repository: string, result: CoordinatorResult
   };
 
   if (result.commitSha) {
-    response.commit_sha = result.commitSha.substring(0, 7);
+    // Truncate git SHAs to the conventional 7-char short form, but pass through
+    // the synthetic `local-<isoDate>` markers used by local-folder repos in
+    // full — truncating to 7 chars yields a meaningless "local-2".
+    response.commit_sha = result.commitSha.startsWith("local-")
+      ? result.commitSha
+      : result.commitSha.substring(0, 7);
   }
   if (result.commitMessage) {
     response.commit_message = result.commitMessage;
@@ -320,7 +318,7 @@ export interface TriggerUpdateDependencies {
  * See: https://github.com/sethb75/PersonalKnowledgeMCP/issues/126#issuecomment-X
  */
 async function executeWithTimeout(
-  coordinator: UpdateCoordinator,
+  coordinator: UpdateCoordinatorLike,
   repositoryName: string,
   timeoutMs: number
 ): Promise<CoordinatorResult> {
@@ -410,31 +408,30 @@ export function createTriggerUpdateHandler(deps: TriggerUpdateDependencies): Too
         };
       }
 
-      // Pick the coordinator that matches the repo's source. Git-flavored repos
-      // (git-remote, local-git) use the existing IncrementalUpdateCoordinator;
-      // local-folder repos use the manifest-based LocalFolderUpdateCoordinator.
-      // If a local-folder repo is requested but no local-folder coordinator was
-      // injected, surface a `service_unavailable` error rather than misroute.
-      let coordinatorForRepo: UpdateCoordinator;
-      if (repo.source === "local-folder") {
-        if (!localFolderCoordinator) {
-          log.warn(
-            { repository: repositoryName },
-            "trigger_incremental_update invoked for local-folder repo with no LocalFolderUpdateCoordinator configured"
-          );
-          return {
-            content: [
-              formatErrorResponse(
-                "service_unavailable",
-                `Repository '${repositoryName}' is a local-folder source but the local-folder update coordinator is not configured on this server.`
-              ),
-            ],
-            isError: true,
-          };
-        }
-        coordinatorForRepo = localFolderCoordinator;
-      } else {
-        coordinatorForRepo = updateCoordinator;
+      // Pick the coordinator that matches the repo's source via the shared
+      // helper. `dispatchCoordinator` returns undefined when a local-folder
+      // repo is requested but no local-folder coordinator was injected — we
+      // surface that as `service_unavailable` rather than misroute through
+      // the git coordinator (which would throw `MissingCommitShaError`).
+      const coordinatorForRepo = dispatchCoordinator(
+        repo,
+        updateCoordinator,
+        localFolderCoordinator
+      );
+      if (!coordinatorForRepo) {
+        log.warn(
+          { repository: repositoryName },
+          "trigger_incremental_update invoked for local-folder repo with no LocalFolderUpdateCoordinator configured"
+        );
+        return {
+          content: [
+            formatErrorResponse(
+              "service_unavailable",
+              `Repository '${repositoryName}' is a local-folder source but the local-folder update coordinator is not configured on this server.`
+            ),
+          ],
+          isError: true,
+        };
       }
 
       // Step 3: Check for existing running job first (for deduplication)

--- a/src/mcp/tools/trigger-incremental-update.ts
+++ b/src/mcp/tools/trigger-incremental-update.ts
@@ -16,7 +16,19 @@
 import type { Tool, CallToolResult, TextContent } from "@modelcontextprotocol/sdk/types.js";
 import type { RepositoryMetadataService } from "../../repositories/types.js";
 import type { IncrementalUpdateCoordinator } from "../../services/incremental-update-coordinator.js";
+import type { LocalFolderUpdateCoordinator } from "../../services/local-folder-update-coordinator.js";
 import type { CoordinatorResult } from "../../services/incremental-update-coordinator-types.js";
+
+/**
+ * Minimal structural interface satisfied by both `IncrementalUpdateCoordinator`
+ * (git-remote / local-git) and `LocalFolderUpdateCoordinator` (local-folder).
+ *
+ * Used by `executeWithTimeout` so the dispatch in the handler can pick a
+ * coordinator without the timeout helper caring which concrete class it has.
+ */
+interface UpdateCoordinator {
+  updateRepository(repositoryName: string): Promise<CoordinatorResult>;
+}
 import { mapToMCPError } from "../errors.js";
 import { getComponentLogger } from "../../logging/index.js";
 import type { ToolHandler } from "../types.js";
@@ -38,6 +50,7 @@ type TriggerErrorCode =
   | "update_in_progress"
   | "update_failed"
   | "timeout"
+  | "service_unavailable"
   | "internal_error";
 
 /**
@@ -272,7 +285,17 @@ function formatAsyncSuccessResponse(repository: string, jobId: string): TextCont
  */
 export interface TriggerUpdateDependencies {
   repositoryService: RepositoryMetadataService;
+  /** Coordinator for git-remote and local-git sources. */
   updateCoordinator: IncrementalUpdateCoordinator;
+  /**
+   * Coordinator for `local-folder` sources. The handler dispatches to this one
+   * after resolving the `RepositoryInfo` if `repo.source === "local-folder"`.
+   * Optional so tests and legacy bootstrap paths that never register a
+   * local-folder repo do not need to construct one. If absent and a
+   * local-folder repo is requested, the handler returns a `service_unavailable`
+   * error rather than misrouting through the git coordinator.
+   */
+  localFolderCoordinator?: LocalFolderUpdateCoordinator;
   rateLimiter: MCPRateLimiter;
   jobTracker: JobTracker;
 }
@@ -297,7 +320,7 @@ export interface TriggerUpdateDependencies {
  * See: https://github.com/sethb75/PersonalKnowledgeMCP/issues/126#issuecomment-X
  */
 async function executeWithTimeout(
-  coordinator: IncrementalUpdateCoordinator,
+  coordinator: UpdateCoordinator,
   repositoryName: string,
   timeoutMs: number
 ): Promise<CoordinatorResult> {
@@ -343,7 +366,8 @@ async function executeWithTimeout(
  * ```
  */
 export function createTriggerUpdateHandler(deps: TriggerUpdateDependencies): ToolHandler {
-  const { repositoryService, updateCoordinator, rateLimiter, jobTracker } = deps;
+  const { repositoryService, updateCoordinator, localFolderCoordinator, rateLimiter, jobTracker } =
+    deps;
 
   return async (args: unknown): Promise<CallToolResult> => {
     const startTime = performance.now();
@@ -384,6 +408,33 @@ export function createTriggerUpdateHandler(deps: TriggerUpdateDependencies): Too
           ],
           isError: true,
         };
+      }
+
+      // Pick the coordinator that matches the repo's source. Git-flavored repos
+      // (git-remote, local-git) use the existing IncrementalUpdateCoordinator;
+      // local-folder repos use the manifest-based LocalFolderUpdateCoordinator.
+      // If a local-folder repo is requested but no local-folder coordinator was
+      // injected, surface a `service_unavailable` error rather than misroute.
+      let coordinatorForRepo: UpdateCoordinator;
+      if (repo.source === "local-folder") {
+        if (!localFolderCoordinator) {
+          log.warn(
+            { repository: repositoryName },
+            "trigger_incremental_update invoked for local-folder repo with no LocalFolderUpdateCoordinator configured"
+          );
+          return {
+            content: [
+              formatErrorResponse(
+                "service_unavailable",
+                `Repository '${repositoryName}' is a local-folder source but the local-folder update coordinator is not configured on this server.`
+              ),
+            ],
+            isError: true,
+          };
+        }
+        coordinatorForRepo = localFolderCoordinator;
+      } else {
+        coordinatorForRepo = updateCoordinator;
       }
 
       // Step 3: Check for existing running job first (for deduplication)
@@ -466,7 +517,7 @@ export function createTriggerUpdateHandler(deps: TriggerUpdateDependencies): Too
 
           try {
             const result = await executeWithTimeout(
-              updateCoordinator,
+              coordinatorForRepo,
               repositoryName,
               UPDATE_TIMEOUT_MS
             );
@@ -506,7 +557,7 @@ export function createTriggerUpdateHandler(deps: TriggerUpdateDependencies): Too
 
       try {
         const result = await executeWithTimeout(
-          updateCoordinator,
+          coordinatorForRepo,
           repositoryName,
           UPDATE_TIMEOUT_MS
         );

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -7,6 +7,7 @@
 
 import type { Tool, CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import type { IncrementalUpdateCoordinator } from "../services/incremental-update-coordinator.js";
+import type { LocalFolderUpdateCoordinator } from "../services/local-folder-update-coordinator.js";
 import type { GraphService } from "../services/graph-service-types.js";
 import type { DocumentSearchService } from "../services/document-search-types.js";
 import type { ImageSearchService } from "../services/image-search-types.js";
@@ -132,8 +133,16 @@ export interface HttpTransportConfig {
  * When not provided, the server operates with only the core tools.
  */
 export interface MCPServerOptionalDeps {
-  /** Coordinator for incremental repository updates */
+  /** Coordinator for incremental repository updates (git-remote / local-git). */
   updateCoordinator?: IncrementalUpdateCoordinator;
+
+  /**
+   * Coordinator for `local-folder` source updates. Required for local-folder
+   * registrations to work end-to-end via `trigger_incremental_update`; if
+   * absent, the dispatch in the tool handler will receive `undefined` and
+   * mark update tools as unavailable.
+   */
+  localFolderCoordinator?: LocalFolderUpdateCoordinator;
 
   /** Rate limiter for administrative operations */
   rateLimiter?: MCPRateLimiter;

--- a/src/services/file-manifest-store.ts
+++ b/src/services/file-manifest-store.ts
@@ -14,7 +14,7 @@
  */
 
 import { join, dirname } from "path";
-import { rename, unlink, mkdir } from "fs/promises";
+import { rename, unlink, mkdir, readdir, readFile } from "fs/promises";
 import type { Logger } from "pino";
 import { z } from "zod";
 import { getComponentLogger } from "../logging/index.js";
@@ -118,6 +118,22 @@ export interface FileManifestStoreService {
    * Idempotent — succeeds with no error when the manifest file does not exist.
    */
   deleteManifest(repository: string): Promise<void>;
+
+  /**
+   * Enumerate the repository names of every persisted manifest on disk.
+   *
+   * Used by the startup orphan-manifest reaper (PR #573 review M-2): a
+   * `local-folder` registration that crashes between `writeInitialFileManifest`
+   * and `repositoryService.updateRepository` leaves a manifest file with no
+   * matching metadata entry. On boot, the orchestrator compares this list
+   * against `RepositoryMetadataService.listRepositories()` and deletes any
+   * manifests whose repository names are absent from the metadata store.
+   *
+   * Returns an empty array when the manifests directory does not exist yet
+   * (fresh install). Manifests with malformed JSON or missing `repository`
+   * fields are skipped with a debug log rather than failing the boot.
+   */
+  listManifests(): Promise<string[]>;
 }
 
 /** Zod schema for a single fingerprint entry (validated on read). */
@@ -291,6 +307,40 @@ export class FileManifestStoreImpl implements FileManifestStoreService {
     );
     this.writeQueue = next.catch(() => undefined);
     await next;
+  }
+
+  async listManifests(): Promise<string[]> {
+    let entries: string[];
+    try {
+      entries = await readdir(this.manifestsDir);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return [];
+      }
+      this.logger.warn(
+        { manifestsDir: this.manifestsDir, err },
+        "Failed to enumerate manifests directory"
+      );
+      return [];
+    }
+
+    const repositories: string[] = [];
+    for (const entry of entries) {
+      if (!entry.endsWith(".json")) continue;
+      const filePath = join(this.manifestsDir, entry);
+      try {
+        const content = await readFile(filePath, "utf-8");
+        const parsed: unknown = JSON.parse(content);
+        const manifest = FileManifestSchema.parse(parsed);
+        repositories.push(manifest.repository);
+      } catch (err) {
+        // Malformed / partial manifests are skipped rather than failing the
+        // entire boot — the reaper can clean them up on a future run after
+        // the user re-indexes.
+        this.logger.debug({ filePath, err }, "Skipping unreadable manifest during listManifests");
+      }
+    }
+    return repositories;
   }
 
   private async saveManifestInternal(repository: string, manifest: FileManifest): Promise<void> {

--- a/src/services/ingestion-errors.ts
+++ b/src/services/ingestion-errors.ts
@@ -82,6 +82,54 @@ export class CloneError extends IngestionError {
 }
 
 /**
+ * Error thrown when a caller attempts to register a `local-folder` repository
+ * with `tier: "public"`. Local folders frequently contain personal or
+ * confidential content, so the public tier is refused outright; the user must
+ * pick `"private"` or `"work"` (or register the content via a deliberate
+ * git-remote source, which has its own publication semantics).
+ */
+export class LocalFolderPublicTierRefusedError extends IngestionError {
+  override name = "LocalFolderPublicTierRefusedError";
+
+  constructor(repository: string) {
+    super(
+      `Cannot register local folder '${repository}' with tier="public". ` +
+        `Local folders are refused at the public tier to prevent accidental ` +
+        `disclosure of personal content. Use tier="private" (default) or ` +
+        `tier="work" instead.`,
+      false
+    );
+  }
+}
+
+/**
+ * Error thrown when a `local-folder` registration would exceed the configured
+ * size guardrails (file count or total bytes) and `force` was not set.
+ *
+ * Distinct from `IngestionError` so callers can distinguish a hard-refusal
+ * caused by guardrails from a generic indexing failure.
+ */
+export class LocalFolderSizeRefusedError extends IngestionError {
+  override name = "LocalFolderSizeRefusedError";
+
+  constructor(
+    public readonly repository: string,
+    public readonly fileCount: number,
+    public readonly totalBytes: number,
+    public readonly fileLimit: number,
+    public readonly byteLimit: number
+  ) {
+    super(
+      `Cannot register local folder '${repository}': ` +
+        `${fileCount} files / ${totalBytes} bytes exceeds the hard refusal ` +
+        `threshold of ${fileLimit} files / ${byteLimit} bytes. Pass ` +
+        `force: true to bypass.`,
+      false
+    );
+  }
+}
+
+/**
  * Error thrown when ChromaDB collection creation fails
  */
 export class CollectionCreationError extends IngestionError {

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -10,11 +10,16 @@
 
 import { resolve, basename, normalize, join, sep, relative, posix } from "node:path";
 import { stat, readdir } from "node:fs/promises";
-import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
 import { isLocalPath } from "../utils/path-utils.js";
 import simpleGit from "simple-git";
 import { GitignoreFilter } from "../ingestion/gitignore-filter.js";
+import {
+  shouldDescendDir,
+  shouldIncludeFile,
+  DEFAULT_MAX_FILE_SIZE_BYTES,
+  type DirEntryLike,
+} from "../ingestion/file-eligibility.js";
+import { streamSha256 } from "../ingestion/sha256-stream.js";
 import {
   FileManifestStoreImpl,
   type FileManifest,
@@ -415,6 +420,13 @@ export class IngestionService {
         batchSize: this.FILE_BATCH_SIZE,
       });
 
+      // Accumulator for files that completed the full chunk → embed → store
+      // pipeline (PR #573 review M-3). Only these get fingerprinted in the
+      // initial FileManifest for `local-folder` repos; files that errored out
+      // are deliberately omitted so the next incremental update treats them
+      // as "added" and retries.
+      const processedRelativePaths: string[] = [];
+
       for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
         const batch = fileBatches[batchIndex];
         if (!batch) continue; // Skip if batch is undefined (shouldn't happen)
@@ -455,6 +467,7 @@ export class IngestionService {
           stats.embeddingsGenerated += batchResult.embeddingsGenerated;
           stats.documentsStored += batchResult.documentsStored;
           errors.push(...batchResult.errors);
+          processedRelativePaths.push(...batchResult.processedRelativePaths);
         } catch (batchError) {
           // Log batch error but continue with next batch
           this.logger.error(`Batch ${batchIndex + 1}/${totalBatches} failed, continuing...`, {
@@ -511,7 +524,8 @@ export class IngestionService {
         lastManifestId = await this.writeInitialFileManifest(
           repositoryName,
           cloneResult.path,
-          fileInfos
+          fileInfos,
+          new Set(processedRelativePaths)
         );
       }
 
@@ -758,9 +772,17 @@ export class IngestionService {
       embeddingsGenerated: 0,
       documentsStored: 0,
       errors: [],
+      processedRelativePaths: [],
     };
 
     const allChunks: InternalChunk[] = [];
+
+    // Track relative paths whose chunks made it into `allChunks`. We only
+    // promote these to `processedRelativePaths` after the embed + store phases
+    // succeed for the whole batch — partial pipeline success is reported as
+    // "no files indexed" so the manifest writer doesn't fingerprint files
+    // whose chunks never reached ChromaDB (PR #573 review M-3).
+    const chunkedRelativePaths: string[] = [];
 
     // Phase 1: Chunk files
     context.onProgress("chunking", {
@@ -780,6 +802,7 @@ export class IngestionService {
           allChunks.push(...docChunks);
           result.filesProcessed++;
           result.chunksCreated += docChunks.length;
+          chunkedRelativePaths.push(fileInfo.relativePath);
         } else {
           // Existing code path: read as text → FileChunker
           const content = await Bun.file(fileInfo.absolutePath).text();
@@ -787,6 +810,7 @@ export class IngestionService {
           allChunks.push(...this.convertFileChunksToInternal(chunks));
           result.filesProcessed++;
           result.chunksCreated += chunks.length;
+          chunkedRelativePaths.push(fileInfo.relativePath);
         }
       } catch (error) {
         // Individual file error - log and continue
@@ -890,6 +914,11 @@ export class IngestionService {
 
     await this.storageClient.addDocuments(collectionName, documents);
     result.documentsStored = documents.length;
+
+    // Storage succeeded — every file whose chunks landed in `allChunks` is
+    // now durably persisted. Promote them to `processedRelativePaths` so the
+    // initial-manifest writer fingerprints only what's actually indexed.
+    result.processedRelativePaths = [...chunkedRelativePaths];
 
     this.logger.debug("Batch processed successfully", {
       batchIndex: context.batchIndex,
@@ -1240,41 +1269,63 @@ export class IngestionService {
   }
 
   /**
-   * Pre-scan a `local-folder` candidate, counting files and bytes after
-   * applying nested `.gitignore` and the user's extension whitelist, and
-   * enforce soft-warn / hard-refuse thresholds.
+   * Default soft / hard guardrail thresholds for `local-folder` registration.
    *
-   * Soft warn (logged + surfaced via progress event):
-   *   - more than 10,000 files OR more than 1 GiB total.
-   * Hard refuse (throws `LocalFolderSizeRefusedError`):
-   *   - more than 100,000 files OR more than 10 GiB total.
-   * `options.force === true` bypasses the hard refusal.
+   * Soft thresholds (`>10K` files OR `>1 GiB`) only log a warning. Hard
+   * thresholds (`>100K` files OR `>10 GiB`) throw `LocalFolderSizeRefusedError`
+   * unless `options.force === true`.
    *
-   * Symlinks are NOT followed during this estimate (lstat-only), so a folder
-   * that includes a link to `/etc` doesn't pad the count and a link loop can't
-   * cause a hang. Walk cost is dominated by readdir + lstat which are cheap
-   * relative to the chunk + embed work the guardrail is protecting against.
+   * Exposed as a static field so unit tests can construct an `IngestionService`
+   * and pass tiny limits via {@link enforceLocalFolderSizeGuardrails}'s
+   * `thresholds` argument without fixturing 100K files (PR #573 review TEST-1).
    */
-  private async enforceLocalFolderSizeGuardrails(
+  static readonly LOCAL_FOLDER_SIZE_THRESHOLDS = {
+    softFileLimit: 10_000,
+    softByteLimit: 1_073_741_824, // 1 GiB
+    hardFileLimit: 100_000,
+    hardByteLimit: 10_737_418_240, // 10 GiB
+  } as const;
+
+  /**
+   * Pre-scan a `local-folder` candidate, counting files and bytes after
+   * applying the same eligibility predicate `FileScanner` will use during the
+   * actual scan, and enforce soft-warn / hard-refuse thresholds.
+   *
+   * Eligibility (gitignore, extension whitelist, default exclusions, dotfile
+   * skip, VCS metadata skip, size cap, symlink skip) is delegated to
+   * `shouldDescendDir` / `shouldIncludeFile` so the guardrail counts the same
+   * files the scanner would index — fixing the H-2 divergence in PR #573.
+   *
+   * `thresholds` is overridable for tests; production callers should leave it
+   * undefined to pick up {@link LOCAL_FOLDER_SIZE_THRESHOLDS}. Soft warn is
+   * also returned via `softWarn: true` in the result so callers can assert
+   * without log inspection.
+   */
+  async enforceLocalFolderSizeGuardrails(
     repositoryName: string,
     rootPath: string,
-    options: IndexOptions
-  ): Promise<void> {
-    const SOFT_FILE_LIMIT = 10_000;
-    const SOFT_BYTE_LIMIT = 1_073_741_824; // 1 GiB
-    const HARD_FILE_LIMIT = 100_000;
-    const HARD_BYTE_LIMIT = 10_737_418_240; // 10 GiB
+    options: IndexOptions,
+    thresholds: {
+      softFileLimit: number;
+      softByteLimit: number;
+      hardFileLimit: number;
+      hardByteLimit: number;
+    } = IngestionService.LOCAL_FOLDER_SIZE_THRESHOLDS
+  ): Promise<{ fileCount: number; totalBytes: number; softWarn: boolean }> {
+    const { softFileLimit, softByteLimit, hardFileLimit, hardByteLimit } = thresholds;
 
     const filter = await GitignoreFilter.load(rootPath);
-    const extensions =
+    const extensions: Set<string> =
       options.includeExtensions && options.includeExtensions.length > 0
         ? new Set(options.includeExtensions.map((e) => e.toLowerCase()))
         : new Set(DEFAULT_EXTENSIONS.map((e) => e.toLowerCase()));
 
     let fileCount = 0;
     let totalBytes = 0;
+    let aborted = false;
 
     const walk = async (dir: string): Promise<void> => {
+      if (aborted) return;
       let entries;
       try {
         entries = await readdir(dir, { withFileTypes: true });
@@ -1282,63 +1333,77 @@ export class IngestionService {
         return;
       }
       for (const entry of entries) {
-        if (entry.name === ".git") continue;
+        if (aborted) return;
         const abs = join(dir, entry.name);
-        // Symlinks: skip outright. Do not stat() the target (cycle / outside-root risk).
+        // Symlinks are never followed (cycle / out-of-tree escape).
         if (entry.isSymbolicLink()) continue;
 
         if (entry.isDirectory()) {
-          if (filter.isIgnored(abs)) continue;
+          if (!shouldDescendDir(abs, entry.name, filter)) continue;
           await walk(abs);
-        } else if (entry.isFile()) {
-          if (filter.isIgnored(abs)) continue;
-          const ext = "." + (entry.name.split(".").pop() ?? "").toLowerCase();
-          if (!extensions.has(ext)) continue;
-          try {
-            const st = await stat(abs);
-            fileCount++;
-            totalBytes += st.size;
-          } catch {
-            continue;
-          }
-          // Early exit on hard refusal (avoids walking the rest of a 200K-file folder).
-          if (!options.force && (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)) {
-            return;
-          }
+          continue;
+        }
+
+        if (!entry.isFile()) continue;
+
+        const ent: DirEntryLike = { name: entry.name, isDir: false, isSymlink: false };
+        const verdict = await shouldIncludeFile(abs, ent, {
+          gitignore: filter,
+          extensions,
+          maxSizeBytes: DEFAULT_MAX_FILE_SIZE_BYTES,
+        });
+        if (!verdict.eligible || !verdict.stats) continue;
+
+        fileCount++;
+        totalBytes += verdict.stats.size;
+
+        // Early exit on hard refusal (avoids walking the rest of a huge folder).
+        if (!options.force && (fileCount > hardFileLimit || totalBytes > hardByteLimit)) {
+          aborted = true;
+          return;
         }
       }
     };
 
     await walk(rootPath);
 
-    if (!options.force && (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)) {
+    if (!options.force && (fileCount > hardFileLimit || totalBytes > hardByteLimit)) {
       throw new LocalFolderSizeRefusedError(
         repositoryName,
         fileCount,
         totalBytes,
-        HARD_FILE_LIMIT,
-        HARD_BYTE_LIMIT
+        hardFileLimit,
+        hardByteLimit
       );
     }
-    if (fileCount > SOFT_FILE_LIMIT || totalBytes > SOFT_BYTE_LIMIT) {
+    const softWarn = fileCount > softFileLimit || totalBytes > softByteLimit;
+    if (softWarn) {
       this.logger.warn(
         {
           repository: repositoryName,
           rootPath,
           fileCount,
           totalBytes,
-          softFileLimit: SOFT_FILE_LIMIT,
-          softByteLimit: SOFT_BYTE_LIMIT,
+          softFileLimit,
+          softByteLimit,
         },
         "Local folder exceeds soft size guardrail; proceeding because under the hard refusal threshold or force=true was set"
       );
     }
+    return { fileCount, totalBytes, softWarn };
   }
 
   /**
    * Compute per-file fingerprints for a freshly-scanned local-folder repo and
    * persist a `FileManifest` so a future incremental update has a baseline to
    * diff against.
+   *
+   * Only files in `processedPaths` (POSIX-relative) are fingerprinted. Files
+   * whose chunks failed to embed/store are omitted so the NEXT incremental
+   * update sees them as `added` and retries — without this, a partial-success
+   * first index would silently lose those files from the index forever
+   * (PR #573 review M-3). Pass `undefined` to fingerprint all `fileInfos`
+   * (used by tests / call paths that have no per-file outcome to filter on).
    *
    * SHA-256 is computed via streaming so files larger than the chunker's
    * normal cap (which they shouldn't be, but a manifest is a different
@@ -1350,14 +1415,21 @@ export class IngestionService {
   private async writeInitialFileManifest(
     repositoryName: string,
     rootPath: string,
-    fileInfos: FileInfo[]
+    fileInfos: FileInfo[],
+    processedPaths?: ReadonlySet<string>
   ): Promise<string> {
     const store = FileManifestStoreImpl.getInstance();
     const files: Record<string, FileManifestEntry> = {};
 
     for (const info of fileInfos) {
+      // Skip files that didn't make it through the full pipeline. `info.relativePath`
+      // is already POSIX-normalized (FileScanner.normalizeToPosix), matching the
+      // form `processFileBatch` records into `processedRelativePaths`.
+      if (processedPaths && !processedPaths.has(info.relativePath)) {
+        continue;
+      }
       try {
-        const sha256 = await this.streamSha256(info.absolutePath);
+        const sha256 = await streamSha256(info.absolutePath);
         const st = await stat(info.absolutePath);
         // Manifest keys are POSIX-normalized relative paths so cross-platform
         // diffs stay deterministic. fileInfos already uses POSIX separators
@@ -1386,20 +1458,5 @@ export class IngestionService {
     };
     await store.saveManifest(repositoryName, manifest);
     return store.computeManifestId(repositoryName);
-  }
-
-  /**
-   * Streaming SHA-256 of a file's contents. Hex digest, lowercase, 64 chars.
-   */
-  private async streamSha256(absolutePath: string): Promise<string> {
-    return new Promise<string>((resolveHash, rejectHash) => {
-      const hash = createHash("sha256");
-      const stream = createReadStream(absolutePath);
-      stream.on("data", (chunk: string | Buffer) => {
-        hash.update(chunk);
-      });
-      stream.on("end", () => resolveHash(hash.digest("hex")));
-      stream.on("error", rejectHash);
-    });
   }
 }

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -305,11 +305,7 @@ export class IngestionService {
           // Size pre-scan and hard-refusal happen before we sink time into
           // FileScanner / chunking / embeddings. Soft-warn thresholds are
           // logged; hard-refuse throws unless options.force is set.
-          await this.enforceLocalFolderSizeGuardrails(
-            repositoryName,
-            resolvedPath,
-            options
-          );
+          await this.enforceLocalFolderSizeGuardrails(repositoryName, resolvedPath, options);
         }
 
         cloneResult = { path: resolvedPath, name: repositoryName, branch, commitSha };
@@ -672,6 +668,19 @@ export class IngestionService {
         // Collection might not exist, log but continue
         this.logger.warn("Collection deletion failed", {
           collectionName,
+          error: err,
+        });
+      }
+
+      // Delete the FileManifest, if any. Idempotent — succeeds with no error
+      // when the manifest file does not exist (e.g. git-remote / local-git
+      // repos that never had one). Without this, re-registering the same name
+      // later would load a stale manifest and skip already-changed files.
+      try {
+        await FileManifestStoreImpl.getInstance().deleteManifest(name);
+      } catch (err) {
+        this.logger.warn("FileManifest deletion failed (continuing)", {
+          repository: name,
           error: err,
         });
       }
@@ -1293,10 +1302,7 @@ export class IngestionService {
             continue;
           }
           // Early exit on hard refusal (avoids walking the rest of a 200K-file folder).
-          if (
-            !options.force &&
-            (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)
-          ) {
+          if (!options.force && (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)) {
             return;
           }
         }
@@ -1305,10 +1311,7 @@ export class IngestionService {
 
     await walk(rootPath);
 
-    if (
-      !options.force &&
-      (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)
-    ) {
+    if (!options.force && (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)) {
       throw new LocalFolderSizeRefusedError(
         repositoryName,
         fileCount,

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -8,10 +8,19 @@
  * @module services/ingestion-service
  */
 
-import { resolve, basename, normalize } from "node:path";
-import { stat } from "node:fs/promises";
+import { resolve, basename, normalize, join, sep, relative, posix } from "node:path";
+import { stat, readdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
 import { isLocalPath } from "../utils/path-utils.js";
 import simpleGit from "simple-git";
+import { GitignoreFilter } from "../ingestion/gitignore-filter.js";
+import {
+  FileManifestStoreImpl,
+  type FileManifest,
+  type FileManifestEntry,
+  FILE_MANIFEST_VERSION,
+} from "./file-manifest-store.js";
 import type { Logger } from "pino";
 import type { RepositoryCloner } from "../ingestion/repository-cloner.js";
 import type { CloneResult, FileInfo, FileChunk } from "../ingestion/types.js";
@@ -40,6 +49,8 @@ import {
   RepositoryAlreadyExistsError,
   IndexingInProgressError,
   CollectionCreationError,
+  LocalFolderPublicTierRefusedError,
+  LocalFolderSizeRefusedError,
 } from "./ingestion-errors.js";
 import type { DocumentChunker } from "../documents/DocumentChunker.js";
 import type { DocumentTypeDetector } from "../documents/DocumentTypeDetector.js";
@@ -240,9 +251,13 @@ export class IngestionService {
       );
 
       let cloneResult: CloneResult;
+      // Source discriminator threaded through to buildRepositoryMetadata. The
+      // remote-clone branch always produces "git-remote"; the local-path branch
+      // distinguishes "local-git" (has a `.git` directory) from "local-folder"
+      // (no git history — change detection happens via FileManifest instead).
+      let effectiveSource: "git-remote" | "local-git" | "local-folder" = "git-remote";
 
       if (isLocalPath(url)) {
-        // Local path — validate it exists and is a git repo, then use in-place
         const resolvedPath = normalize(resolve(url));
 
         try {
@@ -258,16 +273,43 @@ export class IngestionService {
           );
         }
 
-        const git = simpleGit(resolvedPath);
+        const hasGitDir = await this.directoryHasGitFolder(resolvedPath);
+        effectiveSource = hasGitDir ? "local-git" : "local-folder";
+
+        // Tier refusal: local folders may not register at the public tier. We
+        // check before any heavy work so a misconfigured request fails fast.
+        const requestedTier = options.tier ?? "private";
+        if (effectiveSource === "local-folder" && requestedTier === "public") {
+          throw new LocalFolderPublicTierRefusedError(repositoryName);
+        }
 
         let branch = options.branch ?? "unknown";
         let commitSha: string | undefined;
 
-        try {
-          branch = options.branch ?? (await git.revparse(["--abbrev-ref", "HEAD"])).trim();
-          commitSha = (await git.revparse(["HEAD"])).trim();
-        } catch {
-          this.logger.warn({ resolvedPath }, "Could not read git metadata from local path");
+        if (hasGitDir) {
+          // Existing local-git behavior: read git metadata in place.
+          const git = simpleGit(resolvedPath);
+          try {
+            branch = options.branch ?? (await git.revparse(["--abbrev-ref", "HEAD"])).trim();
+            commitSha = (await git.revparse(["HEAD"])).trim();
+          } catch {
+            this.logger.warn({ resolvedPath }, "Could not read git metadata from local path");
+          }
+        } else {
+          // local-folder: skip every simple-git call (no .git to read). The
+          // display branch is a fixed sentinel; real change detection runs
+          // through LocalFolderChangeDetector + FileManifest.
+          branch = options.branch ?? "(local-folder)";
+          commitSha = undefined;
+
+          // Size pre-scan and hard-refusal happen before we sink time into
+          // FileScanner / chunking / embeddings. Soft-warn thresholds are
+          // logged; hard-refuse throws unless options.force is set.
+          await this.enforceLocalFolderSizeGuardrails(
+            repositoryName,
+            resolvedPath,
+            options
+          );
         }
 
         cloneResult = { path: resolvedPath, name: repositoryName, branch, commitSha };
@@ -276,10 +318,12 @@ export class IngestionService {
         this.logger.info("Using local repository path", {
           repository: repositoryName,
           path: resolvedPath,
+          source: effectiveSource,
           branch,
           commitSha,
         });
       } else {
+        effectiveSource = "git-remote";
         const remote = await this.repositoryCloner.clone(url, {
           branch: options.branch,
           fetchLatest: options.force, // Fetch latest when force reindexing
@@ -309,6 +353,12 @@ export class IngestionService {
       const fileInfos = await this.fileScanner.scanFiles(cloneResult.path, {
         includeExtensions: options.includeExtensions,
         excludePatterns: options.excludePatterns,
+        // Walk every nested .gitignore for local sources — users routinely have
+        // them in monorepos and vendored docs. Git-remote shallow clones already
+        // exclude ignored files at clone time, so the cheap root-only path is
+        // preserved there.
+        respectNestedGitignore:
+          effectiveSource === "local-folder" || effectiveSource === "local-git",
         onProgress: (scanned) => {
           this.updateProgress(
             {
@@ -455,6 +505,20 @@ export class IngestionService {
               .join("; ")}`
           : undefined;
 
+      // For local-folder sources, write the initial FileManifest before
+      // persisting metadata so a crash between manifest-write and metadata-write
+      // leaves a recoverable state (next registration sees no metadata, next
+      // local-folder update sees a manifest with `generatedAt = epoch sentinel`
+      // and treats the repo as new).
+      let lastManifestId: string | undefined;
+      if (effectiveSource === "local-folder") {
+        lastManifestId = await this.writeInitialFileManifest(
+          repositoryName,
+          cloneResult.path,
+          fileInfos
+        );
+      }
+
       const metadata = this.buildRepositoryMetadata({
         name: repositoryName,
         url,
@@ -463,6 +527,9 @@ export class IngestionService {
         collectionName,
         options,
         errorMessage,
+        source: effectiveSource,
+        tier: options.tier ?? "private",
+        lastManifestId,
       });
 
       await this.repositoryService.updateRepository(metadata);
@@ -1103,16 +1170,23 @@ export class IngestionService {
     collectionName: string;
     options: IndexOptions;
     errorMessage?: string;
+    /**
+     * Pre-computed source discriminator from the indexer's clone/resolve fork.
+     * Required so the metadata reflects whether `.git` was actually present at
+     * the local path; deriving it from `params.url` alone would conflate
+     * `local-git` and `local-folder`.
+     */
+    source: "git-remote" | "local-git" | "local-folder";
+    /** Security tier (defaults to "private"; "public" already refused for local-folder). */
+    tier: "private" | "work" | "public";
+    /** Manifest pointer set only for `local-folder` sources. */
+    lastManifestId?: string;
   }): RepositoryInfo {
     return {
       name: params.name,
-      // Phase A: distinguish remote clones from local-git paths. Local-folder
-      // sources (no .git) will be added in Phase B via a parallel construction
-      // site. `isLocalPath` mirrors the same gate used in `indexRepository` at
-      // the clone-vs-resolve fork (see ~line 244), so the discriminator we
-      // persist here matches the path that actually produced the index.
-      source: isLocalPath(params.url) ? "local-git" : "git-remote",
-      url: params.url,
+      source: params.source,
+      // local-folder repos have no clone URL — persist null per the type contract.
+      url: params.source === "local-folder" ? null : params.url,
       branch: params.cloneResult.branch,
       localPath: params.cloneResult.path,
       collectionName: params.collectionName,
@@ -1133,6 +1207,196 @@ export class IngestionService {
       embeddingProvider: this.embeddingProvider.providerId,
       embeddingModel: this.embeddingProvider.modelId,
       embeddingDimensions: this.embeddingProvider.dimensions,
+      // Local-folder + multi-tier fields
+      tier: params.tier,
+      lastManifestId: params.lastManifestId,
     };
+  }
+
+  /**
+   * Test whether `absolutePath` contains a `.git` entry (file or directory).
+   *
+   * A `.git` *directory* is the normal case. A `.git` *file* is what `git
+   * worktree` creates inside a linked worktree — we accept both because both
+   * indicate the path is inside a git working tree and the existing
+   * `simple-git` revparse calls will succeed.
+   */
+  private async directoryHasGitFolder(absolutePath: string): Promise<boolean> {
+    try {
+      await stat(join(absolutePath, ".git"));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Pre-scan a `local-folder` candidate, counting files and bytes after
+   * applying nested `.gitignore` and the user's extension whitelist, and
+   * enforce soft-warn / hard-refuse thresholds.
+   *
+   * Soft warn (logged + surfaced via progress event):
+   *   - more than 10,000 files OR more than 1 GiB total.
+   * Hard refuse (throws `LocalFolderSizeRefusedError`):
+   *   - more than 100,000 files OR more than 10 GiB total.
+   * `options.force === true` bypasses the hard refusal.
+   *
+   * Symlinks are NOT followed during this estimate (lstat-only), so a folder
+   * that includes a link to `/etc` doesn't pad the count and a link loop can't
+   * cause a hang. Walk cost is dominated by readdir + lstat which are cheap
+   * relative to the chunk + embed work the guardrail is protecting against.
+   */
+  private async enforceLocalFolderSizeGuardrails(
+    repositoryName: string,
+    rootPath: string,
+    options: IndexOptions
+  ): Promise<void> {
+    const SOFT_FILE_LIMIT = 10_000;
+    const SOFT_BYTE_LIMIT = 1_073_741_824; // 1 GiB
+    const HARD_FILE_LIMIT = 100_000;
+    const HARD_BYTE_LIMIT = 10_737_418_240; // 10 GiB
+
+    const filter = await GitignoreFilter.load(rootPath);
+    const extensions =
+      options.includeExtensions && options.includeExtensions.length > 0
+        ? new Set(options.includeExtensions.map((e) => e.toLowerCase()))
+        : new Set(DEFAULT_EXTENSIONS.map((e) => e.toLowerCase()));
+
+    let fileCount = 0;
+    let totalBytes = 0;
+
+    const walk = async (dir: string): Promise<void> => {
+      let entries;
+      try {
+        entries = await readdir(dir, { withFileTypes: true });
+      } catch {
+        return;
+      }
+      for (const entry of entries) {
+        if (entry.name === ".git") continue;
+        const abs = join(dir, entry.name);
+        // Symlinks: skip outright. Do not stat() the target (cycle / outside-root risk).
+        if (entry.isSymbolicLink()) continue;
+
+        if (entry.isDirectory()) {
+          if (filter.isIgnored(abs)) continue;
+          await walk(abs);
+        } else if (entry.isFile()) {
+          if (filter.isIgnored(abs)) continue;
+          const ext = "." + (entry.name.split(".").pop() ?? "").toLowerCase();
+          if (!extensions.has(ext)) continue;
+          try {
+            const st = await stat(abs);
+            fileCount++;
+            totalBytes += st.size;
+          } catch {
+            continue;
+          }
+          // Early exit on hard refusal (avoids walking the rest of a 200K-file folder).
+          if (
+            !options.force &&
+            (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)
+          ) {
+            return;
+          }
+        }
+      }
+    };
+
+    await walk(rootPath);
+
+    if (
+      !options.force &&
+      (fileCount > HARD_FILE_LIMIT || totalBytes > HARD_BYTE_LIMIT)
+    ) {
+      throw new LocalFolderSizeRefusedError(
+        repositoryName,
+        fileCount,
+        totalBytes,
+        HARD_FILE_LIMIT,
+        HARD_BYTE_LIMIT
+      );
+    }
+    if (fileCount > SOFT_FILE_LIMIT || totalBytes > SOFT_BYTE_LIMIT) {
+      this.logger.warn(
+        {
+          repository: repositoryName,
+          rootPath,
+          fileCount,
+          totalBytes,
+          softFileLimit: SOFT_FILE_LIMIT,
+          softByteLimit: SOFT_BYTE_LIMIT,
+        },
+        "Local folder exceeds soft size guardrail; proceeding because under the hard refusal threshold or force=true was set"
+      );
+    }
+  }
+
+  /**
+   * Compute per-file fingerprints for a freshly-scanned local-folder repo and
+   * persist a `FileManifest` so a future incremental update has a baseline to
+   * diff against.
+   *
+   * SHA-256 is computed via streaming so files larger than the chunker's
+   * normal cap (which they shouldn't be, but a manifest is a different
+   * pipeline) don't blow up memory.
+   *
+   * Returns the manifest pointer (`computeManifestId(name)`) to store on the
+   * `RepositoryInfo`.
+   */
+  private async writeInitialFileManifest(
+    repositoryName: string,
+    rootPath: string,
+    fileInfos: FileInfo[]
+  ): Promise<string> {
+    const store = FileManifestStoreImpl.getInstance();
+    const files: Record<string, FileManifestEntry> = {};
+
+    for (const info of fileInfos) {
+      try {
+        const sha256 = await this.streamSha256(info.absolutePath);
+        const st = await stat(info.absolutePath);
+        // Manifest keys are POSIX-normalized relative paths so cross-platform
+        // diffs stay deterministic. fileInfos already uses POSIX separators
+        // for relativePath but normalize defensively.
+        const relPath = posix.normalize(
+          relative(rootPath, info.absolutePath).split(sep).join(posix.sep)
+        );
+        files[relPath] = {
+          sha256,
+          sizeBytes: st.size,
+          mtimeMs: st.mtimeMs,
+        };
+      } catch (err) {
+        this.logger.warn(
+          { absolutePath: info.absolutePath, err },
+          "Could not fingerprint file for manifest; skipping"
+        );
+      }
+    }
+
+    const manifest: FileManifest = {
+      version: FILE_MANIFEST_VERSION,
+      repository: repositoryName,
+      generatedAt: new Date().toISOString(),
+      files,
+    };
+    await store.saveManifest(repositoryName, manifest);
+    return store.computeManifestId(repositoryName);
+  }
+
+  /**
+   * Streaming SHA-256 of a file's contents. Hex digest, lowercase, 64 chars.
+   */
+  private async streamSha256(absolutePath: string): Promise<string> {
+    return new Promise<string>((resolveHash, rejectHash) => {
+      const hash = createHash("sha256");
+      const stream = createReadStream(absolutePath);
+      stream.on("data", (chunk: string | Buffer) => {
+        hash.update(chunk);
+      });
+      stream.on("end", () => resolveHash(hash.digest("hex")));
+      stream.on("error", rejectHash);
+    });
   }
 }

--- a/src/services/ingestion-types.ts
+++ b/src/services/ingestion-types.ts
@@ -370,4 +370,19 @@ export interface BatchResult {
    * Errors encountered in this batch
    */
   errors: IndexError[];
+
+  /**
+   * POSIX-relative paths of files that fully made it through chunk → embed →
+   * store in this batch.
+   *
+   * Used by `IngestionService.writeInitialFileManifest` to ensure the initial
+   * `local-folder` manifest fingerprints ONLY successfully-indexed files —
+   * fixing PR #573 review M-3 where a partial-success first index would write
+   * fingerprints for files the pipeline errored on, causing the next
+   * incremental update to see no diff and silently skip them forever.
+   *
+   * Empty when nothing in the batch reached ChromaDB. May be a subset of
+   * `filesProcessed` if the embed/store phase fails for the whole batch.
+   */
+  processedRelativePaths: string[];
 }

--- a/src/services/ingestion-types.ts
+++ b/src/services/ingestion-types.ts
@@ -46,6 +46,17 @@ export interface IndexOptions {
    * @default false
    */
   force?: boolean;
+
+  /**
+   * Security tier this repository belongs to.
+   *
+   * Defaults to `"private"` when omitted. `"public"` is refused at registration
+   * for `local-folder` sources to prevent accidental disclosure of personal
+   * content; `"private"` and `"work"` are always allowed.
+   *
+   * @default "private"
+   */
+  tier?: "private" | "work" | "public";
 }
 
 /**

--- a/src/services/interrupted-update-recovery.ts
+++ b/src/services/interrupted-update-recovery.ts
@@ -12,8 +12,10 @@ import { getComponentLogger } from "../logging/index.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../repositories/types.js";
 import type { IngestionService } from "./ingestion-service.js";
 import type { IncrementalUpdateCoordinator } from "./incremental-update-coordinator.js";
+import type { LocalFolderUpdateCoordinator } from "./local-folder-update-coordinator.js";
 import type { InterruptedUpdateInfo } from "./interrupted-update-detector.js";
 import { clearInterruptedUpdateFlag, formatElapsedTime } from "./interrupted-update-detector.js";
+import { dispatchCoordinator } from "./update-coordinator-dispatch.js";
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -95,6 +97,13 @@ export interface RecoveryDependencies {
   repositoryService: RepositoryMetadataService;
   ingestionService: IngestionService;
   updateCoordinator: IncrementalUpdateCoordinator;
+  /**
+   * Optional local-folder coordinator. When a recovered repository's source
+   * is `local-folder`, recovery dispatches to this coordinator instead of the
+   * git coordinator. Optional for back-compat with bootstrap paths that don't
+   * register local-folder repos.
+   */
+  localFolderCoordinator?: LocalFolderUpdateCoordinator;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -139,9 +148,29 @@ export async function evaluateRecoveryStrategy(
       elapsedMs,
       hasLastKnownCommit: !!lastKnownCommit,
       status: repository.status,
+      source: repository.source,
     },
     "Evaluating recovery strategy"
   );
+
+  // Local-folder repos never have a `lastIndexedCommitSha` — change detection
+  // happens via FileManifest, and `LocalFolderUpdateCoordinator` already
+  // tolerates missing/empty manifests + drift. The "no last known commit ⇒
+  // full re-index" rule below is correct for git-flavored repos but would
+  // misroute local-folder repos through `executeFullReindexRecovery` (which
+  // would then crash on `repo.url!`). Always recommend resume; the coordinator
+  // will pick up where the manifest left off.
+  if (repository.source === "local-folder") {
+    logger.info(
+      { repository: repositoryName },
+      "Local-folder source — recommending resume via LocalFolderUpdateCoordinator"
+    );
+    return {
+      type: "resume",
+      reason: "local-folder repos resume via FileManifest, regardless of elapsed time",
+      canAutoRecover: true,
+    };
+  }
 
   // Check 1: Is the update stale (>24 hours old)?
   if (elapsedMs > STALE_UPDATE_THRESHOLD_MS) {
@@ -312,9 +341,25 @@ async function executeResumeRecovery(
   await clearInterruptedUpdateFlag(deps.repositoryService, repositoryName);
   logger.debug({ repository: repositoryName }, "Cleared interrupted update flag");
 
-  // Attempt incremental update
+  // Attempt incremental update — dispatch by source so a recovered local-folder
+  // repo uses its manifest-based coordinator rather than the git coordinator
+  // (which would throw MissingCommitShaError for sources without a SHA).
+  const repo = await deps.repositoryService.getRepository(repositoryName);
+  const coordinator = repo
+    ? dispatchCoordinator(repo, deps.updateCoordinator, deps.localFolderCoordinator)
+    : deps.updateCoordinator;
+  if (!coordinator) {
+    return {
+      strategy,
+      success: false,
+      repositoryName,
+      message: `Cannot recover '${repositoryName}': source='${repo?.source}' but no local-folder coordinator configured`,
+      durationMs: Date.now() - startTime,
+      error: "local_folder_coordinator_unavailable",
+    };
+  }
   try {
-    const result = await deps.updateCoordinator.updateRepository(repositoryName);
+    const result = await coordinator.updateRepository(repositoryName);
     const durationMs = Date.now() - startTime;
 
     if (result.status === "no_changes") {
@@ -425,13 +470,17 @@ async function executeFullReindexRecovery(
   await clearInterruptedUpdateFlag(deps.repositoryService, repositoryName);
   logger.debug({ repository: repositoryName }, "Cleared interrupted update flag");
 
-  // Perform full re-index.
-  // url is non-null for git-remote and local-git sources. Local-folder repos
-  // dispatch through LocalFolderUpdateCoordinator (Phase B) and never reach
-  // this code path.
-  const result = await deps.ingestionService.indexRepository(repository.url!, {
+  // For git-remote and local-git, re-index from the recorded URL. For
+  // local-folder, `repository.url` is null by design (no clone URL exists),
+  // so use the registered `localPath` instead — `isLocalPath` will route it
+  // through the local-path branch in IngestionService and source detection
+  // (.git presence) reaffirms the existing source discriminator.
+  const sourceForReindex = repository.url ?? repository.localPath;
+  const result = await deps.ingestionService.indexRepository(sourceForReindex, {
+    name: repository.name,
     branch: repository.branch,
     force: true,
+    tier: repository.tier,
   });
 
   const durationMs = Date.now() - startTime;

--- a/src/services/interrupted-update-recovery.ts
+++ b/src/services/interrupted-update-recovery.ts
@@ -160,7 +160,28 @@ export async function evaluateRecoveryStrategy(
   // misroute local-folder repos through `executeFullReindexRecovery` (which
   // would then crash on `repo.url!`). Always recommend resume; the coordinator
   // will pick up where the manifest left off.
+  //
+  // Stale-recovery warning (PR #573 review M-5): when the in-progress flag
+  // has been set longer than `STALE_UPDATE_THRESHOLD_MS`, the manifest is
+  // still safe to resume against (the coordinator only advances it on
+  // successful pipeline runs), but the user should know they've potentially
+  // lost weeks of unfinished work. Surface the elapsed time both via a
+  // `warn`-level log AND in the strategy `reason` so it shows up in any
+  // recovery report the user reads.
   if (repository.source === "local-folder") {
+    const isStale = elapsedMs > STALE_UPDATE_THRESHOLD_MS;
+    if (isStale) {
+      const elapsed = formatElapsedTime(elapsedMs);
+      logger.warn(
+        { repository: repositoryName, elapsedMs, elapsed },
+        "Local-folder update interrupted >24h ago — resume is safe (manifest preserved) but review changes after recovery"
+      );
+      return {
+        type: "resume",
+        reason: `local-folder repos resume via FileManifest. Note: update interrupted ${elapsed} ago — review changes carefully after recovery.`,
+        canAutoRecover: true,
+      };
+    }
     logger.info(
       { repository: repositoryName },
       "Local-folder source — recommending resume via LocalFolderUpdateCoordinator"

--- a/src/services/local-folder-change-detector.ts
+++ b/src/services/local-folder-change-detector.ts
@@ -1,0 +1,268 @@
+/**
+ * Change detection for `local-folder` repositories.
+ *
+ * Diffs the current state of a registered folder against its last persisted
+ * `FileManifest` and emits `FileChange[]` matching the contract that
+ * `IncrementalUpdatePipeline.processChanges` already accepts. This is the
+ * non-git equivalent of the `git diff --name-status` output that drives
+ * `IncrementalUpdateCoordinator`'s git-remote and local-git paths.
+ *
+ * The diff algorithm is `(size, mtime)`-fast-path with sha256 fallback:
+ *
+ *   - In current, not in manifest      → `added`   (sha256 captured for the new manifest)
+ *   - In manifest, not in current      → `deleted`
+ *   - Both, `(size, mtime)` differ     → recompute sha256
+ *       - hashes also differ           → `modified`
+ *       - hashes match (touch only)    → skip; carry the prior fingerprint forward
+ *   - Both, `(size, mtime)` match      → skip (fast path; no hash)
+ *   - `paranoid: true`                 → unconditionally hash both sides;
+ *                                         mitigates the SMB / Docker bind-mount
+ *                                         mtime-unreliability risk in the
+ *                                         implementation plan §5.
+ *
+ * Renames are NOT detected in v1; a moved file is reported as `deleted` +
+ * `added`. The downstream pipeline re-embeds the new path; the only cost is
+ * the wasted re-embed which is acceptable for v1.
+ *
+ * @module services/local-folder-change-detector
+ */
+
+import { readdir, stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { createHash } from "node:crypto";
+import { join, relative, sep, posix } from "node:path";
+import type { Logger } from "pino";
+import { getComponentLogger } from "../logging/index.js";
+import { GitignoreFilter } from "../ingestion/gitignore-filter.js";
+import { DEFAULT_EXTENSIONS } from "../ingestion/default-extensions.js";
+import {
+  FileManifestStoreImpl,
+  type FileManifest,
+  type FileManifestEntry,
+} from "./file-manifest-store.js";
+import type { RepositoryInfo } from "../repositories/types.js";
+import type { FileChange } from "./incremental-update-types.js";
+
+/** Options controlling change-detection behavior. */
+export interface DetectOptions {
+  /**
+   * When `true`, recompute sha256 for every file even when `(size, mtime)`
+   * match the manifest. Off by default. Useful on filesystems that report
+   * unreliable mtimes (SMB, certain Docker bind mounts) — costlier but
+   * impervious to mtime drift.
+   */
+  paranoid?: boolean;
+}
+
+/**
+ * Result of a `detect()` call.
+ *
+ * `changes` is what the update pipeline consumes; `nextManifestFiles` is the
+ * fingerprint map the coordinator will persist after the pipeline succeeds
+ * (so a partial pipeline failure does NOT leave the on-disk manifest ahead
+ * of the actual chunk/graph state).
+ */
+export interface ChangeDetectionResult {
+  changes: FileChange[];
+  /** New per-file fingerprints, keyed by POSIX-relative path. */
+  nextManifestFiles: Record<string, FileManifestEntry>;
+}
+
+/**
+ * Detects file-level changes in a `local-folder` repository by diffing the
+ * filesystem against the persisted `FileManifest`.
+ */
+export class LocalFolderChangeDetector {
+  private readonly logger: Logger;
+  private readonly manifestStore: FileManifestStoreImpl;
+
+  constructor(manifestStore?: FileManifestStoreImpl) {
+    this.logger = getComponentLogger("services:local-folder-change-detector");
+    this.manifestStore = manifestStore ?? FileManifestStoreImpl.getInstance();
+  }
+
+  /**
+   * Diff the current state of `repo.localPath` against `repo`'s manifest.
+   *
+   * @param repo - Repository metadata (must have `source === "local-folder"`).
+   *   Caller is responsible for validating that the localPath still exists;
+   *   this method will surface filesystem errors as a thrown `Error` rather
+   *   than fabricating changes.
+   * @param opts - Detection options (paranoid mode).
+   * @returns Changes + the new fingerprint map for the next manifest write.
+   */
+  async detect(repo: RepositoryInfo, opts: DetectOptions = {}): Promise<ChangeDetectionResult> {
+    const startMs = Date.now();
+    const prior = await this.manifestStore.loadManifest(repo.name);
+    const filter = await GitignoreFilter.load(repo.localPath);
+    const extensions = new Set(
+      (repo.includeExtensions.length > 0 ? repo.includeExtensions : DEFAULT_EXTENSIONS).map((e) =>
+        e.toLowerCase()
+      )
+    );
+
+    // Build the "current snapshot" — POSIX relative path → (sizeBytes, mtimeMs).
+    const current = new Map<string, { absPath: string; sizeBytes: number; mtimeMs: number }>();
+    await this.walk(repo.localPath, repo.localPath, filter, extensions, current);
+
+    const changes: FileChange[] = [];
+    const nextManifestFiles: Record<string, FileManifestEntry> = {};
+
+    // Pass 1: files present in the current snapshot.
+    for (const [relPath, snap] of current.entries()) {
+      const priorEntry = prior.files[relPath];
+      const fastPathMatch =
+        !opts.paranoid &&
+        priorEntry !== undefined &&
+        priorEntry.sizeBytes === snap.sizeBytes &&
+        priorEntry.mtimeMs === snap.mtimeMs;
+
+      if (fastPathMatch && priorEntry) {
+        // Unchanged — carry the prior fingerprint forward without re-hashing.
+        nextManifestFiles[relPath] = priorEntry;
+        continue;
+      }
+
+      // Either added, modified, or paranoid recheck — we need a fresh hash.
+      let sha256: string;
+      try {
+        sha256 = await this.streamSha256(snap.absPath);
+      } catch (err) {
+        this.logger.warn({ relPath, err }, "Could not hash file; treating as unchanged");
+        if (priorEntry) nextManifestFiles[relPath] = priorEntry;
+        continue;
+      }
+
+      const fingerprint: FileManifestEntry = {
+        sha256,
+        sizeBytes: snap.sizeBytes,
+        mtimeMs: snap.mtimeMs,
+      };
+      nextManifestFiles[relPath] = fingerprint;
+
+      if (!priorEntry) {
+        changes.push({ path: relPath, status: "added" });
+      } else if (priorEntry.sha256 !== sha256) {
+        changes.push({ path: relPath, status: "modified" });
+      }
+      // else: hash matches; either a touch (mtime drift) or a paranoid hit.
+      // Either way the content is unchanged — no FileChange emitted.
+    }
+
+    // Pass 2: deletions — files in prior manifest but no longer on disk.
+    for (const relPath of Object.keys(prior.files)) {
+      if (!current.has(relPath)) {
+        changes.push({ path: relPath, status: "deleted" });
+      }
+    }
+
+    this.logger.info(
+      {
+        repository: repo.name,
+        currentFileCount: current.size,
+        priorFileCount: Object.keys(prior.files).length,
+        changeCount: changes.length,
+        durationMs: Date.now() - startMs,
+        paranoid: Boolean(opts.paranoid),
+      },
+      "Local folder change detection complete"
+    );
+
+    return { changes, nextManifestFiles };
+  }
+
+  /**
+   * Recursively walk `dir` accumulating per-file snapshots into `out`.
+   *
+   * Honors:
+   *   - the `GitignoreFilter` (nested .gitignore rules)
+   *   - the repo's extension whitelist
+   *   - symlinks: NOT followed (mirrors the size-pre-scan policy in
+   *     `IngestionService`; cycle and out-of-tree escape risks)
+   *
+   * @param rootPath - Repository root (used to compute POSIX-relative paths)
+   * @param dir - Current directory being walked
+   * @param filter - Pre-loaded nested .gitignore filter
+   * @param extensions - Lowercased extension whitelist (with leading dot)
+   * @param out - Map to fill, keyed by POSIX-relative path
+   */
+  private async walk(
+    rootPath: string,
+    dir: string,
+    filter: GitignoreFilter,
+    extensions: Set<string>,
+    out: Map<string, { absPath: string; sizeBytes: number; mtimeMs: number }>
+  ): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      this.logger.debug({ dir, err }, "readdir failed during walk; skipping");
+      return;
+    }
+
+    for (const entry of entries) {
+      if (entry.name === ".git") continue;
+      const absPath = join(dir, entry.name);
+      if (entry.isSymbolicLink()) continue;
+
+      if (entry.isDirectory()) {
+        if (filter.isIgnored(absPath)) continue;
+        await this.walk(rootPath, absPath, filter, extensions, out);
+        continue;
+      }
+
+      if (!entry.isFile()) continue;
+      if (filter.isIgnored(absPath)) continue;
+
+      const dotIdx = entry.name.lastIndexOf(".");
+      const ext = dotIdx >= 0 ? entry.name.substring(dotIdx).toLowerCase() : "";
+      if (!extensions.has(ext)) continue;
+
+      let st;
+      try {
+        st = await stat(absPath);
+      } catch {
+        continue;
+      }
+
+      const relPath = posix.normalize(
+        relative(rootPath, absPath).split(sep).join(posix.sep)
+      );
+      out.set(relPath, { absPath, sizeBytes: st.size, mtimeMs: st.mtimeMs });
+    }
+  }
+
+  /**
+   * Streaming SHA-256 of a file. Hex digest, 64 lowercase chars.
+   *
+   * Duplicated with `IngestionService.streamSha256` rather than extracted to a
+   * shared util because the two call sites have different lifetimes (one runs
+   * once at registration, the other on every update) and cross-importing
+   * pulled `IngestionService` into the change detector's dependency closure,
+   * which is undesirable.
+   */
+  private async streamSha256(absolutePath: string): Promise<string> {
+    return new Promise<string>((resolveHash, rejectHash) => {
+      const hash = createHash("sha256");
+      const stream = createReadStream(absolutePath);
+      stream.on("data", (chunk: string | Buffer) => hash.update(chunk));
+      stream.on("end", () => resolveHash(hash.digest("hex")));
+      stream.on("error", rejectHash);
+    });
+  }
+
+  /**
+   * Convenience helper for callers that need to write the next manifest after
+   * the update pipeline succeeds. Wraps the entries in the standard manifest
+   * envelope and delegates to the store.
+   */
+  buildNextManifest(repository: string, entries: Record<string, FileManifestEntry>): FileManifest {
+    return {
+      version: "1.0",
+      repository,
+      generatedAt: new Date().toISOString(),
+      files: entries,
+    };
+  }
+}

--- a/src/services/local-folder-change-detector.ts
+++ b/src/services/local-folder-change-detector.ts
@@ -128,8 +128,24 @@ export class LocalFolderChangeDetector {
       try {
         sha256 = await this.streamSha256(snap.absPath);
       } catch (err) {
-        this.logger.warn({ relPath, err }, "Could not hash file; treating as unchanged");
-        if (priorEntry) nextManifestFiles[relPath] = priorEntry;
+        // Hash failure (transient I/O, permission flake, etc.) — emit the
+        // file as `modified` (or `added` when no prior entry) and DROP it
+        // from the next manifest. This forces a re-hash on the next update
+        // rather than leaving the prior fingerprint in place, which would
+        // make a genuinely-modified-but-temporarily-unreadable file look
+        // unchanged forever once the read recovers and `(size, mtime)`
+        // happens to match.
+        this.logger.warn(
+          { relPath, err },
+          "Could not hash file; emitting as changed and skipping fingerprint"
+        );
+        if (priorEntry) {
+          changes.push({ path: relPath, status: "modified" });
+        } else {
+          changes.push({ path: relPath, status: "added" });
+        }
+        // Intentionally do NOT add an entry to nextManifestFiles for this path —
+        // the next walk will discover it again and try to hash from scratch.
         continue;
       }
 
@@ -226,9 +242,7 @@ export class LocalFolderChangeDetector {
         continue;
       }
 
-      const relPath = posix.normalize(
-        relative(rootPath, absPath).split(sep).join(posix.sep)
-      );
+      const relPath = posix.normalize(relative(rootPath, absPath).split(sep).join(posix.sep));
       out.set(relPath, { absPath, sizeBytes: st.size, mtimeMs: st.mtimeMs });
     }
   }

--- a/src/services/local-folder-change-detector.ts
+++ b/src/services/local-folder-change-detector.ts
@@ -27,14 +27,19 @@
  * @module services/local-folder-change-detector
  */
 
-import { readdir, stat } from "node:fs/promises";
-import { createReadStream } from "node:fs";
-import { createHash } from "node:crypto";
+import { readdir } from "node:fs/promises";
 import { join, relative, sep, posix } from "node:path";
 import type { Logger } from "pino";
 import { getComponentLogger } from "../logging/index.js";
 import { GitignoreFilter } from "../ingestion/gitignore-filter.js";
 import { DEFAULT_EXTENSIONS } from "../ingestion/default-extensions.js";
+import {
+  shouldDescendDir,
+  shouldIncludeFile,
+  DEFAULT_MAX_FILE_SIZE_BYTES,
+  type DirEntryLike,
+} from "../ingestion/file-eligibility.js";
+import { streamSha256 } from "../ingestion/sha256-stream.js";
 import {
   FileManifestStoreImpl,
   type FileManifest,
@@ -95,7 +100,7 @@ export class LocalFolderChangeDetector {
     const startMs = Date.now();
     const prior = await this.manifestStore.loadManifest(repo.name);
     const filter = await GitignoreFilter.load(repo.localPath);
-    const extensions = new Set(
+    const extensions: Set<string> = new Set(
       (repo.includeExtensions.length > 0 ? repo.includeExtensions : DEFAULT_EXTENSIONS).map((e) =>
         e.toLowerCase()
       )
@@ -126,7 +131,7 @@ export class LocalFolderChangeDetector {
       // Either added, modified, or paranoid recheck — we need a fresh hash.
       let sha256: string;
       try {
-        sha256 = await this.streamSha256(snap.absPath);
+        sha256 = await streamSha256(snap.absPath);
       } catch (err) {
         // Hash failure (transient I/O, permission flake, etc.) — emit the
         // file as `modified` (or `added` when no prior entry) and DROP it
@@ -190,11 +195,11 @@ export class LocalFolderChangeDetector {
   /**
    * Recursively walk `dir` accumulating per-file snapshots into `out`.
    *
-   * Honors:
-   *   - the `GitignoreFilter` (nested .gitignore rules)
-   *   - the repo's extension whitelist
-   *   - symlinks: NOT followed (mirrors the size-pre-scan policy in
-   *     `IngestionService`; cycle and out-of-tree escape risks)
+   * Eligibility (gitignore, extension whitelist, default exclusions, dotfile
+   * skip, VCS metadata skip, size cap, symlink skip) is delegated to the
+   * shared `shouldDescendDir` / `shouldIncludeFile` predicates so this walk
+   * agrees with `FileScanner` on what counts as an indexable file. See
+   * `src/ingestion/file-eligibility.ts` for the full rule list.
    *
    * @param rootPath - Repository root (used to compute POSIX-relative paths)
    * @param dir - Current directory being walked
@@ -218,52 +223,33 @@ export class LocalFolderChangeDetector {
     }
 
     for (const entry of entries) {
-      if (entry.name === ".git") continue;
       const absPath = join(dir, entry.name);
+      // Symlinks are never followed (cycle / out-of-tree escape).
       if (entry.isSymbolicLink()) continue;
 
       if (entry.isDirectory()) {
-        if (filter.isIgnored(absPath)) continue;
+        if (!shouldDescendDir(absPath, entry.name, filter)) continue;
         await this.walk(rootPath, absPath, filter, extensions, out);
         continue;
       }
 
       if (!entry.isFile()) continue;
-      if (filter.isIgnored(absPath)) continue;
 
-      const dotIdx = entry.name.lastIndexOf(".");
-      const ext = dotIdx >= 0 ? entry.name.substring(dotIdx).toLowerCase() : "";
-      if (!extensions.has(ext)) continue;
-
-      let st;
-      try {
-        st = await stat(absPath);
-      } catch {
-        continue;
-      }
+      const ent: DirEntryLike = { name: entry.name, isDir: false, isSymlink: false };
+      const verdict = await shouldIncludeFile(absPath, ent, {
+        gitignore: filter,
+        extensions,
+        maxSizeBytes: DEFAULT_MAX_FILE_SIZE_BYTES,
+      });
+      if (!verdict.eligible || !verdict.stats) continue;
 
       const relPath = posix.normalize(relative(rootPath, absPath).split(sep).join(posix.sep));
-      out.set(relPath, { absPath, sizeBytes: st.size, mtimeMs: st.mtimeMs });
+      out.set(relPath, {
+        absPath,
+        sizeBytes: verdict.stats.size,
+        mtimeMs: verdict.stats.mtimeMs,
+      });
     }
-  }
-
-  /**
-   * Streaming SHA-256 of a file. Hex digest, 64 lowercase chars.
-   *
-   * Duplicated with `IngestionService.streamSha256` rather than extracted to a
-   * shared util because the two call sites have different lifetimes (one runs
-   * once at registration, the other on every update) and cross-importing
-   * pulled `IngestionService` into the change detector's dependency closure,
-   * which is undesirable.
-   */
-  private async streamSha256(absolutePath: string): Promise<string> {
-    return new Promise<string>((resolveHash, rejectHash) => {
-      const hash = createHash("sha256");
-      const stream = createReadStream(absolutePath);
-      stream.on("data", (chunk: string | Buffer) => hash.update(chunk));
-      stream.on("end", () => resolveHash(hash.digest("hex")));
-      stream.on("error", rejectHash);
-    });
   }
 
   /**

--- a/src/services/local-folder-update-coordinator.ts
+++ b/src/services/local-folder-update-coordinator.ts
@@ -1,0 +1,348 @@
+/**
+ * Incremental update coordinator for `local-folder` repositories.
+ *
+ * Mirrors the surface of {@link IncrementalUpdateCoordinator} —
+ * `updateRepository(name)` returns the same `CoordinatorResult` — so the
+ * `trigger_incremental_update` MCP tool can dispatch on `repo.source` without
+ * the call site caring which backend ran.
+ *
+ * The git-flavored coordinator drives change detection from `git diff`
+ * (against GitHub's API or `simple-git`) and treats the commit SHA as the
+ * version anchor. This local-folder variant drives change detection from a
+ * persisted `FileManifest` — a per-file `(sha256, size, mtime)` map — and
+ * records `local-<isoDate>` markers in `UpdateHistoryEntry` instead of git
+ * SHAs (the `RepositoryInfo` schema was relaxed in Phase A specifically to
+ * accept these).
+ *
+ * Failure semantics match the git coordinator's:
+ *
+ *   - `drift_detected` → the registered `localPath` is missing or unreadable
+ *     (user moved or deleted the folder). Recoverable via re-registration.
+ *   - `no_changes`     → the change detector returned an empty diff.
+ *   - `updated`        → pipeline ran; manifest rewritten; metadata advanced.
+ *   - `failed`         → pipeline rejected ALL files; manifest left untouched.
+ *
+ * @module services/local-folder-update-coordinator
+ */
+
+import { stat } from "node:fs/promises";
+import type { Logger } from "pino";
+import { getComponentLogger } from "../logging/index.js";
+import type {
+  RepositoryMetadataService,
+  RepositoryInfo,
+  UpdateHistoryEntry,
+} from "../repositories/types.js";
+import type { IncrementalUpdatePipeline } from "./incremental-update-pipeline.js";
+import { addHistoryEntry } from "../repositories/metadata-store.js";
+import type { CoordinatorResult } from "./incremental-update-coordinator-types.js";
+import {
+  RepositoryNotFoundError,
+  ConcurrentUpdateError,
+} from "./incremental-update-coordinator-errors.js";
+import {
+  FileManifestStoreImpl,
+  FILE_MANIFEST_EMPTY_GENERATED_AT,
+} from "./file-manifest-store.js";
+import { LocalFolderChangeDetector } from "./local-folder-change-detector.js";
+
+/** Configuration accepted by the coordinator constructor. */
+export interface LocalFolderCoordinatorConfig {
+  /** Optional history-rotation cap, mirroring the git coordinator's option. */
+  updateHistoryLimit?: number;
+}
+
+/**
+ * Coordinator for incremental updates of `local-folder` repositories.
+ */
+export class LocalFolderUpdateCoordinator {
+  private readonly logger: Logger;
+  private readonly updateHistoryLimit: number;
+
+  constructor(
+    private readonly repositoryService: RepositoryMetadataService,
+    private readonly updatePipeline: IncrementalUpdatePipeline,
+    private readonly changeDetector: LocalFolderChangeDetector = new LocalFolderChangeDetector(),
+    private readonly manifestStore: FileManifestStoreImpl = FileManifestStoreImpl.getInstance(),
+    config: LocalFolderCoordinatorConfig = {}
+  ) {
+    this.logger = getComponentLogger("services:local-folder-update-coordinator");
+    this.updateHistoryLimit = config.updateHistoryLimit ?? 50;
+  }
+
+  /**
+   * Run an incremental update for a `local-folder` repository.
+   *
+   * Defensive against being invoked for a repo whose `source` is not
+   * `local-folder` — returns a `failed` result with a descriptive error rather
+   * than touching the pipeline. The dispatch in `trigger_incremental_update.ts`
+   * already routes by source, but a second layer here makes the coordinator
+   * safe to call directly from tests and future call sites.
+   *
+   * @param repositoryName - Name from `RepositoryInfo.name`.
+   * @returns `CoordinatorResult` with the same shape the git coordinator emits.
+   */
+  async updateRepository(repositoryName: string): Promise<CoordinatorResult> {
+    const startTime = Date.now();
+    const logger = this.logger.child({ repository: repositoryName });
+
+    let inProgressFlagSet = false;
+    let repo: RepositoryInfo | null = null;
+
+    try {
+      repo = await this.repositoryService.getRepository(repositoryName);
+      if (!repo) {
+        throw new RepositoryNotFoundError(repositoryName);
+      }
+
+      if (repo.source !== "local-folder") {
+        logger.warn(
+          { source: repo.source },
+          "LocalFolderUpdateCoordinator invoked for non-local-folder repo; refusing"
+        );
+        return this.failedResult(
+          `Repository '${repositoryName}' has source '${repo.source}', not 'local-folder'.`,
+          startTime
+        );
+      }
+
+      // Concurrent-update guard mirrors the git coordinator (line 253).
+      if (repo.updateInProgress && repo.updateStartedAt) {
+        throw new ConcurrentUpdateError(repositoryName, repo.updateStartedAt);
+      }
+
+      // Drift: the registered folder is gone (user moved, renamed, or deleted it).
+      // No exception — return drift_detected, the existing surface for this state.
+      const localPathOk = await this.localPathExistsAsDirectory(repo.localPath);
+      if (!localPathOk) {
+        logger.warn(
+          { localPath: repo.localPath },
+          "Drift detected — registered local folder no longer exists or is not readable"
+        );
+        return {
+          status: "drift_detected",
+          stats: this.zeroStats(),
+          errors: [],
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      // Mark in-progress so a crash mid-pipeline is recoverable on next call.
+      const updateStartedAt = new Date().toISOString();
+      await this.repositoryService.updateRepository({
+        ...repo,
+        updateInProgress: true,
+        updateStartedAt,
+      });
+      inProgressFlagSet = true;
+
+      // Detect changes against the prior manifest.
+      const priorManifest = await this.manifestStore.loadManifest(repositoryName);
+      const { changes, nextManifestFiles } = await this.changeDetector.detect(repo);
+
+      if (changes.length === 0) {
+        // No changes — clear in-progress and bail. We deliberately do NOT rewrite
+        // the manifest here because nothing changed; keeping the prior generatedAt
+        // makes "last update timestamp" diagnostics more meaningful.
+        await this.repositoryService.updateRepository({
+          ...repo,
+          updateInProgress: false,
+          updateStartedAt: undefined,
+        });
+        inProgressFlagSet = false;
+        logger.info("No changes detected — local folder is up to date");
+        return {
+          status: "no_changes",
+          stats: this.zeroStats(),
+          errors: [],
+          durationMs: Date.now() - startTime,
+        };
+      }
+
+      // Run the existing pipeline. Its contract is source-agnostic — it consumes
+      // FileChange[] without caring whether they came from git diff or a
+      // manifest diff (incremental-update-pipeline.ts:161).
+      const pipelineResult = await this.updatePipeline.processChanges(changes, {
+        repository: repo.name,
+        localPath: repo.localPath,
+        collectionName: repo.collectionName,
+        includeExtensions: repo.includeExtensions,
+        excludePatterns: repo.excludePatterns,
+      });
+
+      const totalFilesProcessed =
+        pipelineResult.stats.filesAdded +
+        pipelineResult.stats.filesModified +
+        pipelineResult.stats.filesDeleted;
+
+      let historyStatus: "success" | "partial" | "failed" | "incomplete";
+      if (pipelineResult.errors.length === 0) {
+        historyStatus = "success";
+      } else if (totalFilesProcessed === 0) {
+        historyStatus = "failed";
+      } else if (pipelineResult.errors.length >= totalFilesProcessed) {
+        historyStatus = "failed";
+      } else {
+        historyStatus = "partial";
+      }
+
+      // Rewrite the manifest ONLY if the pipeline didn't outright fail. Leaving
+      // the prior manifest in place on full failure means the next update sees
+      // the same diff and can retry, rather than silently advancing the
+      // baseline past unprocessed files.
+      const manifestRewritten = historyStatus !== "failed";
+      const newManifest = this.changeDetector.buildNextManifest(
+        repositoryName,
+        nextManifestFiles
+      );
+      if (manifestRewritten) {
+        await this.manifestStore.saveManifest(repositoryName, newManifest);
+      }
+
+      // Synthetic SHA markers per Phase A's relaxed schema. The "previous"
+      // marker is the manifest we diffed against; "new" is the manifest we
+      // just wrote (or would have written, if we wrote one).
+      const previousMarker =
+        priorManifest.generatedAt === FILE_MANIFEST_EMPTY_GENERATED_AT
+          ? `local-${FILE_MANIFEST_EMPTY_GENERATED_AT}`
+          : `local-${priorManifest.generatedAt}`;
+      const newMarker = manifestRewritten
+        ? `local-${newManifest.generatedAt}`
+        : previousMarker;
+
+      const historyEntry: UpdateHistoryEntry = {
+        timestamp: new Date().toISOString(),
+        previousCommit: previousMarker,
+        newCommit: newMarker,
+        filesAdded: pipelineResult.stats.filesAdded,
+        filesModified: pipelineResult.stats.filesModified,
+        filesDeleted: pipelineResult.stats.filesDeleted,
+        chunksUpserted: pipelineResult.stats.chunksUpserted,
+        chunksDeleted: pipelineResult.stats.chunksDeleted,
+        durationMs: pipelineResult.stats.durationMs,
+        errorCount: pipelineResult.errors.length,
+        status: historyStatus,
+        skippedFileCount: pipelineResult.filterStats.skippedChanges,
+        eligibleFileCount: pipelineResult.filterStats.eligibleChanges,
+        ...(pipelineResult.stats.graph && {
+          graphNodesCreated: pipelineResult.stats.graph.graphNodesCreated,
+          graphNodesDeleted: pipelineResult.stats.graph.graphNodesDeleted,
+          graphRelationshipsCreated: pipelineResult.stats.graph.graphRelationshipsCreated,
+          graphRelationshipsDeleted: pipelineResult.stats.graph.graphRelationshipsDeleted,
+          graphFilesProcessed: pipelineResult.stats.graph.graphFilesProcessed,
+          graphFilesSkipped: pipelineResult.stats.graph.graphFilesSkipped,
+          graphErrorCount: pipelineResult.stats.graph.graphErrors.length,
+        }),
+      };
+
+      const updatedHistory = addHistoryEntry(
+        repo.updateHistory,
+        historyEntry,
+        this.updateHistoryLimit
+      );
+
+      const updatedMetadata: RepositoryInfo = {
+        ...repo,
+        updateHistory: updatedHistory,
+        lastIncrementalUpdateAt: new Date().toISOString(),
+        incrementalUpdateCount: (repo.incrementalUpdateCount || 0) + 1,
+        fileCount:
+          repo.fileCount + pipelineResult.stats.filesAdded - pipelineResult.stats.filesDeleted,
+        chunkCount:
+          repo.chunkCount +
+          pipelineResult.stats.chunksUpserted -
+          pipelineResult.stats.chunksDeleted,
+        status: historyStatus === "failed" ? "error" : "ready",
+        errorMessage:
+          historyStatus === "failed"
+            ? `Incremental update failed with ${pipelineResult.errors.length} error(s)`
+            : undefined,
+        updateInProgress: false,
+        updateStartedAt: undefined,
+      };
+
+      await this.repositoryService.updateRepository(updatedMetadata);
+      inProgressFlagSet = false;
+
+      const resultStatus: CoordinatorResult["status"] =
+        historyStatus === "failed" ? "failed" : "updated";
+
+      const durationMs = Date.now() - startTime;
+      logger.info(
+        {
+          status: resultStatus,
+          filesAdded: pipelineResult.stats.filesAdded,
+          filesModified: pipelineResult.stats.filesModified,
+          filesDeleted: pipelineResult.stats.filesDeleted,
+          durationMs,
+        },
+        "Local folder incremental update completed"
+      );
+
+      return {
+        status: resultStatus,
+        commitSha: newMarker,
+        commitMessage: undefined,
+        stats: pipelineResult.stats,
+        errors: pipelineResult.errors,
+        durationMs,
+      };
+    } catch (error) {
+      logger.error(
+        { err: error },
+        "Local folder incremental update failed with unhandled error"
+      );
+      throw error;
+    } finally {
+      // Mirror the git coordinator's safety net: if we set the in-progress
+      // flag and didn't clear it on the happy path, clear it now so the next
+      // attempt isn't blocked by a stale lock.
+      if (inProgressFlagSet && repo) {
+        try {
+          const current = await this.repositoryService.getRepository(repositoryName);
+          if (current && current.updateInProgress) {
+            await this.repositoryService.updateRepository({
+              ...current,
+              updateInProgress: false,
+              updateStartedAt: undefined,
+            });
+          }
+        } catch (cleanupErr) {
+          this.logger.warn(
+            { err: cleanupErr, repository: repositoryName },
+            "Failed to clear in-progress flag during error cleanup"
+          );
+        }
+      }
+    }
+  }
+
+  private async localPathExistsAsDirectory(absPath: string): Promise<boolean> {
+    try {
+      const st = await stat(absPath);
+      return st.isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
+  private zeroStats(): CoordinatorResult["stats"] {
+    return {
+      filesAdded: 0,
+      filesModified: 0,
+      filesDeleted: 0,
+      chunksUpserted: 0,
+      chunksDeleted: 0,
+      durationMs: 0,
+    };
+  }
+
+  private failedResult(message: string, startTime: number): CoordinatorResult {
+    return {
+      status: "failed",
+      stats: this.zeroStats(),
+      errors: [{ path: "(coordinator)", error: message }],
+      durationMs: Date.now() - startTime,
+    };
+  }
+}

--- a/src/services/local-folder-update-coordinator.ts
+++ b/src/services/local-folder-update-coordinator.ts
@@ -40,10 +40,7 @@ import {
   RepositoryNotFoundError,
   ConcurrentUpdateError,
 } from "./incremental-update-coordinator-errors.js";
-import {
-  FileManifestStoreImpl,
-  FILE_MANIFEST_EMPTY_GENERATED_AT,
-} from "./file-manifest-store.js";
+import { FileManifestStoreImpl, FILE_MANIFEST_EMPTY_GENERATED_AT } from "./file-manifest-store.js";
 import { LocalFolderChangeDetector } from "./local-folder-change-detector.js";
 
 /** Configuration accepted by the coordinator constructor. */
@@ -186,15 +183,29 @@ export class LocalFolderUpdateCoordinator {
         historyStatus = "partial";
       }
 
+      // For files the pipeline reported errors on, carry the PRIOR fingerprint
+      // forward instead of the freshly-walked one. Without this, a partial
+      // failure rewrites the manifest with the new (sha256, size, mtime) of an
+      // errored file, so the next update sees a clean diff and never retries it
+      // — silent permanent data loss in the index. If the file had no prior
+      // fingerprint (it was an `added` change that errored), drop it from the
+      // manifest entirely so the next walk reports it as `added` again.
+      const errorPaths = new Set(pipelineResult.errors.map((e) => e.path));
+      for (const errPath of errorPaths) {
+        const prior = priorManifest.files[errPath];
+        if (prior) {
+          nextManifestFiles[errPath] = prior;
+        } else {
+          delete nextManifestFiles[errPath];
+        }
+      }
+
       // Rewrite the manifest ONLY if the pipeline didn't outright fail. Leaving
       // the prior manifest in place on full failure means the next update sees
       // the same diff and can retry, rather than silently advancing the
       // baseline past unprocessed files.
       const manifestRewritten = historyStatus !== "failed";
-      const newManifest = this.changeDetector.buildNextManifest(
-        repositoryName,
-        nextManifestFiles
-      );
+      const newManifest = this.changeDetector.buildNextManifest(repositoryName, nextManifestFiles);
       if (manifestRewritten) {
         await this.manifestStore.saveManifest(repositoryName, newManifest);
       }
@@ -206,9 +217,7 @@ export class LocalFolderUpdateCoordinator {
         priorManifest.generatedAt === FILE_MANIFEST_EMPTY_GENERATED_AT
           ? `local-${FILE_MANIFEST_EMPTY_GENERATED_AT}`
           : `local-${priorManifest.generatedAt}`;
-      const newMarker = manifestRewritten
-        ? `local-${newManifest.generatedAt}`
-        : previousMarker;
+      const newMarker = manifestRewritten ? `local-${newManifest.generatedAt}` : previousMarker;
 
       const historyEntry: UpdateHistoryEntry = {
         timestamp: new Date().toISOString(),
@@ -288,10 +297,7 @@ export class LocalFolderUpdateCoordinator {
         durationMs,
       };
     } catch (error) {
-      logger.error(
-        { err: error },
-        "Local folder incremental update failed with unhandled error"
-      );
+      logger.error({ err: error }, "Local folder incremental update failed with unhandled error");
       throw error;
     } finally {
       // Mirror the git coordinator's safety net: if we set the in-progress

--- a/src/services/local-folder-update-coordinator.ts
+++ b/src/services/local-folder-update-coordinator.ts
@@ -104,6 +104,24 @@ export class LocalFolderUpdateCoordinator {
       }
 
       // Concurrent-update guard mirrors the git coordinator (line 253).
+      //
+      // TOCTOU caveat (PR #573 review M-4): the read here and the write below
+      // (`updateInProgress: true`) are separate operations. The MCP path is
+      // safe because `JobTracker` and the rate limiter dedupe concurrent
+      // invocations before they reach the coordinator. Direct callers (CLI
+      // `pk-mcp update`, recovery) carry a small race risk: two concurrent
+      // CLI invocations could both observe `updateInProgress=false`, both
+      // proceed to set it to `true`, and then race the metadata writes at
+      // line ~273. Manifest writes are serialized per-repo via the
+      // `FileManifestStoreImpl` write queue so the index itself stays
+      // consistent; the only observable effect is the LATER of the two
+      // metadata writes overwriting the earlier one.
+      //
+      // TODO(local-folder-toctou): replace with an atomic
+      // `RepositoryMetadataService.compareAndSetUpdateInProgress(name, false)`
+      // once the metadata store grows that primitive. Tracked as a follow-up
+      // issue separate from this PR — the CLI risk is low (single-user
+      // workflow) and the MCP path is already safe.
       if (repo.updateInProgress && repo.updateStartedAt) {
         throw new ConcurrentUpdateError(repositoryName, repo.updateStartedAt);
       }

--- a/src/services/orphan-manifest-reaper.ts
+++ b/src/services/orphan-manifest-reaper.ts
@@ -1,0 +1,102 @@
+/**
+ * Orphan FileManifest reaper.
+ *
+ * On startup, deletes any persisted `FileManifest` whose repository name does
+ * not appear in `RepositoryMetadataService.listRepositories()`. This addresses
+ * PR #573 review M-2: a `local-folder` registration that crashes between
+ * `writeInitialFileManifest` and `repositoryService.updateRepository` leaves
+ * a manifest file on disk with no matching metadata entry. If the user then
+ * re-registers the same path under a DIFFERENT name, the original orphan
+ * persists indefinitely — `removeRepository` only deletes manifests for names
+ * the metadata store knows about.
+ *
+ * The reaper is idempotent and best-effort: failures to delete an individual
+ * orphan are logged at warn level and don't block boot. We never DELETE a
+ * manifest that has a metadata entry, so the reaper cannot regress active
+ * repositories.
+ *
+ * @module services/orphan-manifest-reaper
+ */
+
+import { getComponentLogger } from "../logging/index.js";
+import type { RepositoryMetadataService } from "../repositories/types.js";
+import type { FileManifestStoreService } from "./file-manifest-store.js";
+
+/**
+ * Result of a single reaper invocation.
+ *
+ * Surfaced to the caller for logging / observability — there's no further
+ * action required because the orphans have already been deleted.
+ */
+export interface ReaperResult {
+  /** Total manifests examined. */
+  totalManifests: number;
+  /** Names of manifests deleted as orphans. */
+  reaped: string[];
+  /** Names of manifests retained because they have a metadata entry. */
+  retained: string[];
+  /** Names that were detected as orphans but failed to delete. */
+  failed: string[];
+}
+
+/**
+ * Delete every persisted manifest whose repository name is absent from the
+ * metadata store.
+ *
+ * @param metadataService Source of truth for valid repository names.
+ * @param manifestStore Manifest persistence layer (typically the singleton
+ *   `FileManifestStoreImpl.getInstance()`).
+ * @returns A {@link ReaperResult} summarizing what was reaped and retained.
+ */
+export async function pruneOrphanManifests(
+  metadataService: RepositoryMetadataService,
+  manifestStore: FileManifestStoreService
+): Promise<ReaperResult> {
+  const logger = getComponentLogger("services:orphan-manifest-reaper");
+
+  const [registeredRepos, manifestRepos] = await Promise.all([
+    metadataService.listRepositories(),
+    manifestStore.listManifests(),
+  ]);
+
+  const knownNames = new Set<string>(registeredRepos.map((r) => r.name));
+  const reaped: string[] = [];
+  const retained: string[] = [];
+  const failed: string[] = [];
+
+  for (const name of manifestRepos) {
+    if (knownNames.has(name)) {
+      retained.push(name);
+      continue;
+    }
+    try {
+      await manifestStore.deleteManifest(name);
+      reaped.push(name);
+    } catch (err) {
+      failed.push(name);
+      logger.warn(
+        { repository: name, err },
+        "Failed to delete orphan manifest (will retry on next boot)"
+      );
+    }
+  }
+
+  if (reaped.length > 0) {
+    logger.info(
+      { reapedCount: reaped.length, reaped, retained: retained.length },
+      "Reaped orphan FileManifest entries"
+    );
+  } else {
+    logger.debug(
+      { totalManifests: manifestRepos.length, retained: retained.length },
+      "No orphan manifests detected"
+    );
+  }
+
+  return {
+    totalManifests: manifestRepos.length,
+    reaped,
+    retained,
+    failed,
+  };
+}

--- a/src/services/update-coordinator-dispatch.ts
+++ b/src/services/update-coordinator-dispatch.ts
@@ -1,0 +1,53 @@
+/**
+ * Shared dispatch helper for picking the right update coordinator based on
+ * a repository's `source`.
+ *
+ * Phase B introduced a parallel coordinator (`LocalFolderUpdateCoordinator`)
+ * for `local-folder` repositories because the existing
+ * `IncrementalUpdateCoordinator` requires a git commit SHA which local-folder
+ * repos don't have. Multiple call sites — the `trigger_incremental_update`
+ * MCP tool, the `pk-mcp update` and `update-all` CLI commands, and the
+ * interrupted-update recovery service — all need the same dispatch logic.
+ * Centralizing it here keeps the rule in one place.
+ *
+ * @module services/update-coordinator-dispatch
+ */
+
+import type { RepositoryInfo } from "../repositories/types.js";
+import type { CoordinatorResult } from "./incremental-update-coordinator-types.js";
+import type { IncrementalUpdateCoordinator } from "./incremental-update-coordinator.js";
+import type { LocalFolderUpdateCoordinator } from "./local-folder-update-coordinator.js";
+
+/**
+ * Minimal structural surface every update coordinator must expose. Both
+ * `IncrementalUpdateCoordinator` and `LocalFolderUpdateCoordinator` satisfy
+ * this implicitly via duck typing.
+ */
+export interface UpdateCoordinatorLike {
+  updateRepository(repositoryName: string): Promise<CoordinatorResult>;
+}
+
+/**
+ * Pick the coordinator that matches `repo.source`.
+ *
+ * Returns `undefined` when the repo is `local-folder` but no
+ * `localFolderCoordinator` was supplied — callers must handle this and
+ * surface an error rather than misroute through the git coordinator (which
+ * would throw `MissingCommitShaError` because local-folder repos have no
+ * `lastIndexedCommitSha`).
+ *
+ * @param repo - The resolved `RepositoryInfo` for the target repository.
+ * @param gitCoordinator - Coordinator used for `git-remote` and `local-git`.
+ * @param localFolderCoordinator - Coordinator used for `local-folder`. May be
+ *   `undefined` in legacy bootstrap paths.
+ */
+export function dispatchCoordinator(
+  repo: RepositoryInfo,
+  gitCoordinator: IncrementalUpdateCoordinator,
+  localFolderCoordinator?: LocalFolderUpdateCoordinator
+): UpdateCoordinatorLike | undefined {
+  if (repo.source === "local-folder") {
+    return localFolderCoordinator;
+  }
+  return gitCoordinator;
+}

--- a/tests/cli/commands/update-repository-command.test.ts
+++ b/tests/cli/commands/update-repository-command.test.ts
@@ -512,9 +512,14 @@ describe("Update Repository Command", () => {
 
       await updateRepositoryCommand("test-repo", options, mockDeps);
 
+      // Phase B: force re-index now passes `name` and `tier` through, and
+      // falls back to `localPath` for local-folder repos (which have null url).
+      // For this git-remote fixture the URL is still the source.
       expect(mockIndexRepository).toHaveBeenCalledWith(sampleRepo.url, {
+        name: sampleRepo.name,
         branch: sampleRepo.branch,
         force: true,
+        tier: sampleRepo.tier,
         onProgress: expect.any(Function),
       });
 

--- a/tests/ingestion/gitignore-filter.test.ts
+++ b/tests/ingestion/gitignore-filter.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Unit tests for GitignoreFilter (T2.3 / T2.4 acceptance).
+ *
+ * @module tests/ingestion/gitignore-filter
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { GitignoreFilter } from "../../src/ingestion/gitignore-filter.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+
+describe("GitignoreFilter", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    testDir = join(import.meta.dir, "..", "..", "test-temp", `gitignore-${Date.now()}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("returns false (not ignored) when no .gitignore exists anywhere", async () => {
+    await writeFile(join(testDir, "a.ts"), "x");
+    await mkdir(join(testDir, "src"), { recursive: true });
+    await writeFile(join(testDir, "src", "b.ts"), "x");
+
+    const filter = await GitignoreFilter.load(testDir);
+
+    expect(filter.isIgnored(join(testDir, "a.ts"))).toBe(false);
+    expect(filter.isIgnored(join(testDir, "src", "b.ts"))).toBe(false);
+    expect(filter.ruleFileCount).toBe(0);
+  });
+
+  it("honors a root .gitignore", async () => {
+    await writeFile(join(testDir, ".gitignore"), "node_modules/\n*.log\n");
+    await mkdir(join(testDir, "node_modules"), { recursive: true });
+    await writeFile(join(testDir, "node_modules", "pkg.js"), "x");
+    await writeFile(join(testDir, "app.log"), "x");
+    await writeFile(join(testDir, "app.ts"), "x");
+
+    const filter = await GitignoreFilter.load(testDir);
+
+    expect(filter.isIgnored(join(testDir, "node_modules", "pkg.js"))).toBe(true);
+    expect(filter.isIgnored(join(testDir, "app.log"))).toBe(true);
+    expect(filter.isIgnored(join(testDir, "app.ts"))).toBe(false);
+  });
+
+  it("merges nested .gitignore so a deeper rule scopes correctly", async () => {
+    // Root says ignore *.tmp; nested folder /docs/.gitignore adds *.bak.
+    await writeFile(join(testDir, ".gitignore"), "*.tmp\n");
+    await mkdir(join(testDir, "docs"), { recursive: true });
+    await writeFile(join(testDir, "docs", ".gitignore"), "*.bak\n");
+    await writeFile(join(testDir, "x.tmp"), "x");
+    await writeFile(join(testDir, "docs", "y.tmp"), "x");
+    await writeFile(join(testDir, "docs", "z.bak"), "x");
+    await writeFile(join(testDir, "y.bak"), "x");
+    await writeFile(join(testDir, "keep.md"), "x");
+
+    const filter = await GitignoreFilter.load(testDir);
+
+    // Root rule applies everywhere.
+    expect(filter.isIgnored(join(testDir, "x.tmp"))).toBe(true);
+    expect(filter.isIgnored(join(testDir, "docs", "y.tmp"))).toBe(true);
+    // Nested rule only inside docs/.
+    expect(filter.isIgnored(join(testDir, "docs", "z.bak"))).toBe(true);
+    expect(filter.isIgnored(join(testDir, "y.bak"))).toBe(false);
+    // Files not matched by either rule.
+    expect(filter.isIgnored(join(testDir, "keep.md"))).toBe(false);
+  });
+
+  it("supports negation (!keep.txt) in a nested .gitignore", async () => {
+    await writeFile(join(testDir, ".gitignore"), "*.txt\n");
+    await mkdir(join(testDir, "vendor"), { recursive: true });
+    // Inside vendor we want to keep one specific txt file.
+    await writeFile(join(testDir, "vendor", ".gitignore"), "!keep.txt\n");
+    await writeFile(join(testDir, "vendor", "drop.txt"), "x");
+    await writeFile(join(testDir, "vendor", "keep.txt"), "x");
+    await writeFile(join(testDir, "drop-too.txt"), "x");
+
+    const filter = await GitignoreFilter.load(testDir);
+
+    expect(filter.isIgnored(join(testDir, "drop-too.txt"))).toBe(true);
+    expect(filter.isIgnored(join(testDir, "vendor", "drop.txt"))).toBe(true);
+    expect(filter.isIgnored(join(testDir, "vendor", "keep.txt"))).toBe(false);
+  });
+
+  it("rejects paths outside the root as ignored (defense against escapes)", async () => {
+    const filter = await GitignoreFilter.load(testDir);
+    // A sibling path outside the rootPath is reported ignored — callers must not
+    // accidentally process files outside the registered folder.
+    expect(filter.isIgnored("C:/some/other/path/file.ts")).toBe(true);
+  });
+
+  it("filterAbsolute returns only paths that survive the filter", async () => {
+    await writeFile(join(testDir, ".gitignore"), "node_modules/\n");
+    await mkdir(join(testDir, "node_modules"), { recursive: true });
+    await writeFile(join(testDir, "node_modules", "x.js"), "x");
+    await writeFile(join(testDir, "src.ts"), "x");
+
+    const filter = await GitignoreFilter.load(testDir);
+    const survivors = filter.filterAbsolute([
+      join(testDir, "node_modules", "x.js"),
+      join(testDir, "src.ts"),
+    ]);
+
+    expect(survivors).toEqual([join(testDir, "src.ts")]);
+  });
+
+  it("does not crash on unreadable .gitignore (logged + skipped)", async () => {
+    // Write a directory at the .gitignore path — readFile will fail with EISDIR.
+    await mkdir(join(testDir, ".gitignore"), { recursive: true });
+    await writeFile(join(testDir, "a.ts"), "x");
+
+    const filter = await GitignoreFilter.load(testDir);
+    expect(filter.isIgnored(join(testDir, "a.ts"))).toBe(false);
+  });
+});

--- a/tests/integration/services/local-folder-lifecycle.integration.test.ts
+++ b/tests/integration/services/local-folder-lifecycle.integration.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Integration tests for the local-folder lifecycle (#565 Phase B).
+ *
+ * Wires up real `RepositoryMetadataStoreImpl`, real `FileManifestStoreImpl`,
+ * and a real filesystem fixture. The downstream `IncrementalUpdatePipeline` is
+ * stubbed to avoid spinning up ChromaDB / FalkorDB — the focus here is
+ * verifying that LocalFolderUpdateCoordinator correctly drives the manifest
+ * + metadata round-trip end-to-end and surfaces drift_detected when the
+ * registered folder disappears.
+ *
+ * Pipeline-level coverage (chunk updates, graph nodes) is already provided by
+ * the existing IncrementalUpdatePipeline test suite and is not re-asserted
+ * here; the contract between coordinator and pipeline is verified by mock.
+ *
+ * @module tests/integration/services/local-folder-lifecycle.integration.test
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { RepositoryMetadataStoreImpl } from "../../../src/repositories/metadata-store.js";
+import { FileManifestStoreImpl } from "../../../src/services/file-manifest-store.js";
+import { LocalFolderUpdateCoordinator } from "../../../src/services/local-folder-update-coordinator.js";
+import { LocalFolderChangeDetector } from "../../../src/services/local-folder-change-detector.js";
+import type { IncrementalUpdatePipeline } from "../../../src/services/incremental-update-pipeline.js";
+import type { RepositoryInfo } from "../../../src/repositories/types.js";
+import type { UpdateResult } from "../../../src/services/incremental-update-types.js";
+import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
+
+function makeRepo(name: string, localPath: string): RepositoryInfo {
+  return {
+    name,
+    source: "local-folder",
+    url: null,
+    localPath,
+    collectionName: `repo_${name}`,
+    fileCount: 1,
+    chunkCount: 1,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "(local-folder)",
+    includeExtensions: [".ts", ".md"],
+    excludePatterns: [],
+    tier: "private",
+    incrementalUpdateCount: 0,
+  };
+}
+
+function defaultPipelineStub() {
+  return {
+    processChanges: mock(
+      async (): Promise<UpdateResult> => ({
+        stats: {
+          filesAdded: 0,
+          filesModified: 1,
+          filesDeleted: 0,
+          chunksUpserted: 3,
+          chunksDeleted: 1,
+          durationMs: 25,
+        },
+        errors: [],
+        filterStats: {
+          totalChanges: 1,
+          eligibleChanges: 1,
+          filteredChanges: 1,
+          skippedChanges: 0,
+        },
+      })
+    ),
+  } as unknown as IncrementalUpdatePipeline;
+}
+
+describe("Local folder lifecycle integration", () => {
+  let folderDir: string;
+  let dataDir: string;
+  let store: RepositoryMetadataStoreImpl;
+  let manifestStore: FileManifestStoreImpl;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "error", format: "json" });
+    folderDir = await mkdtemp(join(tmpdir(), "lflc-folder-"));
+    dataDir = await mkdtemp(join(tmpdir(), "lflc-data-"));
+    RepositoryMetadataStoreImpl.resetInstance();
+    FileManifestStoreImpl.resetInstance();
+    store = RepositoryMetadataStoreImpl.getInstance(dataDir);
+    manifestStore = FileManifestStoreImpl.getInstance(dataDir);
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(folderDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    try {
+      await rm(dataDir, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+    RepositoryMetadataStoreImpl.resetInstance();
+    FileManifestStoreImpl.resetInstance();
+    resetLogger();
+  });
+
+  it("registers a local folder, updates after a file change, and persists state", async () => {
+    // 1. Seed the folder with one file and pre-populate the manifest as if
+    //    IngestionService had just done its first scan.
+    await writeFile(join(folderDir, "a.ts"), "console.log('v1');");
+    const repo = makeRepo("smoke", folderDir);
+    repo.lastManifestId = manifestStore.computeManifestId(repo.name);
+    await store.updateRepository(repo);
+
+    const detector = new LocalFolderChangeDetector(manifestStore);
+    const seed = await detector.detect(repo);
+    await manifestStore.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date(Date.now() - 60_000).toISOString(),
+      files: seed.nextManifestFiles,
+    });
+
+    // 2. Modify the file so the next coordinator run will see one change.
+    await writeFile(join(folderDir, "a.ts"), "console.log('v2-much-longer');");
+
+    const pipeline = defaultPipelineStub();
+    const coord = new LocalFolderUpdateCoordinator(store, pipeline, detector, manifestStore);
+
+    const result = await coord.updateRepository(repo.name);
+
+    expect(result.status).toBe("updated");
+    expect(pipeline.processChanges).toHaveBeenCalledTimes(1);
+
+    // Pipeline received the right shape: one modified path.
+    const callArgs = (pipeline.processChanges as ReturnType<typeof mock>).mock.calls[0]!;
+    const changes = callArgs[0] as Array<{ path: string; status: string }>;
+    expect(changes).toEqual([{ path: "a.ts", status: "modified" }]);
+
+    // Manifest now reflects v2 content.
+    const persistedManifest = await manifestStore.loadManifest(repo.name);
+    expect(persistedManifest.files["a.ts"]?.sizeBytes).toBeGreaterThan(20);
+
+    // Repository metadata advanced: history entry + counters bumped.
+    const updated = await store.getRepository(repo.name);
+    expect(updated?.updateHistory?.length).toBe(1);
+    expect(updated?.updateHistory?.[0]?.previousCommit.startsWith("local-")).toBe(true);
+    expect(updated?.updateHistory?.[0]?.newCommit.startsWith("local-")).toBe(true);
+    expect(updated?.incrementalUpdateCount).toBe(1);
+    expect(updated?.updateInProgress ?? false).toBe(false);
+  });
+
+  it("reports drift_detected when the registered folder is gone", async () => {
+    await mkdir(folderDir, { recursive: true });
+    await writeFile(join(folderDir, "a.ts"), "x");
+    const repo = makeRepo("drifted", folderDir);
+    await store.updateRepository(repo);
+
+    // Simulate the user moving / deleting their folder out from under us.
+    await rm(folderDir, { recursive: true, force: true });
+
+    const pipeline = defaultPipelineStub();
+    const coord = new LocalFolderUpdateCoordinator(
+      store,
+      pipeline,
+      new LocalFolderChangeDetector(manifestStore),
+      manifestStore
+    );
+
+    const result = await coord.updateRepository(repo.name);
+    expect(result.status).toBe("drift_detected");
+    expect(pipeline.processChanges).not.toHaveBeenCalled();
+
+    // Metadata is NOT mutated on drift — coordinator returns before any write.
+    const after = await store.getRepository(repo.name);
+    expect(after?.updateInProgress ?? false).toBe(false);
+    expect(after?.updateHistory ?? []).toEqual([]);
+  });
+
+  it("returns no_changes when nothing on disk has moved", async () => {
+    await writeFile(join(folderDir, "a.ts"), "stable");
+    const repo = makeRepo("stable", folderDir);
+    await store.updateRepository(repo);
+
+    const detector = new LocalFolderChangeDetector(manifestStore);
+    const seed = await detector.detect(repo);
+    await manifestStore.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: seed.nextManifestFiles,
+    });
+
+    const pipeline = defaultPipelineStub();
+    const coord = new LocalFolderUpdateCoordinator(store, pipeline, detector, manifestStore);
+
+    const result = await coord.updateRepository(repo.name);
+    expect(result.status).toBe("no_changes");
+    expect(pipeline.processChanges).not.toHaveBeenCalled();
+  });
+});

--- a/tests/mcp/tools/list-indexed-repositories.test.ts
+++ b/tests/mcp/tools/list-indexed-repositories.test.ts
@@ -51,6 +51,7 @@ interface ParsedListResponse {
     status: string;
     index_duration_ms: number;
     error_message?: string;
+    local_path?: string;
   }>;
   summary: {
     total_repositories: number;
@@ -344,6 +345,39 @@ describe("createListRepositoriesHandler", () => {
       expect(remoteResp?.url).toBe("https://github.com/user/remote-repo.git");
       expect(localResp?.source).toBe("local-folder");
       expect(localResp?.url).toBeNull();
+    });
+
+    it("exposes local_path for local-folder AND local-git, but never for git-remote (PR #573 review TEST-2 + L-4)", async () => {
+      const remote = createMockRepo("remote-repo", 1, 1, {
+        source: "git-remote",
+        localPath: "/data/repos/remote-repo", // internal clone cache; do NOT expose
+      });
+      const localFolder = createMockRepo("folder-repo", 1, 1, {
+        source: "local-folder",
+        url: null,
+        localPath: "/Users/dev/notes",
+      });
+      const localGit = createMockRepo("git-repo", 1, 1, {
+        source: "local-git",
+        url: null,
+        localPath: "/Users/dev/projects/my-app",
+      });
+      mockRepositoryService.listRepositories = mock(() =>
+        Promise.resolve([remote, localFolder, localGit])
+      );
+
+      const result = await handler({});
+      const response = parseResponse(getTextContent(result.content));
+
+      const remoteResp = response.repositories.find((r) => r.name === "remote-repo");
+      const folderResp = response.repositories.find((r) => r.name === "folder-repo");
+      const gitResp = response.repositories.find((r) => r.name === "git-repo");
+
+      // git-remote: local_path MUST NOT be present (internal clone-cache path).
+      expect(remoteResp).not.toHaveProperty("local_path");
+      // local-folder + local-git: user supplied the path; surface it.
+      expect(folderResp?.local_path).toBe("/Users/dev/notes");
+      expect(gitResp?.local_path).toBe("/Users/dev/projects/my-app");
     });
   });
 

--- a/tests/mcp/tools/trigger-incremental-update.test.ts
+++ b/tests/mcp/tools/trigger-incremental-update.test.ts
@@ -268,6 +268,37 @@ describe("createTriggerUpdateHandler", () => {
         expect(response.error).toBe("repository_not_found");
       }
     });
+
+    it("returns service_unavailable for local-folder repo when localFolderCoordinator is undefined (PR #573 review TEST-2)", async () => {
+      // Repo is a local-folder source, but the handler was constructed without
+      // a LocalFolderUpdateCoordinator dependency. The handler must NOT misroute
+      // through the git coordinator (which would throw MissingCommitShaError) —
+      // it must surface a typed `service_unavailable` error.
+      const localFolderRepo: RepositoryInfo = {
+        ...createMockRepo("folder-only"),
+        source: "local-folder",
+        url: null,
+      };
+      mockRepositoryService.getRepository = mock(() => Promise.resolve(localFolderRepo));
+
+      // Reconstruct the handler with NO localFolderCoordinator.
+      const handlerNoLocal = createTriggerUpdateHandler({
+        repositoryService: mockRepositoryService,
+        updateCoordinator: mockUpdateCoordinator,
+        rateLimiter,
+        jobTracker,
+        // localFolderCoordinator omitted intentionally
+      });
+
+      const result = await handlerNoLocal({ repository: "folder-only" });
+
+      expect(result.isError).toBe(true);
+      const response = JSON.parse(getTextContent(result.content)) as ErrorResponse;
+      expect(response.error).toBe("service_unavailable");
+      expect(response.message).toContain("local-folder");
+      // Coordinator must NOT have been invoked.
+      expect(mockUpdateCoordinator.updateRepository).not.toHaveBeenCalled();
+    });
   });
 
   describe("rate limiting", () => {
@@ -374,6 +405,28 @@ describe("createTriggerUpdateHandler", () => {
       const response = JSON.parse(getTextContent(result.content)) as SyncSuccessResponse;
       expect(response.commit_sha).toBe("abc1234");
       expect(response.commit_sha?.length).toBe(7);
+    });
+
+    it("preserves local-<isoDate> markers without 7-char truncation (PR #573 review TEST-2)", async () => {
+      // local-folder repos use `local-<isoDate>` synthetic markers in place of
+      // git SHAs. Truncating these to 7 chars yields a meaningless "local-2",
+      // which the response formatter explicitly avoids.
+      const localMarker = "local-2026-05-06T12:34:56.789Z";
+      mockUpdateCoordinator.updateRepository = mock(() =>
+        Promise.resolve(
+          createMockResult({
+            commitSha: localMarker,
+            commitMessage: undefined,
+          })
+        )
+      );
+
+      const result = await handler({ repository: "test-repo" });
+
+      const response = JSON.parse(getTextContent(result.content)) as SyncSuccessResponse;
+      // Marker must be preserved IN FULL, not truncated to "local-2".
+      expect(response.commit_sha).toBe(localMarker);
+      expect(response.commit_sha).not.toBe("local-2");
     });
 
     it("should mark complete in rate limiter", async () => {

--- a/tests/services/ingestion-service-local-folder.test.ts
+++ b/tests/services/ingestion-service-local-folder.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Focused tests for `IngestionService` Phase B behaviors.
+ *
+ * - tier="public" + local-folder is refused.
+ * - removeRepository deletes the FileManifest.
+ *
+ * Heavy mocked because IngestionService has many collaborators; we only need
+ * the call surface and a real metadata + manifest store to assert against.
+ *
+ * @module tests/services/ingestion-service-local-folder
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { IngestionService } from "../../src/services/ingestion-service.js";
+import { FileManifestStoreImpl } from "../../src/services/file-manifest-store.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+import type { EmbeddingProvider } from "../../src/providers/types.js";
+import type { ChromaStorageClient } from "../../src/storage/types.js";
+import type { RepositoryMetadataService, RepositoryInfo } from "../../src/repositories/types.js";
+
+function makeStubProvider(): EmbeddingProvider {
+  return {
+    providerId: "stub",
+    modelId: "stub-model",
+    dimensions: 4,
+    generateEmbedding: mock(async () => [0.1, 0.2, 0.3, 0.4] as number[]),
+    generateEmbeddings: mock(async (texts: string[]) =>
+      texts.map(() => [0.1, 0.2, 0.3, 0.4] as number[])
+    ),
+    healthCheck: mock(async () => true),
+    getCapabilities: () => ({
+      maxBatchSize: 100,
+      maxTokensPerText: 8191,
+      supportsGPU: false,
+      requiresNetwork: false,
+      estimatedLatencyMs: 1,
+    }),
+  };
+}
+
+function makeStubStorage(): ChromaStorageClient {
+  return {
+    deleteCollection: mock(async () => undefined),
+    createCollection: mock(async () => undefined),
+    addDocuments: mock(async () => undefined),
+    getCollection: mock(async () => null),
+    listCollections: mock(async () => []),
+    queryDocuments: mock(async () => ({ documents: [] })),
+    healthCheck: mock(async () => true),
+  } as unknown as ChromaStorageClient;
+}
+
+interface StubMetadata extends RepositoryMetadataService {
+  data: Map<string, RepositoryInfo>;
+}
+
+function makeStubMetadata(seed?: RepositoryInfo): StubMetadata {
+  const data = new Map<string, RepositoryInfo>();
+  if (seed) data.set(seed.name, seed);
+  return {
+    data,
+    listRepositories: mock(async () => Array.from(data.values())),
+    getRepository: mock(async (name: string) => data.get(name) ?? null),
+    updateRepository: mock(async (info: RepositoryInfo) => {
+      data.set(info.name, info);
+    }),
+    removeRepository: mock(async (name: string) => {
+      data.delete(name);
+    }),
+  } as unknown as StubMetadata;
+}
+
+describe("IngestionService Phase B", () => {
+  let testDir: string;
+  let dataDir: string;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDir = join(import.meta.dir, "..", "..", "test-temp", `is-lfb-${stamp}`);
+    dataDir = join(import.meta.dir, "..", "..", "test-temp", `is-lfb-data-${stamp}`);
+    await mkdir(testDir, { recursive: true });
+    await mkdir(dataDir, { recursive: true });
+    FileManifestStoreImpl.resetInstance();
+    FileManifestStoreImpl.getInstance(dataDir);
+  });
+
+  afterEach(async () => {
+    FileManifestStoreImpl.resetInstance();
+    await rm(testDir, { recursive: true, force: true });
+    await rm(dataDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("refuses to register a local folder with tier='public'", async () => {
+    await writeFile(join(testDir, "a.ts"), "x");
+
+    const cloner = { clone: mock(), cleanup: mock() } as any;
+    // Scanner is never called — the tier check fires before the scan phase.
+    const scanner = { scanFiles: mock(async () => []) } as any;
+    const chunker = {} as any;
+    const provider = makeStubProvider();
+    const storage = makeStubStorage();
+    const metadata = makeStubMetadata();
+
+    const svc = new IngestionService(cloner, scanner, chunker, provider, storage, metadata);
+
+    const result = await svc.indexRepository(testDir, {
+      name: "publicAttempt",
+      tier: "public",
+    });
+
+    // The IngestionService catches non-Already/InProgress errors and converts
+    // to a `failed` IndexResult — assert the failure surfaced the typed error.
+    expect(result.status).toBe("failed");
+    const errMessages = result.errors.map((e) => e.message ?? "");
+    expect(errMessages.some((m) => m.includes("public") && m.includes("local"))).toBe(true);
+  });
+
+  it("removeRepository deletes the persisted FileManifest", async () => {
+    // Seed a fake repo metadata + a manifest as if a prior local-folder index ran.
+    const repo: RepositoryInfo = {
+      name: "needs-cleanup",
+      source: "local-folder",
+      url: null,
+      localPath: testDir,
+      collectionName: "needs_cleanup",
+      fileCount: 1,
+      chunkCount: 1,
+      lastIndexedAt: new Date().toISOString(),
+      indexDurationMs: 0,
+      status: "ready",
+      branch: "(local-folder)",
+      includeExtensions: [".ts"],
+      excludePatterns: [],
+      tier: "private",
+    };
+    const metadata = makeStubMetadata(repo);
+    const store = FileManifestStoreImpl.getInstance();
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: { "a.ts": { sha256: "0".repeat(64), sizeBytes: 1, mtimeMs: 1 } },
+    });
+
+    // Sanity: manifest exists before removal.
+    const before = await store.loadManifest(repo.name);
+    expect(before.files).toHaveProperty(["a.ts"]);
+
+    const svc = new IngestionService(
+      { clone: mock(), cleanup: mock() } as any,
+      { scanFiles: mock() } as any,
+      {} as any,
+      makeStubProvider(),
+      makeStubStorage(),
+      metadata
+    );
+
+    await svc.removeRepository(repo.name);
+
+    // Manifest is gone from the store (loadManifest returns the empty sentinel).
+    const after = await store.loadManifest(repo.name);
+    expect(Object.keys(after.files)).toEqual([]);
+  });
+});

--- a/tests/services/ingestion-service-size-guard.test.ts
+++ b/tests/services/ingestion-service-size-guard.test.ts
@@ -1,0 +1,287 @@
+/**
+ * Tests for `IngestionService.enforceLocalFolderSizeGuardrails`.
+ *
+ * Covers PR #573 review TEST-1: soft-warn, hard-refusal, and `--force` bypass
+ * across the size-and-file-count guardrail. Thresholds are injected so tests
+ * can use tiny limits (5 files / 1 KiB) without fixturing 100K files.
+ *
+ * @module tests/services/ingestion-service-size-guard
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { IngestionService } from "../../src/services/ingestion-service.js";
+import { LocalFolderSizeRefusedError } from "../../src/services/ingestion-errors.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+import type { EmbeddingProvider } from "../../src/providers/types.js";
+import type { ChromaStorageClient } from "../../src/storage/types.js";
+import type { RepositoryMetadataService } from "../../src/repositories/types.js";
+
+function stubProvider(): EmbeddingProvider {
+  return {
+    providerId: "stub",
+    modelId: "stub-model",
+    dimensions: 4,
+    generateEmbedding: mock(async () => [0, 0, 0, 0] as number[]),
+    generateEmbeddings: mock(async (texts: string[]) => texts.map(() => [0, 0, 0, 0] as number[])),
+    healthCheck: mock(async () => true),
+    getCapabilities: () => ({
+      maxBatchSize: 100,
+      maxTokensPerText: 8191,
+      supportsGPU: false,
+      requiresNetwork: false,
+      estimatedLatencyMs: 1,
+    }),
+  };
+}
+
+function stubStorage(): ChromaStorageClient {
+  return {
+    deleteCollection: mock(async () => undefined),
+    addDocuments: mock(async () => undefined),
+    getOrCreateCollection: mock(async () => undefined),
+    healthCheck: mock(async () => true),
+  } as unknown as ChromaStorageClient;
+}
+
+function stubMetadata(): RepositoryMetadataService {
+  return {
+    listRepositories: mock(async () => []),
+    getRepository: mock(async () => null),
+    updateRepository: mock(async () => undefined),
+    removeRepository: mock(async () => undefined),
+  } as unknown as RepositoryMetadataService;
+}
+
+function makeService(): IngestionService {
+  return new IngestionService(
+    { clone: mock(), cleanup: mock() } as any,
+    { scanFiles: mock() } as any,
+    {} as any,
+    stubProvider(),
+    stubStorage(),
+    stubMetadata()
+  );
+}
+
+describe("IngestionService.enforceLocalFolderSizeGuardrails", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDir = join(import.meta.dir, "..", "..", "test-temp", `is-sg-${stamp}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("returns no soft-warn under both soft thresholds", async () => {
+    await writeFile(join(testDir, "a.ts"), "x");
+    await writeFile(join(testDir, "b.ts"), "y");
+
+    const result = await makeService().enforceLocalFolderSizeGuardrails(
+      "tiny",
+      testDir,
+      {},
+      {
+        softFileLimit: 100,
+        softByteLimit: 100_000,
+        hardFileLimit: 1_000,
+        hardByteLimit: 1_000_000,
+      }
+    );
+
+    expect(result.fileCount).toBe(2);
+    expect(result.softWarn).toBe(false);
+  });
+
+  it("flips softWarn=true once the soft file-count threshold is exceeded", async () => {
+    // Six small files, soft file limit of 5.
+    for (let i = 0; i < 6; i++) {
+      await writeFile(join(testDir, `f${i}.ts`), "x");
+    }
+
+    const result = await makeService().enforceLocalFolderSizeGuardrails(
+      "softfiles",
+      testDir,
+      {},
+      {
+        softFileLimit: 5,
+        softByteLimit: 1_000_000,
+        hardFileLimit: 1_000,
+        hardByteLimit: 1_000_000,
+      }
+    );
+
+    expect(result.fileCount).toBe(6);
+    expect(result.softWarn).toBe(true);
+  });
+
+  it("flips softWarn=true once the soft byte-size threshold is exceeded", async () => {
+    // Two files totalling 200 bytes; soft byte limit of 100.
+    await writeFile(join(testDir, "a.ts"), "a".repeat(120));
+    await writeFile(join(testDir, "b.ts"), "b".repeat(120));
+
+    const result = await makeService().enforceLocalFolderSizeGuardrails(
+      "softbytes",
+      testDir,
+      {},
+      {
+        softFileLimit: 100,
+        softByteLimit: 100,
+        hardFileLimit: 1_000,
+        hardByteLimit: 1_000_000,
+      }
+    );
+
+    expect(result.softWarn).toBe(true);
+    expect(result.totalBytes).toBeGreaterThan(100);
+  });
+
+  it("throws LocalFolderSizeRefusedError when hard file-count threshold is exceeded", async () => {
+    // Eight tiny files, hard file limit of 5.
+    for (let i = 0; i < 8; i++) {
+      await writeFile(join(testDir, `f${i}.ts`), "x");
+    }
+
+    let caught: unknown;
+    try {
+      await makeService().enforceLocalFolderSizeGuardrails(
+        "hardfiles",
+        testDir,
+        {},
+        {
+          softFileLimit: 1,
+          softByteLimit: 1,
+          hardFileLimit: 5,
+          hardByteLimit: 1_000_000,
+        }
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LocalFolderSizeRefusedError);
+  });
+
+  it("throws LocalFolderSizeRefusedError when hard byte-size threshold is exceeded", async () => {
+    // One large file (1200 bytes), hard byte limit of 1024.
+    await writeFile(join(testDir, "big.ts"), "x".repeat(1200));
+
+    let caught: unknown;
+    try {
+      await makeService().enforceLocalFolderSizeGuardrails(
+        "hardbytes",
+        testDir,
+        {},
+        {
+          softFileLimit: 1,
+          softByteLimit: 1,
+          hardFileLimit: 1_000,
+          hardByteLimit: 1024,
+        }
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(LocalFolderSizeRefusedError);
+  });
+
+  it("force=true bypasses hard refusal even when both hard thresholds are exceeded", async () => {
+    // Eight files totalling >1500 bytes; hard limits set to 5 / 1024.
+    for (let i = 0; i < 8; i++) {
+      await writeFile(join(testDir, `f${i}.ts`), "x".repeat(200));
+    }
+
+    const result = await makeService().enforceLocalFolderSizeGuardrails(
+      "forced",
+      testDir,
+      { force: true },
+      {
+        softFileLimit: 1,
+        softByteLimit: 1,
+        hardFileLimit: 5,
+        hardByteLimit: 1024,
+      }
+    );
+
+    // No throw; counts still report the full walk because the early-exit
+    // branch is gated on `!options.force`.
+    expect(result.fileCount).toBe(8);
+    expect(result.softWarn).toBe(true);
+  });
+
+  it("respects the gitignore filter when counting files", async () => {
+    await writeFile(join(testDir, ".gitignore"), "ignored.ts\n");
+    await writeFile(join(testDir, "kept.ts"), "x");
+    await writeFile(join(testDir, "ignored.ts"), "x");
+
+    const result = await makeService().enforceLocalFolderSizeGuardrails(
+      "gitignore",
+      testDir,
+      {},
+      {
+        softFileLimit: 100,
+        softByteLimit: 100_000,
+        hardFileLimit: 1_000,
+        hardByteLimit: 1_000_000,
+      }
+    );
+
+    // ignored.ts MUST be excluded — same eligibility predicate the scanner uses.
+    expect(result.fileCount).toBe(1);
+  });
+
+  it("excludes default-exclusion directories like node_modules without a .gitignore", async () => {
+    await writeFile(join(testDir, "kept.ts"), "x");
+    const nm = join(testDir, "node_modules");
+    await mkdir(nm, { recursive: true });
+    for (let i = 0; i < 50; i++) {
+      await writeFile(join(nm, `dep${i}.ts`), "x");
+    }
+
+    const result = await makeService().enforceLocalFolderSizeGuardrails(
+      "nm",
+      testDir,
+      {},
+      {
+        softFileLimit: 100,
+        softByteLimit: 100_000,
+        hardFileLimit: 1_000,
+        hardByteLimit: 1_000_000,
+      }
+    );
+
+    // The 50 node_modules files MUST NOT count — divergence from FileScanner
+    // here is the H-2 bug the shared eligibility predicate fixes.
+    expect(result.fileCount).toBe(1);
+  });
+
+  it("excludes oversized files via the shared MAX_FILE_SIZE_BYTES cap", async () => {
+    // The size cap is 1 MiB. Generate one file just over.
+    const big = "y".repeat(1_048_576 + 100);
+    await writeFile(join(testDir, "huge.ts"), big);
+    await writeFile(join(testDir, "small.ts"), "z");
+
+    const result = await makeService().enforceLocalFolderSizeGuardrails(
+      "oversized",
+      testDir,
+      {},
+      {
+        softFileLimit: 100,
+        softByteLimit: 100_000_000,
+        hardFileLimit: 1_000,
+        hardByteLimit: 1_000_000_000,
+      }
+    );
+
+    // The huge file is excluded; only `small.ts` counts.
+    expect(result.fileCount).toBe(1);
+  });
+});

--- a/tests/services/local-folder-change-detector.test.ts
+++ b/tests/services/local-folder-change-detector.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for LocalFolderChangeDetector (T3.1 acceptance).
+ *
+ * @module tests/services/local-folder-change-detector
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, writeFile, rm, utimes } from "node:fs/promises";
+import { join } from "node:path";
+import { LocalFolderChangeDetector } from "../../src/services/local-folder-change-detector.js";
+import {
+  FileManifestStoreImpl,
+  type FileManifest,
+} from "../../src/services/file-manifest-store.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+import type { RepositoryInfo } from "../../src/repositories/types.js";
+
+function makeRepo(name: string, localPath: string): RepositoryInfo {
+  return {
+    name,
+    source: "local-folder",
+    url: null,
+    localPath,
+    collectionName: `repo_${name}`,
+    fileCount: 0,
+    chunkCount: 0,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "(local-folder)",
+    includeExtensions: [".ts", ".md"],
+    excludePatterns: [],
+  };
+}
+
+describe("LocalFolderChangeDetector", () => {
+  let testDir: string;
+  let dataDir: string;
+  let store: FileManifestStoreImpl;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDir = join(import.meta.dir, "..", "..", "test-temp", `lfcd-${stamp}`);
+    dataDir = join(import.meta.dir, "..", "..", "test-temp", `lfcd-data-${stamp}`);
+    await mkdir(testDir, { recursive: true });
+    await mkdir(dataDir, { recursive: true });
+    FileManifestStoreImpl.resetInstance();
+    store = FileManifestStoreImpl.getInstance(dataDir);
+  });
+
+  afterEach(async () => {
+    FileManifestStoreImpl.resetInstance();
+    await rm(testDir, { recursive: true, force: true });
+    await rm(dataDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("detects added files when manifest is empty", async () => {
+    await writeFile(join(testDir, "a.ts"), "console.log(1);");
+    await writeFile(join(testDir, "b.ts"), "console.log(2);");
+    const repo = makeRepo("test", testDir);
+
+    const detector = new LocalFolderChangeDetector(store);
+    const result = await detector.detect(repo);
+
+    const adds = result.changes.filter((c) => c.status === "added").map((c) => c.path).sort();
+    expect(adds).toEqual(["a.ts", "b.ts"]);
+    expect(Object.keys(result.nextManifestFiles).sort()).toEqual(["a.ts", "b.ts"]);
+  });
+
+  it("detects modified files (size differs)", async () => {
+    await writeFile(join(testDir, "a.ts"), "v1");
+    const repo = makeRepo("test", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+
+    // Seed manifest from initial scan.
+    let initial = await detector.detect(repo);
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: initial.nextManifestFiles,
+    });
+
+    // Modify content (size changes).
+    await writeFile(join(testDir, "a.ts"), "v2-longer");
+    const result = await detector.detect(repo);
+
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]).toEqual({ path: "a.ts", status: "modified" });
+  });
+
+  it("detects modified files when mtime differs but size is identical (rare)", async () => {
+    // Two equal-length contents with different bytes.
+    await writeFile(join(testDir, "a.ts"), "AAAA");
+    const repo = makeRepo("test", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+    let initial = await detector.detect(repo);
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: initial.nextManifestFiles,
+    });
+
+    // Same length, different content. Bump mtime to trigger the slow path.
+    await writeFile(join(testDir, "a.ts"), "BBBB");
+    const future = new Date(Date.now() + 60_000);
+    await utimes(join(testDir, "a.ts"), future, future);
+
+    const result = await detector.detect(repo);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0]?.status).toBe("modified");
+  });
+
+  it("treats touch-only (mtime drift, hash match) as no change", async () => {
+    await writeFile(join(testDir, "a.ts"), "stable");
+    const repo = makeRepo("test", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+    const initial = await detector.detect(repo);
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: initial.nextManifestFiles,
+    });
+
+    // Same bytes, future mtime → triggers hash recomputation, hashes match → skip.
+    const future = new Date(Date.now() + 120_000);
+    await utimes(join(testDir, "a.ts"), future, future);
+
+    const result = await detector.detect(repo);
+    expect(result.changes).toEqual([]);
+  });
+
+  it("detects deletions", async () => {
+    await writeFile(join(testDir, "a.ts"), "x");
+    await writeFile(join(testDir, "b.ts"), "y");
+    const repo = makeRepo("test", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+    const initial = await detector.detect(repo);
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: initial.nextManifestFiles,
+    });
+
+    await rm(join(testDir, "b.ts"));
+    const result = await detector.detect(repo);
+    expect(result.changes).toEqual([{ path: "b.ts", status: "deleted" }]);
+  });
+
+  it("paranoid mode hashes every file even on apparent (size, mtime) match", async () => {
+    // Goal: verify paranoid mode catches a content change that the fast path
+    // would miss because mtime + size happen to be unchanged. Filesystem mtime
+    // preservation across writeFile + utimes is platform-dependent (Windows
+    // NTFS rounds to ~16 ms in some configurations), so this test does not
+    // assert that the fast path actually misses — only that paranoid catches.
+    await writeFile(join(testDir, "a.ts"), "AAAA");
+    const repo = makeRepo("test", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+    const initial = await detector.detect(repo);
+    const seedManifest = {
+      version: "1.0" as const,
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: initial.nextManifestFiles,
+    };
+    await store.saveManifest(repo.name, seedManifest);
+
+    // Same length, different bytes. Force mtime back to the seeded value so
+    // the fast path *might* skip on platforms with mtime preservation.
+    await writeFile(join(testDir, "a.ts"), "BBBB");
+    const original = initial.nextManifestFiles["a.ts"];
+    if (!original) throw new Error("seed manifest missing a.ts");
+    await utimes(join(testDir, "a.ts"), new Date(original.mtimeMs), new Date(original.mtimeMs));
+
+    // Re-seed manifest after the second write so the prior fingerprint matches
+    // what stat() now reports — this isolates the "content-changed-but-fast-path-
+    // would-skip" condition from any mtime jitter.
+    const stale = await detector.detect(repo);
+    const staleEntry = stale.nextManifestFiles["a.ts"]!;
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      // Persist the OLD (AAAA) sha256 against the NEW (BBBB) size+mtime so the
+      // fast path matches but the content actually differs.
+      files: {
+        "a.ts": {
+          sha256: original.sha256,
+          sizeBytes: staleEntry.sizeBytes,
+          mtimeMs: staleEntry.mtimeMs,
+        },
+      },
+    });
+
+    const paranoid = await detector.detect(repo, { paranoid: true });
+    expect(paranoid.changes).toEqual([{ path: "a.ts", status: "modified" }]);
+  });
+
+  it("excludes files outside the include-extensions whitelist", async () => {
+    await writeFile(join(testDir, "code.ts"), "x");
+    await writeFile(join(testDir, "binary.bin"), "x");
+    const repo = makeRepo("test", testDir);
+    repo.includeExtensions = [".ts"];
+
+    const detector = new LocalFolderChangeDetector(store);
+    const result = await detector.detect(repo);
+    const paths = result.changes.map((c) => c.path);
+    expect(paths).toEqual(["code.ts"]);
+    // `toHaveProperty` treats "." as a path separator, so use array form
+    // to look up the literal "code.ts" key.
+    expect(result.nextManifestFiles["code.ts"]).toBeDefined();
+    expect(result.nextManifestFiles["binary.bin"]).toBeUndefined();
+  });
+
+  it("respects nested .gitignore", async () => {
+    await mkdir(join(testDir, "src"), { recursive: true });
+    await writeFile(join(testDir, ".gitignore"), "build/\n");
+    await mkdir(join(testDir, "build"), { recursive: true });
+    await writeFile(join(testDir, "build", "out.ts"), "x");
+    await writeFile(join(testDir, "src", "in.ts"), "x");
+
+    const repo = makeRepo("test", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+    const result = await detector.detect(repo);
+    const paths = result.changes.map((c) => c.path).sort();
+    expect(paths).toEqual(["src/in.ts"]);
+  });
+
+  it("buildNextManifest returns a well-formed manifest envelope", () => {
+    const detector = new LocalFolderChangeDetector(store);
+    const m: FileManifest = detector.buildNextManifest("repo", {
+      "a.ts": { sha256: "0".repeat(64), sizeBytes: 4, mtimeMs: 1 },
+    });
+    expect(m.version).toBe("1.0");
+    expect(m.repository).toBe("repo");
+    expect(m.files["a.ts"]?.sha256.length).toBe(64);
+    // generatedAt is a valid ISO string
+    expect(() => new Date(m.generatedAt).toISOString()).not.toThrow();
+  });
+});

--- a/tests/services/local-folder-change-detector.test.ts
+++ b/tests/services/local-folder-change-detector.test.ts
@@ -64,7 +64,10 @@ describe("LocalFolderChangeDetector", () => {
     const detector = new LocalFolderChangeDetector(store);
     const result = await detector.detect(repo);
 
-    const adds = result.changes.filter((c) => c.status === "added").map((c) => c.path).sort();
+    const adds = result.changes
+      .filter((c) => c.status === "added")
+      .map((c) => c.path)
+      .sort();
     expect(adds).toEqual(["a.ts", "b.ts"]);
     expect(Object.keys(result.nextManifestFiles).sort()).toEqual(["a.ts", "b.ts"]);
   });
@@ -75,7 +78,7 @@ describe("LocalFolderChangeDetector", () => {
     const detector = new LocalFolderChangeDetector(store);
 
     // Seed manifest from initial scan.
-    let initial = await detector.detect(repo);
+    const initial = await detector.detect(repo);
     await store.saveManifest(repo.name, {
       version: "1.0",
       repository: repo.name,
@@ -96,7 +99,7 @@ describe("LocalFolderChangeDetector", () => {
     await writeFile(join(testDir, "a.ts"), "AAAA");
     const repo = makeRepo("test", testDir);
     const detector = new LocalFolderChangeDetector(store);
-    let initial = await detector.detect(repo);
+    const initial = await detector.detect(repo);
     await store.saveManifest(repo.name, {
       version: "1.0",
       repository: repo.name,

--- a/tests/services/local-folder-update-coordinator.test.ts
+++ b/tests/services/local-folder-update-coordinator.test.ts
@@ -14,10 +14,7 @@ import { LocalFolderUpdateCoordinator } from "../../src/services/local-folder-up
 import { LocalFolderChangeDetector } from "../../src/services/local-folder-change-detector.js";
 import { FileManifestStoreImpl } from "../../src/services/file-manifest-store.js";
 import type { IncrementalUpdatePipeline } from "../../src/services/incremental-update-pipeline.js";
-import type {
-  RepositoryInfo,
-  RepositoryMetadataService,
-} from "../../src/repositories/types.js";
+import type { RepositoryInfo, RepositoryMetadataService } from "../../src/repositories/types.js";
 import type { UpdateResult } from "../../src/services/incremental-update-types.js";
 import { initializeLogger, resetLogger } from "../../src/logging/index.js";
 
@@ -69,7 +66,9 @@ function makeMetadataService(initial: RepositoryInfo | null): MockMetadataServic
     current: initial,
     saved: [] as RepositoryInfo[],
     listRepositories: mock(async () => (initial ? [initial] : [])),
-    getRepository: mock(async (name: string) => (svc.current && svc.current.name === name ? svc.current : null)),
+    getRepository: mock(async (name: string) =>
+      svc.current && svc.current.name === name ? svc.current : null
+    ),
     updateRepository: mock(async (info: RepositoryInfo) => {
       svc.current = info;
       svc.saved.push(info);
@@ -248,6 +247,67 @@ describe("LocalFolderUpdateCoordinator", () => {
     // next attempt sees the same diff and can retry.
     const persisted = await store.loadManifest(repo.name);
     expect(persisted.generatedAt).toBe(seedManifest.generatedAt);
+  });
+
+  it("preserves prior fingerprint for files the pipeline reported errors on (partial success)", async () => {
+    // Three files modified on disk; pipeline succeeds on two (count=2) and errors
+    // on one. With errors < processed, historyStatus is "partial" → manifest IS
+    // rewritten. The errored file's prior fingerprint must be carried forward
+    // so the next update sees its diff and retries it. Without the fix the
+    // manifest would advance past the unprocessed file and silently lose the
+    // index update.
+    await writeFile(join(testDir, "ok1.ts"), "v1");
+    await writeFile(join(testDir, "ok2.ts"), "v1");
+    await writeFile(join(testDir, "bad.ts"), "v1");
+    const repo = makeRepo("partial", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+
+    const seed = await detector.detect(repo);
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: seed.nextManifestFiles,
+    });
+    const seededBad = seed.nextManifestFiles["bad.ts"]!;
+    const seededOk1 = seed.nextManifestFiles["ok1.ts"]!;
+
+    await writeFile(join(testDir, "ok1.ts"), "v2-bigger");
+    await writeFile(join(testDir, "ok2.ts"), "v2-bigger");
+    await writeFile(join(testDir, "bad.ts"), "v2-also-bigger");
+
+    const metadata = makeMetadataService(repo);
+    const pipeline = {
+      processChanges: mock(async () => ({
+        stats: {
+          filesAdded: 0,
+          filesModified: 2, // ok1 + ok2 succeeded
+          filesDeleted: 0,
+          chunksUpserted: 2,
+          chunksDeleted: 0,
+          durationMs: 5,
+        },
+        errors: [{ path: "bad.ts", error: "transient embedding failure" }],
+        filterStats: {
+          totalChanges: 3,
+          eligibleChanges: 3,
+          filteredChanges: 3,
+          skippedChanges: 0,
+        },
+      })),
+    } as unknown as IncrementalUpdatePipeline;
+    const coord = new LocalFolderUpdateCoordinator(metadata, pipeline, detector, store);
+
+    const result = await coord.updateRepository("partial");
+    expect(result.status).toBe("updated"); // partial-success surfaces as "updated"
+
+    const persisted = await store.loadManifest(repo.name);
+    // ok1.ts advanced — sha differs from seed.
+    expect(persisted.files["ok1.ts"]?.sha256).not.toBe(seededOk1.sha256);
+    // bad.ts kept its prior fingerprint so the next update will see the diff.
+    expect(persisted.files["bad.ts"]?.sha256).toBe(seededBad.sha256);
+    expect(persisted.files["bad.ts"]?.sizeBytes).toBe(seededBad.sizeBytes);
+    expect(persisted.files["bad.ts"]?.mtimeMs).toBe(seededBad.mtimeMs);
   });
 
   it("refuses to run for a repository whose source is not local-folder", async () => {

--- a/tests/services/local-folder-update-coordinator.test.ts
+++ b/tests/services/local-folder-update-coordinator.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Unit tests for LocalFolderUpdateCoordinator (T3.2 acceptance).
+ *
+ * @module tests/services/local-folder-update-coordinator
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { LocalFolderUpdateCoordinator } from "../../src/services/local-folder-update-coordinator.js";
+import { LocalFolderChangeDetector } from "../../src/services/local-folder-change-detector.js";
+import { FileManifestStoreImpl } from "../../src/services/file-manifest-store.js";
+import type { IncrementalUpdatePipeline } from "../../src/services/incremental-update-pipeline.js";
+import type {
+  RepositoryInfo,
+  RepositoryMetadataService,
+} from "../../src/repositories/types.js";
+import type { UpdateResult } from "../../src/services/incremental-update-types.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+
+function makeRepo(name: string, localPath: string): RepositoryInfo {
+  return {
+    name,
+    source: "local-folder",
+    url: null,
+    localPath,
+    collectionName: `repo_${name}`,
+    fileCount: 0,
+    chunkCount: 0,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "(local-folder)",
+    includeExtensions: [".ts"],
+    excludePatterns: [],
+  };
+}
+
+function emptyUpdateResult(): UpdateResult {
+  return {
+    stats: {
+      filesAdded: 0,
+      filesModified: 0,
+      filesDeleted: 0,
+      chunksUpserted: 0,
+      chunksDeleted: 0,
+      durationMs: 0,
+    },
+    errors: [],
+    filterStats: {
+      totalChanges: 0,
+      eligibleChanges: 0,
+      filteredChanges: 0,
+      skippedChanges: 0,
+    },
+  };
+}
+
+interface MockMetadataService extends RepositoryMetadataService {
+  current: RepositoryInfo | null;
+  saved: RepositoryInfo[];
+}
+
+function makeMetadataService(initial: RepositoryInfo | null): MockMetadataService {
+  const svc = {
+    current: initial,
+    saved: [] as RepositoryInfo[],
+    listRepositories: mock(async () => (initial ? [initial] : [])),
+    getRepository: mock(async (name: string) => (svc.current && svc.current.name === name ? svc.current : null)),
+    updateRepository: mock(async (info: RepositoryInfo) => {
+      svc.current = info;
+      svc.saved.push(info);
+    }),
+    removeRepository: mock(async () => {
+      svc.current = null;
+    }),
+  } as unknown as MockMetadataService;
+  return svc;
+}
+
+describe("LocalFolderUpdateCoordinator", () => {
+  let testDir: string;
+  let dataDir: string;
+  let store: FileManifestStoreImpl;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDir = join(import.meta.dir, "..", "..", "test-temp", `lfuc-${stamp}`);
+    dataDir = join(import.meta.dir, "..", "..", "test-temp", `lfuc-data-${stamp}`);
+    await mkdir(testDir, { recursive: true });
+    await mkdir(dataDir, { recursive: true });
+    FileManifestStoreImpl.resetInstance();
+    store = FileManifestStoreImpl.getInstance(dataDir);
+  });
+
+  afterEach(async () => {
+    FileManifestStoreImpl.resetInstance();
+    await rm(testDir, { recursive: true, force: true });
+    await rm(dataDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("returns drift_detected when localPath is missing", async () => {
+    const repo = makeRepo("driftRepo", join(testDir, "missing"));
+    const metadata = makeMetadataService(repo);
+    const pipeline = {
+      processChanges: mock(async () => emptyUpdateResult()),
+    } as unknown as IncrementalUpdatePipeline;
+    const detector = new LocalFolderChangeDetector(store);
+    const coord = new LocalFolderUpdateCoordinator(metadata, pipeline, detector, store);
+
+    const result = await coord.updateRepository("driftRepo");
+
+    expect(result.status).toBe("drift_detected");
+    expect(pipeline.processChanges).not.toHaveBeenCalled();
+  });
+
+  it("returns no_changes when there is nothing to update", async () => {
+    await writeFile(join(testDir, "a.ts"), "x");
+    const repo = makeRepo("noChange", testDir);
+    // Pre-seed manifest matching the current state so detector returns [].
+    const detector = new LocalFolderChangeDetector(store);
+    const initial = await detector.detect(repo);
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: initial.nextManifestFiles,
+    });
+
+    const metadata = makeMetadataService(repo);
+    const pipeline = {
+      processChanges: mock(async () => emptyUpdateResult()),
+    } as unknown as IncrementalUpdatePipeline;
+    const coord = new LocalFolderUpdateCoordinator(metadata, pipeline, detector, store);
+
+    const result = await coord.updateRepository("noChange");
+    expect(result.status).toBe("no_changes");
+    expect(pipeline.processChanges).not.toHaveBeenCalled();
+  });
+
+  it("runs the pipeline and rewrites the manifest on a successful update", async () => {
+    await writeFile(join(testDir, "a.ts"), "v1");
+    const repo = makeRepo("happy", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+
+    // Seed manifest reflecting v1.
+    const seed = await detector.detect(repo);
+    await store.saveManifest(repo.name, {
+      version: "1.0",
+      repository: repo.name,
+      generatedAt: new Date(Date.now() - 60_000).toISOString(),
+      files: seed.nextManifestFiles,
+    });
+
+    // Modify file → next detect() returns one modified change.
+    await writeFile(join(testDir, "a.ts"), "v2-bigger");
+
+    const metadata = makeMetadataService(repo);
+    const pipeline = {
+      processChanges: mock(async () => ({
+        stats: {
+          filesAdded: 0,
+          filesModified: 1,
+          filesDeleted: 0,
+          chunksUpserted: 2,
+          chunksDeleted: 1,
+          durationMs: 12,
+        },
+        errors: [],
+        filterStats: {
+          totalChanges: 1,
+          eligibleChanges: 1,
+          filteredChanges: 1,
+          skippedChanges: 0,
+        },
+      })),
+    } as unknown as IncrementalUpdatePipeline;
+    const coord = new LocalFolderUpdateCoordinator(metadata, pipeline, detector, store);
+
+    const result = await coord.updateRepository("happy");
+
+    expect(result.status).toBe("updated");
+    expect(result.stats.filesModified).toBe(1);
+    expect(pipeline.processChanges).toHaveBeenCalledTimes(1);
+
+    // Manifest was rewritten — should now reflect the v2 content.
+    const persisted = await store.loadManifest(repo.name);
+    expect(persisted.files["a.ts"]?.sizeBytes).toBeGreaterThan(2);
+
+    // History entry appended with local-<isoDate> markers.
+    const final = metadata.saved[metadata.saved.length - 1];
+    expect(final?.updateHistory?.length ?? 0).toBeGreaterThan(0);
+    const hist = final?.updateHistory?.[0];
+    expect(hist?.previousCommit.startsWith("local-")).toBe(true);
+    expect(hist?.newCommit.startsWith("local-")).toBe(true);
+    expect(final?.incrementalUpdateCount).toBe(1);
+  });
+
+  it("does NOT rewrite the manifest when the pipeline fully fails", async () => {
+    await writeFile(join(testDir, "a.ts"), "v1");
+    const repo = makeRepo("fail", testDir);
+    const detector = new LocalFolderChangeDetector(store);
+
+    const seed = await detector.detect(repo);
+    const seedManifest = {
+      version: "1.0" as const,
+      repository: repo.name,
+      generatedAt: new Date().toISOString(),
+      files: seed.nextManifestFiles,
+    };
+    await store.saveManifest(repo.name, seedManifest);
+
+    // Modify file so detector emits a change.
+    await writeFile(join(testDir, "a.ts"), "v2-bigger");
+
+    const metadata = makeMetadataService(repo);
+    const pipeline = {
+      processChanges: mock(async () => ({
+        stats: {
+          filesAdded: 0,
+          filesModified: 0,
+          filesDeleted: 0,
+          chunksUpserted: 0,
+          chunksDeleted: 0,
+          durationMs: 5,
+        },
+        // Pipeline reports an error and zero successful processing → "failed".
+        errors: [{ path: "a.ts", error: "boom" }],
+        filterStats: {
+          totalChanges: 1,
+          eligibleChanges: 1,
+          filteredChanges: 1,
+          skippedChanges: 0,
+        },
+      })),
+    } as unknown as IncrementalUpdatePipeline;
+    const coord = new LocalFolderUpdateCoordinator(metadata, pipeline, detector, store);
+
+    const result = await coord.updateRepository("fail");
+    expect(result.status).toBe("failed");
+
+    // Manifest should still be the seed — old fingerprint preserved so the
+    // next attempt sees the same diff and can retry.
+    const persisted = await store.loadManifest(repo.name);
+    expect(persisted.generatedAt).toBe(seedManifest.generatedAt);
+  });
+
+  it("refuses to run for a repository whose source is not local-folder", async () => {
+    const repo = { ...makeRepo("wrongSource", testDir), source: "git-remote" as const };
+    const metadata = makeMetadataService(repo);
+    const pipeline = {
+      processChanges: mock(async () => emptyUpdateResult()),
+    } as unknown as IncrementalUpdatePipeline;
+    const coord = new LocalFolderUpdateCoordinator(metadata, pipeline);
+
+    const result = await coord.updateRepository("wrongSource");
+    expect(result.status).toBe("failed");
+    expect(pipeline.processChanges).not.toHaveBeenCalled();
+  });
+});

--- a/tests/services/local-folder-update-coordinator.test.ts
+++ b/tests/services/local-folder-update-coordinator.test.ts
@@ -320,6 +320,34 @@ describe("LocalFolderUpdateCoordinator", () => {
 
     const result = await coord.updateRepository("wrongSource");
     expect(result.status).toBe("failed");
+    expect(result.errors[0]?.error).toContain("not 'local-folder'");
+    expect(pipeline.processChanges).not.toHaveBeenCalled();
+  });
+
+  it("throws ConcurrentUpdateError when updateInProgress is already true", async () => {
+    // Repo metadata is seeded with an active update flag; the coordinator's
+    // pre-check at the top of updateRepository must reject before touching the
+    // pipeline. PR #573 review TEST-2 (concurrent-update guard).
+    const repo: RepositoryInfo = {
+      ...makeRepo("locked", testDir),
+      updateInProgress: true,
+      updateStartedAt: new Date(Date.now() - 60_000).toISOString(),
+    };
+    const metadata = makeMetadataService(repo);
+    const pipeline = {
+      processChanges: mock(async () => emptyUpdateResult()),
+    } as unknown as IncrementalUpdatePipeline;
+    const detector = new LocalFolderChangeDetector(store);
+    const coord = new LocalFolderUpdateCoordinator(metadata, pipeline, detector, store);
+
+    let caught: unknown;
+    try {
+      await coord.updateRepository("locked");
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    expect((caught as Error).message).toMatch(/already in progress/i);
     expect(pipeline.processChanges).not.toHaveBeenCalled();
   });
 });

--- a/tests/services/orphan-manifest-reaper.test.ts
+++ b/tests/services/orphan-manifest-reaper.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for the orphan FileManifest reaper.
+ *
+ * Covers PR #573 review M-2: a `local-folder` registration that crashes
+ * between manifest write and metadata write leaves an orphaned manifest. The
+ * reaper deletes any manifest whose repository name is absent from the
+ * metadata store.
+ *
+ * @module tests/services/orphan-manifest-reaper
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { FileManifestStoreImpl } from "../../src/services/file-manifest-store.js";
+import { pruneOrphanManifests } from "../../src/services/orphan-manifest-reaper.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+import type { RepositoryInfo, RepositoryMetadataService } from "../../src/repositories/types.js";
+
+function makeRepo(name: string): RepositoryInfo {
+  return {
+    name,
+    source: "local-folder",
+    url: null,
+    localPath: `/tmp/${name}`,
+    collectionName: `repo_${name}`,
+    fileCount: 0,
+    chunkCount: 0,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "(local-folder)",
+    includeExtensions: [".ts"],
+    excludePatterns: [],
+  };
+}
+
+function makeMetadataService(repos: RepositoryInfo[]): RepositoryMetadataService {
+  return {
+    listRepositories: mock(async () => repos),
+    getRepository: mock(async () => null),
+    updateRepository: mock(async () => undefined),
+    removeRepository: mock(async () => undefined),
+  } as unknown as RepositoryMetadataService;
+}
+
+describe("pruneOrphanManifests", () => {
+  let dataDir: string;
+  let store: FileManifestStoreImpl;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    dataDir = join(import.meta.dir, "..", "..", "test-temp", `omr-${stamp}`);
+    await mkdir(dataDir, { recursive: true });
+    FileManifestStoreImpl.resetInstance();
+    store = FileManifestStoreImpl.getInstance(dataDir);
+  });
+
+  afterEach(async () => {
+    FileManifestStoreImpl.resetInstance();
+    await rm(dataDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("deletes manifests whose repository names are absent from metadata", async () => {
+    // Two manifests on disk.
+    await store.saveManifest("registered", {
+      version: "1.0",
+      repository: "registered",
+      generatedAt: new Date().toISOString(),
+      files: {},
+    });
+    await store.saveManifest("orphaned", {
+      version: "1.0",
+      repository: "orphaned",
+      generatedAt: new Date().toISOString(),
+      files: {},
+    });
+
+    // Only "registered" is in the metadata store.
+    const metadata = makeMetadataService([makeRepo("registered")]);
+
+    const result = await pruneOrphanManifests(metadata, store);
+
+    expect(result.totalManifests).toBe(2);
+    expect(result.reaped).toEqual(["orphaned"]);
+    expect(result.retained).toEqual(["registered"]);
+    expect(result.failed).toEqual([]);
+
+    // Sanity: orphaned manifest is gone from the store.
+    const orphanedAfter = await store.loadManifest("orphaned");
+    expect(Object.keys(orphanedAfter.files)).toEqual([]);
+    expect(orphanedAfter.generatedAt).toBe("1970-01-01T00:00:00.000Z");
+  });
+
+  it("returns an empty result when no manifests exist", async () => {
+    const metadata = makeMetadataService([]);
+    const result = await pruneOrphanManifests(metadata, store);
+    expect(result.totalManifests).toBe(0);
+    expect(result.reaped).toEqual([]);
+    expect(result.retained).toEqual([]);
+  });
+
+  it("retains all manifests when every repository is registered", async () => {
+    await store.saveManifest("a", {
+      version: "1.0",
+      repository: "a",
+      generatedAt: new Date().toISOString(),
+      files: {},
+    });
+    await store.saveManifest("b", {
+      version: "1.0",
+      repository: "b",
+      generatedAt: new Date().toISOString(),
+      files: {},
+    });
+
+    const metadata = makeMetadataService([makeRepo("a"), makeRepo("b")]);
+
+    const result = await pruneOrphanManifests(metadata, store);
+
+    expect(result.totalManifests).toBe(2);
+    expect(result.reaped).toEqual([]);
+    expect(result.retained.sort()).toEqual(["a", "b"]);
+  });
+
+  it("records a failure (instead of throwing) when deleteManifest rejects", async () => {
+    await store.saveManifest("orphaned", {
+      version: "1.0",
+      repository: "orphaned",
+      generatedAt: new Date().toISOString(),
+      files: {},
+    });
+
+    // Wrap the real store so listManifests still works but deleteManifest fails.
+    const wrapped: typeof store = {
+      ...store,
+      listManifests: () => store.listManifests(),
+      loadManifest: (n: string) => store.loadManifest(n),
+      saveManifest: (n: string, m: any) => store.saveManifest(n, m),
+      deleteManifest: () => Promise.reject(new Error("permission denied")),
+    } as any;
+
+    const metadata = makeMetadataService([]);
+
+    const result = await pruneOrphanManifests(metadata, wrapped);
+
+    // Reaper completes without throwing; the failure is reported to the caller.
+    expect(result.failed).toEqual(["orphaned"]);
+    expect(result.reaped).toEqual([]);
+  });
+});

--- a/tests/services/update-coordinator-dispatch.test.ts
+++ b/tests/services/update-coordinator-dispatch.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Unit tests for the source-aware update coordinator dispatch helper.
+ *
+ * Phase B added a parallel coordinator for `local-folder` repos; the dispatch
+ * rule must stay consistent across the MCP tool, the CLI commands, and the
+ * recovery service so a single helper is shared. This test pins the rule.
+ *
+ * @module tests/services/update-coordinator-dispatch
+ */
+
+import { describe, it, expect } from "bun:test";
+import { dispatchCoordinator } from "../../src/services/update-coordinator-dispatch.js";
+import type { IncrementalUpdateCoordinator } from "../../src/services/incremental-update-coordinator.js";
+import type { LocalFolderUpdateCoordinator } from "../../src/services/local-folder-update-coordinator.js";
+import type { RepositoryInfo } from "../../src/repositories/types.js";
+
+function makeRepo(source: RepositoryInfo["source"]): RepositoryInfo {
+  return {
+    name: "x",
+    source,
+    url: source === "local-folder" ? null : "https://example.invalid/repo.git",
+    localPath: "/tmp/x",
+    collectionName: "x",
+    fileCount: 0,
+    chunkCount: 0,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "main",
+    includeExtensions: [".ts"],
+    excludePatterns: [],
+  };
+}
+
+describe("dispatchCoordinator", () => {
+  // Cast empty objects to the coordinator types — we never call methods on them
+  // so the implementation surface is irrelevant; only identity matters.
+  const gitCoord = { tag: "git" } as unknown as IncrementalUpdateCoordinator;
+  const localCoord = { tag: "local" } as unknown as LocalFolderUpdateCoordinator;
+
+  it("returns the git coordinator for git-remote sources", () => {
+    expect(dispatchCoordinator(makeRepo("git-remote"), gitCoord, localCoord)).toBe(gitCoord);
+  });
+
+  it("returns the git coordinator for local-git sources", () => {
+    expect(dispatchCoordinator(makeRepo("local-git"), gitCoord, localCoord)).toBe(gitCoord);
+  });
+
+  it("returns the local-folder coordinator for local-folder sources", () => {
+    expect(dispatchCoordinator(makeRepo("local-folder"), gitCoord, localCoord)).toBe(localCoord);
+  });
+
+  it("returns undefined when local-folder source is requested but no local coordinator is supplied", () => {
+    expect(dispatchCoordinator(makeRepo("local-folder"), gitCoord, undefined)).toBeUndefined();
+  });
+
+  it("still returns the git coordinator when source is git-remote even without a local coordinator", () => {
+    expect(dispatchCoordinator(makeRepo("git-remote"), gitCoord, undefined)).toBe(gitCoord);
+  });
+});

--- a/tests/unit/services/interrupted-update-recovery.test.ts
+++ b/tests/unit/services/interrupted-update-recovery.test.ts
@@ -220,6 +220,51 @@ describe("evaluateRecoveryStrategy", () => {
     });
   });
 
+  describe("local-folder source", () => {
+    it("recommends resume for fresh local-folder repos regardless of last commit (PR #573 review)", async () => {
+      // Local-folder repos never have a `lastIndexedCommitSha`. The git path
+      // would route them to full_reindex which crashes on `repo.url!`; the
+      // local-folder branch must intercept and always recommend resume.
+      const repo = createMockRepo({
+        source: "local-folder",
+        url: null,
+      });
+      const info = createMockInterruptedInfo({
+        elapsedMs: 60_000,
+        lastKnownCommit: undefined,
+        repository: repo,
+      });
+
+      const strategy = await evaluateRecoveryStrategy(info);
+
+      expect(strategy.type).toBe("resume");
+      expect(strategy.canAutoRecover).toBe(true);
+      expect(strategy.reason).toMatch(/local-folder|FileManifest/i);
+    });
+
+    it("warns and surfaces elapsed time for stale (>24h) local-folder recoveries (PR #573 review M-5)", async () => {
+      const repo = createMockRepo({
+        source: "local-folder",
+        url: null,
+      });
+      const info = createMockInterruptedInfo({
+        elapsedMs: 48 * 60 * 60 * 1000, // 48 hours stale
+        lastKnownCommit: undefined,
+        repository: repo,
+      });
+
+      const strategy = await evaluateRecoveryStrategy(info);
+
+      // Still resume (manifest is preserved on prior failure), but the reason
+      // string must explicitly mention the elapsed time so it shows up in any
+      // recovery report the operator reads.
+      expect(strategy.type).toBe("resume");
+      expect(strategy.canAutoRecover).toBe(true);
+      expect(strategy.reason).toMatch(/ago/i);
+      expect(strategy.reason).toMatch(/review/i);
+    });
+  });
+
   describe("edge cases", () => {
     it("should handle zero elapsed time", async () => {
       const info = createMockInterruptedInfo({


### PR DESCRIPTION
## Summary

Phase B of the [Local Folder as Repository](docs/pm/Local-Folder-As-Repository-PRD.md) feature. Wires the `local-folder` source through the existing ingestion + incremental-update pipelines so a non-git folder can be registered, indexed, semantically searched, and refreshed via `trigger_incremental_update`. Drift is reported when the registered folder is moved or deleted.

Phase A foundation (#564 / PR #572) is reused intact: `RepositoryInfo.source` discriminator, `tier`, `lastManifestId`, relaxed `UpdateHistoryEntry`, and `FileManifestStore`.

Tasks delivered: **T2.1–T2.6** (initial scan path) and **T3.1–T3.4** (change detection + incremental update). See [implementation plan §2 PRs 2 + 3](docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md#pr-2--local-folder-ingestion-path-initial-scan).

## What changed

### New components
- `src/ingestion/gitignore-filter.ts` — nested `.gitignore` filter (T2.3). Walks the tree, evaluates rules deepest-first, honors negation (`!keep.txt`).
- `src/services/local-folder-change-detector.ts` — manifest-vs-disk diff producing `FileChange[]` (T3.1). Fast-path `(size, mtime)` skip with sha256 fallback; optional `paranoid` mode for unreliable mtimes.
- `src/services/local-folder-update-coordinator.ts` — same `updateRepository(name): Promise<CoordinatorResult>` signature as `IncrementalUpdateCoordinator` (T3.2). Returns `drift_detected` on missing `localPath`; appends `UpdateHistoryEntry` with `local-<isoDate>` markers.
- `LocalFolderPublicTierRefusedError`, `LocalFolderSizeRefusedError` (T2.5, T2.6).

### Wired into existing services
- `IngestionService` branches on `.git` presence inside the local-path arm (T2.1) → `local-git` if present, `local-folder` otherwise. Refuses `tier=public` for local-folder (T2.6). Pre-scans with 10K files / 1 GiB soft warn and 100K / 10 GiB hard refuse (bypassed by `force=true`) (T2.5). Writes the initial `FileManifest` after the first scan (T2.2).
- `FileScanner` + `ScanOptions.respectNestedGitignore` — on for local sources, off for git-remote (T2.4).
- `trigger_incremental_update` MCP tool dispatches by `repo.source` (T3.3); local-folder repos route to the new coordinator. Wired through `MCPServerOptionalDeps`, `ToolRegistryDependencies`, `dependency-init`, and `src/index.ts`. Optional in `TriggerUpdateDependencies` — handler returns `service_unavailable` if a local-folder repo arrives without the coordinator configured.
- `list_indexed_repositories` adds `local_path` for non-git-remote sources (T3.4).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun run build` — bundles index.js (7.18 MB) and cli.js (5.72 MB) without errors
- [x] **21 new unit tests pass** (gitignore-filter, change-detector, update-coordinator) at 100% line coverage on the three new modules
- [x] **3 new integration tests pass** (`local-folder-lifecycle.integration.test.ts`): register → modify → update happy path, drift_detected on missing folder, no_changes when nothing moved
- [x] Pre-existing test groups continue to pass with 0 new failures: `tests/services` (236), `tests/ingestion` (7), `tests/mcp` (404), `tests/documents` (22), `tests/auth + tests/cli + tests/repositories + tests/integration` (1080 pass / 0 fail / 123 skip)
- [x] Existing `tests/mcp/tools/trigger-incremental-update*.test.ts` continue to pass without modification (`localFolderCoordinator` is optional in `TriggerUpdateDependencies`)
- 2 pre-existing failures in `tests/isolated/pdf-extractor-*` and several hangs in `tests/isolated/graph-*-command` reproduce identically on `main` (environment-dependent: native sharp/pdfjs bindings + CLI subprocess behavior), not introduced by this PR

### Manual smoke (recommended before merge)
```powershell
# In the worktree (or after merging to main and pulling):
mkdir C:/tmp/pkm-565-fixture/src
"console.log('hi')" | Out-File -Encoding utf8 C:/tmp/pkm-565-fixture/src/a.ts
bun run cli index C:/tmp/pkm-565-fixture --name smoke565 --tier private
bun run cli status     # smoke565 should show source=local-folder
bun run cli search "console"
"console.log('hi v2')" | Out-File -Encoding utf8 C:/tmp/pkm-565-fixture/src/a.ts
# Trigger via MCP test client; expect chunks updated, no drift.
```

## PR size

~2,140 LoC (1,300 production + 840 test). Exceeds the 400-LoC PR guideline — accepted per the [PRD §7](docs/pm/Local-Folder-As-Repository-PRD.md#7-phasing) and [implementation plan §6.1](docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md#61-consolidated-5-phase-delivery): this slice is one coherent, reviewable feature; reviewers should expect to load the design docs as context.

## Out of scope (deferred to subsequent phases)

- CLI flags (`--name`, `--watch`, `--tier`, `--force`, `--follow-symlinks`), `register_local_folder` MCP tool, filesystem watcher, `FolderEventRouter` — all Phase C / #566.
- Document graph (markdown/PDF/DOCX entities) — Phase D / #567.
- ADR-0007, README polish — Phase E / #568.

Fixes #565

🤖 Generated with [Claude Code](https://claude.com/claude-code)