### PR TITLE
feat(#566): Phase C — CLI auto-detect + register_local_folder MCP tool + watcher (T4.1-T4.4 + T5.1-T5.4)

### DIFF
--- a/src/cli/commands/index-command.ts
+++ b/src/cli/commands/index-command.ts
@@ -181,9 +181,7 @@ export async function indexCommand(
   try {
     // Resolve watch default by source: local-folder → true unless --no-watch
     // explicitly disables it; everything else → false.
-    const effectiveWatch = isLocalFolderSource
-      ? options.watch !== false
-      : false;
+    const effectiveWatch = isLocalFolderSource ? options.watch !== false : false;
 
     // Index repository with progress callback
     const result = await deps.ingestionService.indexRepository(url, {

--- a/src/cli/commands/index-command.ts
+++ b/src/cli/commands/index-command.ts
@@ -23,9 +23,21 @@ export interface IndexCommandOptions {
   force?: boolean;
   /** Embedding provider to use (openai, transformersjs, local, ollama) */
   provider?: string;
+  /** Security tier — passed through to IngestionService (which enforces folder-specific rules). */
+  tier?: "private" | "work" | "public";
+  /**
+   * Whether to enable the filesystem watcher after indexing finishes. Only
+   * applied when the path resolves to a `local-folder` source. `undefined`
+   * means "use the default for this source" — true for local folders, false
+   * for git sources.
+   */
+  watch?: boolean;
+  /** Whether the local-folder watcher should follow symlinks. Default false. */
+  followSymlinks?: boolean;
 }
 
 import { resolve, normalize, basename } from "node:path";
+import { stat } from "node:fs/promises";
 import { isLocalPath } from "../../utils/path-utils.js";
 
 /**
@@ -113,6 +125,44 @@ export async function indexCommand(
   // Extract or use provided repository name
   const repositoryName = options.name || extractRepositoryName(url);
 
+  // Resolve flag semantics by source. We auto-detect local vs git via
+  // isLocalPath; for local paths we additionally probe `.git` so the watch
+  // default doesn't activate for local-git sources (those have a remote
+  // equivalent and shouldn't pull in the local-folder watcher pipeline).
+  const looksLocal = isLocalPath(url);
+  let isLocalFolderSource = false;
+  if (looksLocal) {
+    try {
+      const resolved = normalize(resolve(url));
+      const pathStat = await stat(resolved);
+      if (pathStat.isDirectory()) {
+        try {
+          await stat(`${resolved}/.git`);
+          isLocalFolderSource = false; // has .git → local-git, not local-folder
+        } catch {
+          isLocalFolderSource = true;
+        }
+      }
+    } catch {
+      // Path stat will fail again inside IngestionService and surface a typed
+      // error; we just don't set the watcher defaults here.
+    }
+  }
+
+  // Phase C (T4.1): refuse non-local flags on git URLs early so the user
+  // doesn't get a confusing IngestionService error after a long clone.
+  if (!looksLocal && (options.watch === true || options.followSymlinks === true)) {
+    throw new Error(
+      "--watch and --follow-symlinks are only valid for local folders, not git URLs.\n" +
+        "Either omit these flags or pass a local path."
+    );
+  }
+  if (!isLocalFolderSource && options.tier === "public" && looksLocal) {
+    // local-git rejects `tier=public` only for the folder source; we let
+    // IngestionService be the single source of truth for public-tier policy
+    // on git-remote / local-git so the message stays consistent.
+  }
+
   // Check if repository already exists (unless force)
   if (!options.force) {
     const existing = await deps.repositoryService.getRepository(repositoryName);
@@ -129,11 +179,20 @@ export async function indexCommand(
   const spinner = createIndexSpinner(repositoryName);
 
   try {
+    // Resolve watch default by source: local-folder → true unless --no-watch
+    // explicitly disables it; everything else → false.
+    const effectiveWatch = isLocalFolderSource
+      ? options.watch !== false
+      : false;
+
     // Index repository with progress callback
     const result = await deps.ingestionService.indexRepository(url, {
       name: options.name,
       branch: options.branch,
       force: options.force,
+      tier: options.tier,
+      watch: effectiveWatch,
+      followSymlinks: options.followSymlinks ?? false,
       onProgress: (progress) => {
         updateIndexSpinner(spinner, progress);
       },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,12 +113,25 @@ program
 // Index command
 program
   .command("index")
-  .description("Index a repository for semantic search")
-  .argument("<url>", "Repository URL to index")
+  .description("Index a git repository OR a local folder (auto-detected) for semantic search")
+  .argument("<url>", "Git URL or absolute / relative local folder path")
   .option("-n, --name <name>", "Custom repository name")
-  .option("-b, --branch <branch>", "Branch to clone")
+  .option("-b, --branch <branch>", "Branch to clone (git only)")
   .option("-f, --force", "Force reindexing if repository already exists")
   .option("-p, --provider <provider>", "Embedding provider (openai, transformersjs, local, ollama)")
+  .option(
+    "--tier <tier>",
+    "Security tier: private | work | public (local folders default to private; public is refused for folders)"
+  )
+  .option(
+    "--watch",
+    "Enable filesystem watcher after indexing a local folder (default: enabled)"
+  )
+  .option("--no-watch", "Disable filesystem watcher even for local folders")
+  .option(
+    "--follow-symlinks",
+    "Follow symlinks inside the local folder (default: skip; out-of-folder targets are rejected even when set)"
+  )
   .action(async (url: string, options: Record<string, unknown>) => {
     try {
       const validatedOptions = IndexCommandOptionsSchema.parse(options);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -123,10 +123,7 @@ program
     "--tier <tier>",
     "Security tier: private | work | public (local folders default to private; public is refused for folders)"
   )
-  .option(
-    "--watch",
-    "Enable filesystem watcher after indexing a local folder (default: enabled)"
-  )
+  .option("--watch", "Enable filesystem watcher after indexing a local folder (default: enabled)")
   .option("--no-watch", "Disable filesystem watcher even for local folders")
   .option(
     "--follow-symlinks",

--- a/src/cli/utils/validation.ts
+++ b/src/cli/utils/validation.ts
@@ -16,6 +16,12 @@ const VALID_PROVIDERS = ["openai", "transformersjs", "transformers", "local", "o
 
 /**
  * Schema for index command options
+ *
+ * Phase C (#566) extends the schema with local-folder registration flags:
+ * `--tier`, `--watch`/`--no-watch`, and `--follow-symlinks`. These are only
+ * meaningful when the path resolves to a non-git folder; they are passed
+ * through to `IngestionService.indexRepository` which enforces the
+ * source-specific semantics (e.g. refusing `--tier public` on a local folder).
  */
 export const IndexCommandOptionsSchema = z.object({
   name: z.string().optional(),
@@ -28,6 +34,14 @@ export const IndexCommandOptionsSchema = z.object({
     .refine((val) => !val || VALID_PROVIDERS.includes(val as (typeof VALID_PROVIDERS)[number]), {
       message: "Invalid provider. Valid values: openai, transformersjs, local, ollama",
     }),
+  tier: z
+    .enum(["private", "work", "public"])
+    .optional()
+    .describe("Security tier (local-folder default: private; public refused for folders)"),
+  // Commander surfaces `--no-watch` as `watch: false`; absence is `watch: undefined`.
+  // The handler treats `undefined` as "default by source" — true for local-folder.
+  watch: z.boolean().optional(),
+  followSymlinks: z.boolean().optional(),
 });
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,11 +308,9 @@ async function main(): Promise<void> {
       logger.debug("No watched folders to restore from store");
     }
 
-    // Phase C (#566 / T5.3): restore local-folder watchers for repos that
-    // previously had `watchEnabled: true`. We can't do this until the
-    // `folderUpdatePipeline` exists, so the loop runs immediately after the
-    // watch-manager wiring below — see the `restoreLocalFolderWatchers`
-    // call after the FolderEventRouter is constructed.
+    // Phase C (#566 / T5.3): the local-folder watcher restoration loop runs
+    // AFTER the GITHUB_PAT branch below, so the final `localFolderCoordinator`
+    // instance is chosen before any watcher attaches (review H-1).
 
     // Create change detection service wrapping folder watcher
     const changeDetectionService = new ChangeDetectionService(folderWatcherService);
@@ -392,11 +390,24 @@ async function main(): Promise<void> {
       localFolderWatchManager
     );
 
+    // The router closure intentionally references `localFolderCoordinator`
+    // (the let-binding, not a snapshot) so the PAT branch below can replace
+    // the instance with a graph-aware variant and the watcher dispatch picks
+    // up the new coordinator on the next event without re-wiring. The guard
+    // (review M-2) handles the case where the PAT branch's catch sets the
+    // coordinator back to `undefined` mid-session.
     const folderEventRouter = new FolderEventRouter(
       repositoryService,
       async (repo) => {
+        if (!localFolderCoordinator) {
+          logger.warn(
+            { repository: repo.name },
+            "Local-folder watcher dispatch fired with no coordinator wired; dropping event"
+          );
+          return;
+        }
         try {
-          await localFolderCoordinator!.updateRepository(repo.name);
+          await localFolderCoordinator.updateRepository(repo.name);
         } catch (error) {
           logger.error(
             {
@@ -410,47 +421,6 @@ async function main(): Promise<void> {
     );
     folderWatcherService.onFileEvent(folderEventRouter.asEventHandler());
     logger.info("FolderEventRouter wired alongside Phase 6 ChangeDetectionService");
-
-    // Phase C (#566 / T5.3): restore watchers for local-folder repos that
-    // had `watchEnabled === true` when the server last ran. Failures here
-    // are logged and skipped so a single broken path can't block startup.
-    try {
-      const allRepos = await repositoryService.listRepositories();
-      const watchedLocalFolders = allRepos.filter(
-        (r) => r.source === "local-folder" && r.watchEnabled === true
-      );
-      if (watchedLocalFolders.length > 0) {
-        logger.info(
-          { count: watchedLocalFolders.length },
-          "Restoring local-folder watchers from metadata"
-        );
-        for (const repo of watchedLocalFolders) {
-          try {
-            await localFolderCoordinator.startWatching(repo);
-            logger.info(
-              { repository: repo.name, path: repo.localPath },
-              "Restored local-folder watcher"
-            );
-          } catch (error) {
-            logger.warn(
-              {
-                repository: repo.name,
-                path: repo.localPath,
-                error: error instanceof Error ? error.message : String(error),
-              },
-              "Failed to restore local-folder watcher - skipping"
-            );
-          }
-        }
-      } else {
-        logger.debug("No local-folder watchers to restore");
-      }
-    } catch (error) {
-      logger.warn(
-        { error: error instanceof Error ? error.message : String(error) },
-        "Local-folder watcher restoration query failed - skipping all"
-      );
-    }
 
     const envPath = `${process.cwd()}/.env`;
     logger.info({ envPath }, "Resolving GitHub PAT");
@@ -545,6 +515,57 @@ async function main(): Promise<void> {
     } else {
       logger.info("GITHUB_PAT not set - MCP incremental update tools disabled");
       updateToolsUnavailableReason = "GITHUB_PAT is not configured";
+    }
+
+    // Phase C (#566 / T5.3): restore watchers for local-folder repos that had
+    // `watchEnabled === true` when the server last ran. Runs AFTER the PAT
+    // branch (review H-1) so the final `localFolderCoordinator` instance is
+    // chosen before any watcher attaches — this preserves the invariant that
+    // a graph-aware coordinator (when the PAT branch upgraded it) handles
+    // every restored watcher's update calls. Failures are per-repo logged and
+    // skipped so a single broken path can't block startup.
+    if (localFolderCoordinator) {
+      try {
+        const allRepos = await repositoryService.listRepositories();
+        const watchedLocalFolders = allRepos.filter(
+          (r) => r.source === "local-folder" && r.watchEnabled === true
+        );
+        if (watchedLocalFolders.length > 0) {
+          logger.info(
+            { count: watchedLocalFolders.length },
+            "Restoring local-folder watchers from metadata"
+          );
+          for (const repo of watchedLocalFolders) {
+            try {
+              await localFolderCoordinator.startWatching(repo);
+              logger.info(
+                { repository: repo.name, path: repo.localPath },
+                "Restored local-folder watcher"
+              );
+            } catch (error) {
+              logger.warn(
+                {
+                  repository: repo.name,
+                  path: repo.localPath,
+                  error: error instanceof Error ? error.message : String(error),
+                },
+                "Failed to restore local-folder watcher - skipping"
+              );
+            }
+          }
+        } else {
+          logger.debug("No local-folder watchers to restore");
+        }
+      } catch (error) {
+        logger.warn(
+          { error: error instanceof Error ? error.message : String(error) },
+          "Local-folder watcher restoration query failed - skipping all"
+        );
+      }
+    } else {
+      logger.warn(
+        "Local-folder coordinator unavailable - watcher restoration skipped"
+      );
     }
 
     // Step 5c: Build an IngestionService for the `register_local_folder` tool

--- a/src/index.ts
+++ b/src/index.ts
@@ -396,29 +396,26 @@ async function main(): Promise<void> {
     // up the new coordinator on the next event without re-wiring. The guard
     // (review M-2) handles the case where the PAT branch's catch sets the
     // coordinator back to `undefined` mid-session.
-    const folderEventRouter = new FolderEventRouter(
-      repositoryService,
-      async (repo) => {
-        if (!localFolderCoordinator) {
-          logger.warn(
-            { repository: repo.name },
-            "Local-folder watcher dispatch fired with no coordinator wired; dropping event"
-          );
-          return;
-        }
-        try {
-          await localFolderCoordinator.updateRepository(repo.name);
-        } catch (error) {
-          logger.error(
-            {
-              repository: repo.name,
-              error: error instanceof Error ? error.message : String(error),
-            },
-            "Local-folder watcher dispatch failed"
-          );
-        }
+    const folderEventRouter = new FolderEventRouter(repositoryService, async (repo) => {
+      if (!localFolderCoordinator) {
+        logger.warn(
+          { repository: repo.name },
+          "Local-folder watcher dispatch fired with no coordinator wired; dropping event"
+        );
+        return;
       }
-    );
+      try {
+        await localFolderCoordinator.updateRepository(repo.name);
+      } catch (error) {
+        logger.error(
+          {
+            repository: repo.name,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Local-folder watcher dispatch failed"
+        );
+      }
+    });
     folderWatcherService.onFileEvent(folderEventRouter.asEventHandler());
     logger.info("FolderEventRouter wired alongside Phase 6 ChangeDetectionService");
 
@@ -563,9 +560,7 @@ async function main(): Promise<void> {
         );
       }
     } else {
-      logger.warn(
-        "Local-folder coordinator unavailable - watcher restoration skipped"
-      );
+      logger.warn("Local-folder coordinator unavailable - watcher restoration skipped");
     }
 
     // Step 5c: Build an IngestionService for the `register_local_folder` tool

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,8 @@ import type { GraphService } from "./services/graph-service-types.js";
 // Incremental update dependencies
 import { FileChunker } from "./ingestion/file-chunker.js";
 import { FileScanner } from "./ingestion/file-scanner.js";
+import { RepositoryCloner } from "./ingestion/repository-cloner.js";
+import { IngestionService } from "./services/ingestion-service.js";
 import { GitHubClientImpl } from "./services/github-client.js";
 import { IncrementalUpdatePipeline } from "./services/incremental-update-pipeline.js";
 import { IncrementalUpdateCoordinator } from "./services/incremental-update-coordinator.js";
@@ -446,6 +448,36 @@ async function main(): Promise<void> {
       updateToolsUnavailableReason = "GITHUB_PAT is not configured";
     }
 
+    // Step 5c: Build an IngestionService for the `register_local_folder` tool
+    // (Phase C / #566). This is constructed up-front (independent of the
+    // GITHUB_PAT branch above) because local-folder registration does not
+    // require a remote and has no PAT dependency. The repositoryCloner is
+    // wired in for parity with the type contract; it is never invoked for
+    // local-folder paths because the local branch in `IngestionService.index`
+    // skips it entirely.
+    const registrationFileScanner = new FileScanner();
+    const registrationFileChunker = new FileChunker();
+    const registrationDocChunker = new DocumentChunker();
+    const registrationDocTypeDetector = new DocumentTypeDetector();
+    const registrationRepositoryCloner = new RepositoryCloner({
+      clonePath: Bun.env["CLONE_PATH"] || "./data/repositories",
+      githubPat: Bun.env["GITHUB_PAT"],
+      gitPat: Bun.env["GIT_PAT"],
+    });
+    const ingestionService = new IngestionService(
+      registrationRepositoryCloner,
+      registrationFileScanner,
+      registrationFileChunker,
+      embeddingProvider,
+      chromaClient,
+      repositoryService,
+      {
+        documentChunker: registrationDocChunker,
+        documentTypeDetector: registrationDocTypeDetector,
+      }
+    );
+    logger.debug("Ingestion service initialized for register_local_folder MCP tool");
+
     // Step 6: Create MCP server
     logger.info("Creating MCP server");
     const mcpServer = new PersonalKnowledgeMCPServer(
@@ -466,6 +498,7 @@ async function main(): Promise<void> {
         jobTracker,
         documentSearchService,
         listWatchedFoldersService,
+        ingestionService,
         updateToolsUnavailableReason,
       }
     );

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,8 @@ import { FolderWatcherService } from "./services/folder-watcher-service.js";
 import { WatchedFolderStoreImpl } from "./services/watched-folder-store.js";
 import { ChangeDetectionService } from "./services/change-detection-service.js";
 import { FolderDocumentIndexingService } from "./services/folder-document-indexing-service.js";
+import { FolderEventRouter } from "./services/folder-event-router.js";
+import { LocalFolderRepoWatchManager } from "./services/local-folder-repo-watch-manager.js";
 import { ListWatchedFoldersServiceImpl } from "./services/list-watched-folders-service.js";
 import { DocumentTypeDetector } from "./documents/DocumentTypeDetector.js";
 import { DocumentChunker } from "./documents/DocumentChunker.js";
@@ -306,6 +308,12 @@ async function main(): Promise<void> {
       logger.debug("No watched folders to restore from store");
     }
 
+    // Phase C (#566 / T5.3): restore local-folder watchers for repos that
+    // previously had `watchEnabled: true`. We can't do this until the
+    // `folderUpdatePipeline` exists, so the loop runs immediately after the
+    // watch-manager wiring below — see the `restoreLocalFolderWatchers`
+    // call after the FolderEventRouter is constructed.
+
     // Create change detection service wrapping folder watcher
     const changeDetectionService = new ChangeDetectionService(folderWatcherService);
 
@@ -353,12 +361,96 @@ async function main(): Promise<void> {
 
     logger.info("Folder watcher and document indexing services initialized");
 
-    // Step 5b: Initialize incremental update dependencies (optional - requires GITHUB_PAT)
+    // Step 5b: Initialize incremental update dependencies. Git-based update
+    // coordinator + rate limiter + job tracker are PAT-gated below; the
+    // local-folder coordinator (Phase C / #566) is NOT — local folders don't
+    // need GitHub. The PAT branch may overwrite `localFolderCoordinator` with
+    // a graph-aware variant when a graph adapter is configured.
     let updateCoordinator: IncrementalUpdateCoordinator | undefined;
     let localFolderCoordinator: LocalFolderUpdateCoordinator | undefined;
     let rateLimiter: MCPRateLimiter | undefined;
     let jobTracker: JobTracker | undefined;
     let updateToolsUnavailableReason: string | undefined;
+
+    // Phase C: build the local-folder watch manager + router up-front so the
+    // coordinator (constructed below) can delegate watch lifecycle to it. The
+    // router subscribes to `folderWatcherService.onFileEvent` alongside Phase
+    // 6's `ChangeDetectionService`; each subscriber inspects `event.folderId`
+    // and acts only on the namespace it owns.
+    const localFolderWatchManager = new LocalFolderRepoWatchManager(folderWatcherService);
+
+    // Default local-folder coordinator (no graph ingestion) — used when no
+    // GITHUB_PAT is set. The PAT branch below replaces this with a
+    // graph-aware variant when both the PAT and a graph adapter are
+    // configured, preserving the prior Phase B behavior for paying users.
+    localFolderCoordinator = new LocalFolderUpdateCoordinator(
+      repositoryService,
+      folderUpdatePipeline,
+      undefined,
+      undefined,
+      {},
+      localFolderWatchManager
+    );
+
+    const folderEventRouter = new FolderEventRouter(
+      repositoryService,
+      async (repo) => {
+        try {
+          await localFolderCoordinator!.updateRepository(repo.name);
+        } catch (error) {
+          logger.error(
+            {
+              repository: repo.name,
+              error: error instanceof Error ? error.message : String(error),
+            },
+            "Local-folder watcher dispatch failed"
+          );
+        }
+      }
+    );
+    folderWatcherService.onFileEvent(folderEventRouter.asEventHandler());
+    logger.info("FolderEventRouter wired alongside Phase 6 ChangeDetectionService");
+
+    // Phase C (#566 / T5.3): restore watchers for local-folder repos that
+    // had `watchEnabled === true` when the server last ran. Failures here
+    // are logged and skipped so a single broken path can't block startup.
+    try {
+      const allRepos = await repositoryService.listRepositories();
+      const watchedLocalFolders = allRepos.filter(
+        (r) => r.source === "local-folder" && r.watchEnabled === true
+      );
+      if (watchedLocalFolders.length > 0) {
+        logger.info(
+          { count: watchedLocalFolders.length },
+          "Restoring local-folder watchers from metadata"
+        );
+        for (const repo of watchedLocalFolders) {
+          try {
+            await localFolderCoordinator.startWatching(repo);
+            logger.info(
+              { repository: repo.name, path: repo.localPath },
+              "Restored local-folder watcher"
+            );
+          } catch (error) {
+            logger.warn(
+              {
+                repository: repo.name,
+                path: repo.localPath,
+                error: error instanceof Error ? error.message : String(error),
+              },
+              "Failed to restore local-folder watcher - skipping"
+            );
+          }
+        }
+      } else {
+        logger.debug("No local-folder watchers to restore");
+      }
+    } catch (error) {
+      logger.warn(
+        { error: error instanceof Error ? error.message : String(error) },
+        "Local-folder watcher restoration query failed - skipping all"
+      );
+    }
 
     const envPath = `${process.cwd()}/.env`;
     logger.info({ envPath }, "Resolving GitHub PAT");
@@ -418,9 +510,16 @@ async function main(): Promise<void> {
         );
 
         // Local-folder coordinator shares the metadata service + pipeline.
+        // Phase C: replaces the no-graph default constructed above so that
+        // local-folder updates triggered via `trigger_incremental_update`
+        // populate the graph when a graph adapter is configured.
         localFolderCoordinator = new LocalFolderUpdateCoordinator(
           repositoryService,
-          updatePipeline
+          updatePipeline,
+          undefined,
+          undefined,
+          {},
+          localFolderWatchManager
         );
 
         // Create rate limiter (2-second cooldown by default, configurable via UPDATE_RATE_LIMIT_MS)
@@ -509,6 +608,10 @@ async function main(): Promise<void> {
     // being emitted into a disposed ChangeDetectionService during shutdown.
     mcpServer.registerPreShutdownHook(async () => {
       logger.info("Stopping all folder watchers");
+      // Cancel pending router debounce timers so we don't keep refs after the
+      // watcher fleet stops — otherwise a stale debounce would fire into a
+      // detached repository service.
+      folderEventRouter.shutdown();
       await folderWatcherService.stopAllWatchers();
     });
 

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -101,6 +101,7 @@ export class PersonalKnowledgeMCPServer {
         documentSearchService: optionalDeps.documentSearchService,
         imageSearchService: optionalDeps.imageSearchService,
         listWatchedFoldersService: optionalDeps.listWatchedFoldersService,
+        ingestionService: optionalDeps.ingestionService,
         updateToolsUnavailableReason: optionalDeps.updateToolsUnavailableReason,
       });
     } else {

--- a/src/mcp/tools/index.ts
+++ b/src/mcp/tools/index.ts
@@ -44,6 +44,11 @@ import {
   getGraphMetricsToolDefinition,
   createGetGraphMetricsHandler,
 } from "./get-graph-metrics.js";
+import {
+  registerLocalFolderToolDefinition,
+  createRegisterLocalFolderHandler,
+} from "./register-local-folder.js";
+import type { IngestionService } from "../../services/ingestion-service.js";
 
 /**
  * Dependencies for tool registry creation
@@ -76,6 +81,11 @@ export interface ToolRegistryDependencies {
   imageSearchService?: ImageSearchService;
   /** Optional: ListWatchedFoldersService for listing watched folders */
   listWatchedFoldersService?: ListWatchedFoldersService;
+  /**
+   * Optional: IngestionService for the `register_local_folder` tool (Phase C).
+   * When omitted the tool is not registered.
+   */
+  ingestionService?: IngestionService;
   /** Optional: Human-readable reason why update tools are unavailable */
   updateToolsUnavailableReason?: string;
 }
@@ -256,6 +266,21 @@ export function createToolRegistry(
     registry["list_watched_folders"] = {
       definition: listWatchedFoldersToolDefinition,
       handler: createListWatchedFoldersHandler(deps.listWatchedFoldersService),
+    };
+  }
+
+  // Phase C (T4.4): register `register_local_folder` when an IngestionService
+  // is wired. The tool runs synchronously by default; async mode is only
+  // honored when a JobTracker is also available.
+  if (deps.ingestionService) {
+    registry["register_local_folder"] = {
+      definition: registerLocalFolderToolDefinition,
+      handler: createRegisterLocalFolderHandler({
+        ingestionService: deps.ingestionService,
+        localFolderCoordinator: deps.localFolderCoordinator,
+        repositoryService: deps.repositoryService,
+        jobTracker: deps.jobTracker,
+      }),
     };
   }
 

--- a/src/mcp/tools/register-local-folder.ts
+++ b/src/mcp/tools/register-local-folder.ts
@@ -93,14 +93,12 @@ export const registerLocalFolderToolDefinition: Tool = {
       },
       name: {
         type: "string",
-        description:
-          "Optional repository name. Defaults to the basename of the resolved path.",
+        description: "Optional repository name. Defaults to the basename of the resolved path.",
       },
       tier: {
         type: "string",
         enum: ["private", "work"],
-        description:
-          "Security tier. Defaults to 'private'. 'public' is refused for local folders.",
+        description: "Security tier. Defaults to 'private'. 'public' is refused for local folders.",
       },
       force: {
         type: "boolean",
@@ -110,8 +108,7 @@ export const registerLocalFolderToolDefinition: Tool = {
       },
       watch: {
         type: "boolean",
-        description:
-          "Start the filesystem watcher after the initial scan. Defaults to true.",
+        description: "Start the filesystem watcher after the initial scan. Defaults to true.",
         default: true,
       },
       followSymlinks: {
@@ -153,11 +150,10 @@ function validateArgs(args: unknown): RegisterArgs {
   return {
     path: path.trim(),
     name: typeof obj["name"] === "string" ? obj["name"].trim() : undefined,
-    tier: tier as RegisterArgs["tier"],
+    tier: tier,
     force: typeof obj["force"] === "boolean" ? obj["force"] : false,
     watch: typeof obj["watch"] === "boolean" ? obj["watch"] : true,
-    followSymlinks:
-      typeof obj["followSymlinks"] === "boolean" ? obj["followSymlinks"] : false,
+    followSymlinks: typeof obj["followSymlinks"] === "boolean" ? obj["followSymlinks"] : false,
     async: typeof obj["async"] === "boolean" ? obj["async"] : false,
   };
 }
@@ -200,8 +196,7 @@ function formatAsyncSuccessResponse(repository: string, jobId: string): TextCont
     async: true,
     job_id: jobId,
     repository,
-    message:
-      "Registration started. Use get_update_status with this job_id to poll for completion.",
+    message: "Registration started. Use get_update_status with this job_id to poll for completion.",
   };
   return { type: "text", text: JSON.stringify(response, null, 2) };
 }

--- a/src/mcp/tools/register-local-folder.ts
+++ b/src/mcp/tools/register-local-folder.ts
@@ -1,0 +1,374 @@
+/**
+ * register_local_folder MCP Tool Implementation (Phase C / issue #566 / T4.3-T4.4)
+ *
+ * Registers an absolute or relative filesystem path as a `local-folder`
+ * repository: scans, embeds, persists `RepositoryInfo` with `source =
+ * "local-folder"`, and (when `watch === true`) starts the chokidar watcher.
+ *
+ * Sync mode (`async: false`, default): runs registration to completion and
+ * returns the resulting repository name + status. Suitable for small folders.
+ *
+ * Async mode (`async: true`): returns immediately with a job ID created via
+ * the shared `JobTracker` so the caller can poll `get_update_status`. The
+ * background worker maps the `IndexResult` to a synthetic `CoordinatorResult`
+ * compatible with the existing JobTracker job-completion machinery.
+ *
+ * @module mcp/tools/register-local-folder
+ */
+
+import type { Tool, CallToolResult, TextContent } from "@modelcontextprotocol/sdk/types.js";
+import type { IngestionService } from "../../services/ingestion-service.js";
+import type { LocalFolderUpdateCoordinator } from "../../services/local-folder-update-coordinator.js";
+import type { RepositoryMetadataService } from "../../repositories/types.js";
+import type { CoordinatorResult } from "../../services/incremental-update-coordinator-types.js";
+import type { IndexResult } from "../../services/ingestion-types.js";
+import { mapToMCPError } from "../errors.js";
+import { getComponentLogger } from "../../logging/index.js";
+import type { ToolHandler } from "../types.js";
+import type { JobTracker } from "../job-tracker.js";
+
+let logger: ReturnType<typeof getComponentLogger> | null = null;
+function getLogger(): ReturnType<typeof getComponentLogger> {
+  if (!logger) logger = getComponentLogger("mcp:register-local-folder");
+  return logger;
+}
+
+type RegisterErrorCode =
+  | "invalid_argument"
+  | "registration_failed"
+  | "internal_error"
+  | "service_unavailable";
+
+interface RegisterArgs {
+  path: string;
+  name?: string;
+  tier?: "private" | "work" | "public";
+  force?: boolean;
+  watch?: boolean;
+  followSymlinks?: boolean;
+  async?: boolean;
+}
+
+interface SyncSuccessResponse {
+  success: true;
+  repository: string;
+  status: "registered" | "partial" | "failed";
+  files_processed: number;
+  chunks_created: number;
+  duration_ms: number;
+  watch_enabled: boolean;
+  follow_symlinks: boolean;
+}
+
+interface AsyncSuccessResponse {
+  success: true;
+  async: true;
+  job_id: string;
+  repository: string;
+  message: string;
+}
+
+interface ErrorResponse {
+  success: false;
+  error: RegisterErrorCode;
+  message: string;
+}
+
+export const registerLocalFolderToolDefinition: Tool = {
+  name: "register_local_folder",
+  description:
+    "Registers a local filesystem folder as a `local-folder` repository in the knowledge base. " +
+    "Scans the folder, generates embeddings, and (by default) starts a filesystem watcher " +
+    "that re-indexes the folder when its files change. The path may be absolute or relative; " +
+    "for `local-folder` sources `tier='public'` is refused. Use `async: true` to return a job " +
+    "ID immediately and poll `get_update_status` for completion.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      path: {
+        type: "string",
+        description: "Absolute or relative path to the folder to register.",
+        minLength: 1,
+      },
+      name: {
+        type: "string",
+        description:
+          "Optional repository name. Defaults to the basename of the resolved path.",
+      },
+      tier: {
+        type: "string",
+        enum: ["private", "work"],
+        description:
+          "Security tier. Defaults to 'private'. 'public' is refused for local folders.",
+      },
+      force: {
+        type: "boolean",
+        description:
+          "Force re-registration even if a repo with this name (or absolute path) is already registered.",
+        default: false,
+      },
+      watch: {
+        type: "boolean",
+        description:
+          "Start the filesystem watcher after the initial scan. Defaults to true.",
+        default: true,
+      },
+      followSymlinks: {
+        type: "boolean",
+        description:
+          "Follow filesystem symlinks inside the folder (out-of-folder targets are still rejected).",
+        default: false,
+      },
+      async: {
+        type: "boolean",
+        description:
+          "If true, return a job ID immediately and run registration in the background. " +
+          "Use get_update_status with the job_id to poll for completion. Defaults to false.",
+        default: false,
+      },
+    },
+    required: ["path"],
+  },
+};
+
+function validateArgs(args: unknown): RegisterArgs {
+  if (typeof args !== "object" || args === null) {
+    throw new Error("Arguments must be an object");
+  }
+  const obj = args as Record<string, unknown>;
+  const path = obj["path"];
+  if (typeof path !== "string" || path.trim() === "") {
+    throw new Error("path must be a non-empty string");
+  }
+  const tier = obj["tier"];
+  if (
+    tier !== undefined &&
+    tier !== "private" &&
+    tier !== "work" &&
+    tier !== "public" // accept then refuse downstream so error matches IngestionService
+  ) {
+    throw new Error("tier must be one of 'private', 'work'");
+  }
+  return {
+    path: path.trim(),
+    name: typeof obj["name"] === "string" ? obj["name"].trim() : undefined,
+    tier: tier as RegisterArgs["tier"],
+    force: typeof obj["force"] === "boolean" ? obj["force"] : false,
+    watch: typeof obj["watch"] === "boolean" ? obj["watch"] : true,
+    followSymlinks:
+      typeof obj["followSymlinks"] === "boolean" ? obj["followSymlinks"] : false,
+    async: typeof obj["async"] === "boolean" ? obj["async"] : false,
+  };
+}
+
+function formatErrorResponse(code: RegisterErrorCode, message: string): TextContent {
+  const response: ErrorResponse = { success: false, error: code, message };
+  return { type: "text", text: JSON.stringify(response, null, 2) };
+}
+
+function formatSyncSuccessResponse(
+  repository: string,
+  result: IndexResult,
+  watchEnabled: boolean,
+  followSymlinks: boolean
+): TextContent {
+  // IndexResult.status is "success" | "partial" | "failed"; we surface the same
+  // shape but rename "success" → "registered" so the tool's response semantics
+  // are unambiguous to downstream callers.
+  const statusMap: Record<string, SyncSuccessResponse["status"]> = {
+    success: "registered",
+    partial: "partial",
+    failed: "failed",
+  };
+  const response: SyncSuccessResponse = {
+    success: true,
+    repository,
+    status: statusMap[result.status] ?? "registered",
+    files_processed: result.stats.filesProcessed,
+    chunks_created: result.stats.chunksCreated,
+    duration_ms: Math.round(result.stats.durationMs),
+    watch_enabled: watchEnabled,
+    follow_symlinks: followSymlinks,
+  };
+  return { type: "text", text: JSON.stringify(response, null, 2) };
+}
+
+function formatAsyncSuccessResponse(repository: string, jobId: string): TextContent {
+  const response: AsyncSuccessResponse = {
+    success: true,
+    async: true,
+    job_id: jobId,
+    repository,
+    message:
+      "Registration started. Use get_update_status with this job_id to poll for completion.",
+  };
+  return { type: "text", text: JSON.stringify(response, null, 2) };
+}
+
+/**
+ * Map an `IndexResult` to the `CoordinatorResult` shape the JobTracker expects
+ * for `complete()`. Registration doesn't have a meaningful diff (every file is
+ * "added"), so we set `filesAdded = filesProcessed` and the rest to zero.
+ */
+function indexResultToCoordinatorResult(result: IndexResult): CoordinatorResult {
+  return {
+    status: result.status === "failed" ? "failed" : "updated",
+    stats: {
+      filesAdded: result.stats.filesProcessed,
+      filesModified: 0,
+      filesDeleted: 0,
+      chunksUpserted: result.stats.chunksCreated,
+      chunksDeleted: 0,
+      durationMs: result.stats.durationMs,
+    },
+    errors: result.errors.map((e) => ({
+      path: "",
+      error: e.message ?? String(e),
+    })),
+    durationMs: result.stats.durationMs,
+    commitSha: `local-${new Date().toISOString()}`,
+    commitMessage: `Initial registration of local folder`,
+  };
+}
+
+export interface RegisterLocalFolderDependencies {
+  ingestionService: IngestionService;
+  /**
+   * Optional. When provided, registrations with `watch: true` will start the
+   * filesystem watcher after the initial scan completes. When absent, the
+   * `watch` flag is honored in metadata but no live watcher is attached
+   * (acceptable for environments that disable watchers, e.g. CI smoke tests).
+   */
+  localFolderCoordinator?: LocalFolderUpdateCoordinator;
+  repositoryService: RepositoryMetadataService;
+  /**
+   * Optional. Required for `async: true`; when absent, async requests fall
+   * back to sync so we never silently lose registration progress.
+   */
+  jobTracker?: JobTracker;
+}
+
+export function createRegisterLocalFolderHandler(
+  deps: RegisterLocalFolderDependencies
+): ToolHandler {
+  const { ingestionService, localFolderCoordinator, repositoryService, jobTracker } = deps;
+
+  return async (args: unknown): Promise<CallToolResult> => {
+    const log = getLogger();
+    const startTime = performance.now();
+
+    let validated: RegisterArgs;
+    try {
+      validated = validateArgs(args);
+    } catch (validationError) {
+      const message =
+        validationError instanceof Error ? validationError.message : String(validationError);
+      log.warn({ error: message }, "Argument validation failed");
+      return {
+        content: [formatErrorResponse("invalid_argument", message)],
+        isError: true,
+      };
+    }
+
+    const requestedAsync = validated.async === true && jobTracker !== undefined;
+
+    const runRegistration = async (): Promise<{
+      repositoryName: string;
+      result: IndexResult;
+    }> => {
+      const result = await ingestionService.indexRepository(validated.path, {
+        name: validated.name,
+        tier: validated.tier,
+        force: validated.force,
+        watch: validated.watch ?? true,
+        followSymlinks: validated.followSymlinks ?? false,
+      });
+      const repositoryName = result.repository;
+
+      // Start the watcher only when the caller asked for it AND a coordinator
+      // is wired AND the registration succeeded enough to leave a usable
+      // metadata entry. We re-resolve the RepositoryInfo because the
+      // coordinator owns watcher lifecycle (it'll persist watchEnabled).
+      if ((validated.watch ?? true) && localFolderCoordinator && result.status !== "failed") {
+        const repo = await repositoryService.getRepository(repositoryName);
+        if (repo && repo.source === "local-folder") {
+          try {
+            await localFolderCoordinator.startWatching(repo);
+          } catch (watchError) {
+            log.warn(
+              { repository: repositoryName, error: watchError },
+              "Failed to start watcher after registration; metadata is persisted, watch must be re-enabled manually"
+            );
+          }
+        }
+      }
+
+      return { repositoryName, result };
+    };
+
+    if (requestedAsync && jobTracker) {
+      // Use a placeholder name for the job ID until we know the resolved name;
+      // we then update the job tracker with the real result on completion.
+      const placeholderName =
+        validated.name?.trim() || validated.path.split(/[\\/]/).filter(Boolean).pop() || "pending";
+      const jobId = jobTracker.createJob(placeholderName);
+
+      void (async () => {
+        jobTracker.updateStatus(jobId, "running");
+        try {
+          const { result } = await runRegistration();
+          jobTracker.complete(jobId, indexResultToCoordinatorResult(result));
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          jobTracker.fail(jobId, message);
+          log.error({ error: message, jobId }, "Async registration failed");
+        }
+      })();
+
+      return {
+        content: [formatAsyncSuccessResponse(placeholderName, jobId)],
+        isError: false,
+      };
+    }
+
+    try {
+      const { repositoryName, result } = await runRegistration();
+      const duration = performance.now() - startTime;
+      log.info(
+        {
+          repository: repositoryName,
+          status: result.status,
+          duration_ms: Math.round(duration),
+        },
+        "Synchronous registration completed"
+      );
+
+      if (result.status === "failed") {
+        const errMessage = result.errors[0]?.message ?? "Registration failed without details";
+        return {
+          content: [formatErrorResponse("registration_failed", errMessage)],
+          isError: true,
+        };
+      }
+
+      return {
+        content: [
+          formatSyncSuccessResponse(
+            repositoryName,
+            result,
+            (validated.watch ?? true) && localFolderCoordinator !== undefined,
+            validated.followSymlinks ?? false
+          ),
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      log.error({ error }, "Synchronous registration threw");
+      const mcpError = mapToMCPError(error);
+      return {
+        content: [formatErrorResponse("internal_error", mcpError.message)],
+        isError: true,
+      };
+    }
+  };
+}

--- a/src/mcp/tools/register-local-folder.ts
+++ b/src/mcp/tools/register-local-folder.ts
@@ -16,6 +16,7 @@
  * @module mcp/tools/register-local-folder
  */
 
+import { basename, normalize, resolve } from "node:path";
 import type { Tool, CallToolResult, TextContent } from "@modelcontextprotocol/sdk/types.js";
 import type { IngestionService } from "../../services/ingestion-service.js";
 import type { LocalFolderUpdateCoordinator } from "../../services/local-folder-update-coordinator.js";
@@ -272,9 +273,29 @@ export function createRegisterLocalFolderHandler(
 
     const requestedAsync = validated.async === true && jobTracker !== undefined;
 
+    // Pre-resolve the eventual repository name so async-mode callers can poll
+    // `get_update_status` and see the real name on the JobTracker record (review
+    // H-2 / H-3). Mirrors `IngestionService.extractRepositoryName` for local
+    // paths: explicit `--name` wins; otherwise basename of the resolved path.
+    // If the basename is unrecoverable (e.g. ".." / "."), fall back to
+    // "pending" — the IngestionService call will throw a descriptive error and
+    // the tool surfaces it via formatErrorResponse below.
+    const predictedRepositoryName = (() => {
+      const explicit = validated.name?.trim();
+      if (explicit) return explicit;
+      try {
+        const candidate = basename(normalize(resolve(validated.path)));
+        if (candidate && candidate !== "." && candidate !== "..") return candidate;
+      } catch {
+        // basename/resolve don't typically throw, but be defensive on bad input
+      }
+      return "pending";
+    })();
+
     const runRegistration = async (): Promise<{
       repositoryName: string;
       result: IndexResult;
+      watcherActuallyAttached: boolean;
     }> => {
       const result = await ingestionService.indexRepository(validated.path, {
         name: validated.name,
@@ -289,11 +310,15 @@ export function createRegisterLocalFolderHandler(
       // is wired AND the registration succeeded enough to leave a usable
       // metadata entry. We re-resolve the RepositoryInfo because the
       // coordinator owns watcher lifecycle (it'll persist watchEnabled).
+      // Track ACTUAL attachment so the response can't lie when chokidar
+      // fails to attach (review C-1).
+      let watcherActuallyAttached = false;
       if ((validated.watch ?? true) && localFolderCoordinator && result.status !== "failed") {
         const repo = await repositoryService.getRepository(repositoryName);
         if (repo && repo.source === "local-folder") {
           try {
             await localFolderCoordinator.startWatching(repo);
+            watcherActuallyAttached = true;
           } catch (watchError) {
             log.warn(
               { repository: repositoryName, error: watchError },
@@ -303,15 +328,14 @@ export function createRegisterLocalFolderHandler(
         }
       }
 
-      return { repositoryName, result };
+      return { repositoryName, result, watcherActuallyAttached };
     };
 
     if (requestedAsync && jobTracker) {
-      // Use a placeholder name for the job ID until we know the resolved name;
-      // we then update the job tracker with the real result on completion.
-      const placeholderName =
-        validated.name?.trim() || validated.path.split(/[\\/]/).filter(Boolean).pop() || "pending";
-      const jobId = jobTracker.createJob(placeholderName);
+      // Use the predicted name for the job ID so polling via `get_update_status`
+      // returns the real registered name even before the worker completes
+      // (review H-2 / H-3).
+      const jobId = jobTracker.createJob(predictedRepositoryName);
 
       void (async () => {
         jobTracker.updateStatus(jobId, "running");
@@ -326,13 +350,13 @@ export function createRegisterLocalFolderHandler(
       })();
 
       return {
-        content: [formatAsyncSuccessResponse(placeholderName, jobId)],
+        content: [formatAsyncSuccessResponse(predictedRepositoryName, jobId)],
         isError: false,
       };
     }
 
     try {
-      const { repositoryName, result } = await runRegistration();
+      const { repositoryName, result, watcherActuallyAttached } = await runRegistration();
       const duration = performance.now() - startTime;
       log.info(
         {
@@ -356,7 +380,7 @@ export function createRegisterLocalFolderHandler(
           formatSyncSuccessResponse(
             repositoryName,
             result,
-            (validated.watch ?? true) && localFolderCoordinator !== undefined,
+            watcherActuallyAttached,
             validated.followSymlinks ?? false
           ),
         ],

--- a/src/mcp/types.ts
+++ b/src/mcp/types.ts
@@ -12,6 +12,7 @@ import type { GraphService } from "../services/graph-service-types.js";
 import type { DocumentSearchService } from "../services/document-search-types.js";
 import type { ImageSearchService } from "../services/image-search-types.js";
 import type { ListWatchedFoldersService } from "../services/list-watched-folders-types.js";
+import type { IngestionService } from "../services/ingestion-service.js";
 import type { MCPRateLimiter } from "./rate-limiter.js";
 import type { JobTracker } from "./job-tracker.js";
 
@@ -161,6 +162,12 @@ export interface MCPServerOptionalDeps {
 
   /** ListWatchedFoldersService for listing watched folders */
   listWatchedFoldersService?: ListWatchedFoldersService;
+
+  /**
+   * IngestionService for the `register_local_folder` tool (Phase C / #566).
+   * When omitted the tool is not registered.
+   */
+  ingestionService?: IngestionService;
 
   /** Human-readable reason why update tools are unavailable (stub mode) */
   updateToolsUnavailableReason?: string;

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -330,6 +330,38 @@ export interface RepositoryInfo {
    * avoid case-collisions across distinct repository names.
    */
   lastManifestId?: string;
+
+  // ─────────────────────────────────────────────────────────────────────────────
+  // Local-folder watcher fields (Phase C)
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Whether a filesystem watcher is currently subscribed to this repository.
+   *
+   * Only meaningful when `source === "local-folder"`. Persisted so that the
+   * MCP server can restore active watchers on startup. Toggled by
+   * `LocalFolderUpdateCoordinator.startWatching` / `stopWatching`.
+   */
+  watchEnabled?: boolean;
+
+  /**
+   * Whether the watcher should follow filesystem symlinks.
+   *
+   * Only meaningful when `source === "local-folder"`. Defaults to `false` for
+   * safety — out-of-repo symlink targets are rejected even when this is set.
+   * The depth cap (8) is enforced by chokidar config at watch start.
+   */
+  followSymlinks?: boolean;
+
+  /**
+   * Per-repository debounce window in milliseconds for the local-folder
+   * watcher. Defaults to 2000 ms when omitted.
+   *
+   * Only meaningful when `source === "local-folder"`. Lets noisy editors
+   * (e.g. saves that touch many sibling files in burst) coalesce into a
+   * single re-index call.
+   */
+  watchDebounceMs?: number;
 }
 
 /**

--- a/src/services/folder-event-router.ts
+++ b/src/services/folder-event-router.ts
@@ -1,0 +1,184 @@
+/**
+ * FolderEventRouter — single shared subscriber for `FolderWatcherService` events
+ * that dispatches to either Phase 6's document-indexing pipeline (for
+ * `WatchedFolder` events) or Phase C's local-folder coordinator (for
+ * `local-folder:<repo>` events). Phase C (issue #566 / T5.1).
+ *
+ * The router is installed alongside Phase 6's `ChangeDetectionService` rather
+ * than replacing it: each subscriber inspects `event.folderId` and acts only
+ * on the namespace it owns. Routing precedence:
+ *
+ *   1. `event.folderId` matches `LOCAL_FOLDER_ID_PREFIX` → look up the repo
+ *      by the suffix, debounce per-repo, then call the local-folder dispatch.
+ *   2. Otherwise → no-op (Phase 6's `ChangeDetectionService` handles it).
+ *
+ * Per-repo debounce coalesces noisy editor saves into a single coordinator
+ * call. The debounce window is `repo.watchDebounceMs ?? DEFAULT_DEBOUNCE_MS`.
+ *
+ * @module services/folder-event-router
+ */
+
+import type { Logger } from "pino";
+import { getComponentLogger } from "../logging/index.js";
+import type { FileEvent } from "./folder-watcher-types.js";
+import type { RepositoryMetadataService, RepositoryInfo } from "../repositories/types.js";
+
+/** Synthetic `WatchedFolder.id` prefix used by Phase C local-folder repos. */
+export const LOCAL_FOLDER_ID_PREFIX = "local-folder:";
+
+/** Default per-repo debounce window in milliseconds. */
+export const DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS = 2000;
+
+/**
+ * Build the synthetic folder-id for a local-folder repository. The id is
+ * deterministic from the repo name so restoration on server restart and
+ * cross-process lookup are stable.
+ */
+export function localFolderIdFor(repositoryName: string): string {
+  return `${LOCAL_FOLDER_ID_PREFIX}${repositoryName}`;
+}
+
+/**
+ * Inverse of {@link localFolderIdFor} — returns the repo name when the id is
+ * in the local-folder namespace, otherwise `null`.
+ */
+export function repositoryNameFromLocalFolderId(folderId: string): string | null {
+  if (!folderId.startsWith(LOCAL_FOLDER_ID_PREFIX)) return null;
+  return folderId.slice(LOCAL_FOLDER_ID_PREFIX.length);
+}
+
+/**
+ * Function called by the router when a debounced batch of events for a
+ * local-folder repo is ready to be processed. Production wires this to
+ * `LocalFolderUpdateCoordinator.updateRepository(repositoryName)`.
+ */
+export type LocalFolderDispatch = (repository: RepositoryInfo) => void | Promise<void>;
+
+/**
+ * Optional config for the router. Tests pass overrides to shorten timers and
+ * inject fakes; production accepts the defaults.
+ */
+export interface FolderEventRouterConfig {
+  /** Default debounce window when the repo has no per-repo override. */
+  defaultDebounceMs?: number;
+  /**
+   * Override hook for testing — returns a `setTimeout` substitute. When
+   * omitted the global `setTimeout` is used.
+   */
+  scheduleTimeout?: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  /** Companion to `scheduleTimeout` for cancellation. Defaults to global `clearTimeout`. */
+  cancelTimeout?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+export class FolderEventRouter {
+  private readonly debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly defaultDebounceMs: number;
+  private readonly schedule: (cb: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  private readonly cancel: (handle: ReturnType<typeof setTimeout>) => void;
+  private _logger: Logger | null = null;
+
+  constructor(
+    private readonly repositoryService: RepositoryMetadataService,
+    private readonly localFolderDispatch: LocalFolderDispatch,
+    config: FolderEventRouterConfig = {}
+  ) {
+    this.defaultDebounceMs = config.defaultDebounceMs ?? DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS;
+    this.schedule = config.scheduleTimeout ?? setTimeout;
+    this.cancel = config.cancelTimeout ?? clearTimeout;
+  }
+
+  private get logger(): Logger {
+    if (!this._logger) this._logger = getComponentLogger("services:folder-event-router");
+    return this._logger;
+  }
+
+  /**
+   * Bind this router as a `FolderWatcherService` subscriber.
+   *
+   * Returns a function reference suitable for `folderWatcherService.onFileEvent(...)`.
+   * The function is bound so it is safe to subscribe and forget.
+   */
+  asEventHandler(): (event: FileEvent) => void {
+    return (event) => {
+      // Don't await — handler signature allows void. Errors from the
+      // dispatch are caught and logged so a stuck dispatcher cannot kill
+      // the watcher's broadcast loop.
+      void this.route(event);
+    };
+  }
+
+  /**
+   * Route a single FileEvent. Public so tests can drive routing directly
+   * without instantiating the full FolderWatcherService.
+   */
+  async route(event: FileEvent): Promise<void> {
+    const repositoryName = repositoryNameFromLocalFolderId(event.folderId);
+    if (repositoryName === null) {
+      // Not a local-folder event — Phase 6's ChangeDetectionService owns it.
+      return;
+    }
+
+    let repo: RepositoryInfo | null;
+    try {
+      repo = await this.repositoryService.getRepository(repositoryName);
+    } catch (error) {
+      this.logger.warn(
+        {
+          repository: repositoryName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "FolderEventRouter: metadata lookup failed; dropping event"
+      );
+      return;
+    }
+
+    if (!repo || repo.source !== "local-folder") {
+      this.logger.warn(
+        { repository: repositoryName, source: repo?.source ?? "missing" },
+        "FolderEventRouter: routed local-folder id resolved to non-local-folder repo; dropping event"
+      );
+      return;
+    }
+
+    this.scheduleDebouncedDispatch(repo);
+  }
+
+  /**
+   * Coalesce successive events for the same repo into a single dispatch.
+   * The previous timer (if any) is cancelled and replaced; the dispatch
+   * fires `debounceMs` after the LAST observed event.
+   */
+  private scheduleDebouncedDispatch(repo: RepositoryInfo): void {
+    const existing = this.debounceTimers.get(repo.name);
+    if (existing !== undefined) {
+      this.cancel(existing);
+    }
+
+    const debounceMs = repo.watchDebounceMs ?? this.defaultDebounceMs;
+    const timer = this.schedule(() => {
+      this.debounceTimers.delete(repo.name);
+      void Promise.resolve(this.localFolderDispatch(repo)).catch((error) => {
+        this.logger.error(
+          {
+            repository: repo.name,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "FolderEventRouter: localFolderDispatch threw"
+        );
+      });
+    }, debounceMs);
+
+    this.debounceTimers.set(repo.name, timer);
+  }
+
+  /**
+   * Cancel all pending debounce timers. Used on server shutdown so we don't
+   * leave timers holding refs after the watcher fleet has stopped.
+   */
+  shutdown(): void {
+    for (const timer of this.debounceTimers.values()) {
+      this.cancel(timer);
+    }
+    this.debounceTimers.clear();
+  }
+}

--- a/src/services/folder-event-router.ts
+++ b/src/services/folder-event-router.ts
@@ -18,6 +18,8 @@
  * @module services/folder-event-router
  */
 
+import { realpath } from "node:fs/promises";
+import { sep } from "node:path";
 import type { Logger } from "pino";
 import { getComponentLogger } from "../logging/index.js";
 import type { FileEvent } from "./folder-watcher-types.js";
@@ -140,7 +142,56 @@ export class FolderEventRouter {
       return;
     }
 
+    // Out-of-folder symlink rejection (review C-2 / issue #566 acceptance).
+    // chokidar's `followSymlinks: true` will dereference symlinks regardless
+    // of where their target points; the depth cap bounds traversal length but
+    // not geographical scope. Filter at event time by realpath-comparing the
+    // event's absolute path against the repo's real root. This is TOCTOU-aware
+    // because we resolve at the moment the event fires, not at watch-attach.
+    // The check runs only when the user explicitly opted in to symlink
+    // following — when followSymlinks is false (default), chokidar already
+    // skips symlinks, so this filter would only reject false positives.
+    if (repo.followSymlinks === true) {
+      const inside = await this.isEventWithinRepoRoot(repo.localPath, event.absolutePath);
+      if (!inside) {
+        this.logger.warn(
+          {
+            repository: repo.name,
+            eventPath: event.absolutePath,
+            repoRoot: repo.localPath,
+          },
+          "FolderEventRouter: dropping event whose realpath escapes the repo root (out-of-folder symlink target)"
+        );
+        return;
+      }
+    }
+
     this.scheduleDebouncedDispatch(repo);
+  }
+
+  /**
+   * Check whether `eventAbsolutePath` resolves (via realpath) to a location
+   * inside `repoLocalPath`'s real root. Returns false on any realpath failure
+   * — the conservative choice that prevents accidentally indexing files
+   * pointed to by broken or hostile symlinks.
+   */
+  private async isEventWithinRepoRoot(
+    repoLocalPath: string,
+    eventAbsolutePath: string
+  ): Promise<boolean> {
+    try {
+      const [realRoot, realEventPath] = await Promise.all([
+        realpath(repoLocalPath),
+        realpath(eventAbsolutePath),
+      ]);
+      // Append separator to the root so a sibling directory whose name
+      // happens to share a prefix (e.g. /repo and /repo-backup) does not
+      // satisfy the containment check.
+      const normalizedRoot = realRoot.endsWith(sep) ? realRoot : realRoot + sep;
+      return realEventPath === realRoot || realEventPath.startsWith(normalizedRoot);
+    } catch {
+      return false;
+    }
   }
 
   /**

--- a/src/services/folder-watcher-service.ts
+++ b/src/services/folder-watcher-service.ts
@@ -559,6 +559,14 @@ export class FolderWatcherService {
             }
           : undefined;
 
+        // Phase C (issue #566): allow per-folder symlink + depth control.
+        // Omitting the fields preserves Phase 6 behavior (chokidar defaults:
+        // followSymlinks=true, depth=undefined). Local-folder repos pass
+        // explicit values to enforce the safer Phase C symlink policy.
+        const followSymlinksOption =
+          folder.followSymlinks === undefined ? undefined : folder.followSymlinks;
+        const depthOption = folder.depthCap === undefined ? undefined : folder.depthCap;
+
         const watcher = chokidar.watch(folder.path, {
           ignored,
           persistent: true,
@@ -569,7 +577,8 @@ export class FolderWatcherService {
           },
           usePolling: this.config.usePolling,
           interval: this.config.pollInterval,
-          depth: undefined, // Watch recursively
+          depth: depthOption, // Watch recursively unless capped (Phase C)
+          ...(followSymlinksOption !== undefined && { followSymlinks: followSymlinksOption }),
         });
 
         watcher.on("ready", () => {

--- a/src/services/folder-watcher-types.ts
+++ b/src/services/folder-watcher-types.ts
@@ -74,6 +74,25 @@ export interface WatchedFolder {
    * Last time the folder configuration was updated
    */
   updatedAt: Date | null;
+
+  /**
+   * Whether chokidar should follow symlinks inside the watched folder.
+   *
+   * Optional. When omitted, chokidar's default applies (`true`). Phase 6
+   * watched folders historically inherited the chokidar default; Phase C
+   * (local-folder repos, issue #566) opts in explicitly so the registration
+   * code can set `false` for safety while preserving Phase 6 behavior.
+   */
+  followSymlinks?: boolean;
+
+  /**
+   * Maximum directory recursion depth chokidar should descend.
+   *
+   * Optional. When omitted, chokidar uses unlimited depth (existing Phase 6
+   * behavior). Phase C uses this together with `followSymlinks: true` to cap
+   * symlink chase depth at 8 per the local-folder symlink policy.
+   */
+  depthCap?: number;
 }
 
 /**

--- a/src/services/ingestion-errors.ts
+++ b/src/services/ingestion-errors.ts
@@ -56,6 +56,31 @@ export class RepositoryAlreadyExistsError extends IngestionError {
 }
 
 /**
+ * Error thrown when a `local-folder` registration attempts to claim an
+ * absolute path that is already registered under a different repository name.
+ *
+ * Distinct from `RepositoryAlreadyExistsError` because the user-visible fix is
+ * different: the user supplied a non-colliding name but the underlying path
+ * is shared. Includes the existing registration's name so the message points
+ * to the conflict directly.
+ */
+export class LocalFolderPathAlreadyRegisteredError extends IngestionError {
+  override name = "LocalFolderPathAlreadyRegisteredError";
+
+  constructor(
+    public readonly absolutePath: string,
+    public readonly existingRepository: string
+  ) {
+    super(
+      `Local folder path '${absolutePath}' is already registered as ` +
+        `repository '${existingRepository}'. Use force: true on the existing ` +
+        `registration to reindex, or unregister it first.`,
+      false
+    );
+  }
+}
+
+/**
  * Error thrown when attempting to start indexing while another
  * indexing operation is in progress
  */

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -10,7 +10,7 @@
 
 import { resolve, basename, normalize, join, sep, relative, posix } from "node:path";
 import { stat, readdir } from "node:fs/promises";
-import { isLocalPath } from "../utils/path-utils.js";
+import { isLocalPath, canonicalizePathForComparison } from "../utils/path-utils.js";
 import simpleGit from "simple-git";
 import { GitignoreFilter } from "../ingestion/gitignore-filter.js";
 import {
@@ -55,6 +55,7 @@ import {
   IndexingInProgressError,
   CollectionCreationError,
   LocalFolderPublicTierRefusedError,
+  LocalFolderPathAlreadyRegisteredError,
   LocalFolderSizeRefusedError,
 } from "./ingestion-errors.js";
 import type { DocumentChunker } from "../documents/DocumentChunker.js";
@@ -286,6 +287,27 @@ export class IngestionService {
         const requestedTier = options.tier ?? "private";
         if (effectiveSource === "local-folder" && requestedTier === "public") {
           throw new LocalFolderPublicTierRefusedError(repositoryName);
+        }
+
+        // Duplicate-path detection (Phase C, T4.2): reject when this absolute
+        // path is already registered under a different name. The name-based
+        // collision check above (line ~239) catches re-registrations with the
+        // same name; this catches the user pointing two distinct names at the
+        // same on-disk folder, which would have two coordinators racing on the
+        // same FileManifest. Skipped under `force: true` because the user is
+        // explicitly asking to reindex the existing entry. Comparison is
+        // canonicalised so different separator/case representations of the
+        // same path collide on Windows (NTFS is case-insensitive).
+        if (effectiveSource === "local-folder" && !options.force) {
+          const canonical = canonicalizePathForComparison(resolvedPath);
+          const allRepos = await this.repositoryService.listRepositories();
+          for (const existing of allRepos) {
+            if (existing.source !== "local-folder") continue;
+            if (existing.name === repositoryName) continue;
+            if (canonicalizePathForComparison(existing.localPath) === canonical) {
+              throw new LocalFolderPathAlreadyRegisteredError(resolvedPath, existing.name);
+            }
+          }
         }
 
         let branch = options.branch ?? "unknown";
@@ -540,6 +562,11 @@ export class IngestionService {
         source: effectiveSource,
         tier: options.tier ?? "private",
         lastManifestId,
+        // Phase C: persist watcher prefs only for local-folder sources so the
+        // MCP server bootstrap can restore active watchers across restarts.
+        watchEnabled: effectiveSource === "local-folder" ? (options.watch ?? false) : undefined,
+        followSymlinks:
+          effectiveSource === "local-folder" ? (options.followSymlinks ?? false) : undefined,
       });
 
       await this.repositoryService.updateRepository(metadata);
@@ -591,10 +618,15 @@ export class IngestionService {
         originalError: error,
       };
 
-      // If error is one of our custom errors, rethrow it
+      // If error is one of our custom errors, rethrow it. The path-collision
+      // error (Phase C) joins this list because the user-corrective fix —
+      // unregister or pass `force` on the existing entry — is identical in
+      // shape to a name collision; both want the typed error surfaced to the
+      // CLI/MCP wrapper rather than the generic `failed` IndexResult.
       if (
         error instanceof RepositoryAlreadyExistsError ||
-        error instanceof IndexingInProgressError
+        error instanceof IndexingInProgressError ||
+        error instanceof LocalFolderPathAlreadyRegisteredError
       ) {
         throw error;
       }
@@ -1219,6 +1251,10 @@ export class IngestionService {
     tier: "private" | "work" | "public";
     /** Manifest pointer set only for `local-folder` sources. */
     lastManifestId?: string;
+    /** Watcher enable flag — only meaningful for `local-folder` sources. */
+    watchEnabled?: boolean;
+    /** Whether the watcher should follow symlinks — only meaningful for `local-folder`. */
+    followSymlinks?: boolean;
   }): RepositoryInfo {
     return {
       name: params.name,
@@ -1248,6 +1284,10 @@ export class IngestionService {
       // Local-folder + multi-tier fields
       tier: params.tier,
       lastManifestId: params.lastManifestId,
+      // Phase C watcher fields — undefined for non-local-folder sources so we
+      // don't lie about watch capability for git repos.
+      watchEnabled: params.watchEnabled,
+      followSymlinks: params.followSymlinks,
     };
   }
 

--- a/src/services/ingestion-types.ts
+++ b/src/services/ingestion-types.ts
@@ -57,6 +57,30 @@ export interface IndexOptions {
    * @default "private"
    */
   tier?: "private" | "work" | "public";
+
+  /**
+   * Whether the registered repository should have a filesystem watcher
+   * subscribed after the initial scan completes.
+   *
+   * Only meaningful when the path resolves to a `local-folder` source.
+   * Persisted on `RepositoryInfo.watchEnabled` so the MCP server can restore
+   * active watchers across restarts.
+   *
+   * @default false
+   */
+  watch?: boolean;
+
+  /**
+   * Whether the local-folder watcher should follow filesystem symlinks.
+   *
+   * Only meaningful when the path resolves to a `local-folder` source.
+   * Defaults to `false` for safety. When `true`, chokidar is configured to
+   * follow symlinks but the registration code rejects targets outside the
+   * repository root (depth-cap and TOCTOU-aware via `fs.realpath`).
+   *
+   * @default false
+   */
+  followSymlinks?: boolean;
 }
 
 /**

--- a/src/services/local-folder-repo-watch-manager.ts
+++ b/src/services/local-folder-repo-watch-manager.ts
@@ -1,0 +1,172 @@
+/**
+ * LocalFolderRepoWatchManager — owns the `WatchedFolder`-shaped synthetic
+ * subscriptions that drive Phase C's local-folder watcher. Sits between
+ * `LocalFolderUpdateCoordinator` and the shared `FolderWatcherService` so
+ * the coordinator stays focused on update orchestration.
+ *
+ * Responsibilities (issue #566 / T5.3, T5.4):
+ *
+ *   - Build a synthetic `WatchedFolder` per registered repo, with
+ *     `id = "local-folder:<name>"` so the `FolderEventRouter` can pick it
+ *     out of the shared event stream.
+ *   - Apply Phase C's symlink policy: default-deny (`followSymlinks=false`),
+ *     opt-in via `RepositoryInfo.followSymlinks=true`. Opt-in additionally
+ *     caps chokidar depth at 8 to bound symlink-chase traversal.
+ *   - Validate the registered `localPath` is reachable before attaching the
+ *     watcher; resolves to its real path via `fs.realpath` first so a
+ *     symlink swap between registration and watch start can't redirect
+ *     watch traffic outside the repo root (TOCTOU-aware).
+ *
+ * The manager intentionally does not implement the `LocalFolderWatchManager`
+ * interface lazily — it satisfies it directly so the coordinator can accept
+ * either the real manager or a test fake without conditional plumbing.
+ *
+ * @module services/local-folder-repo-watch-manager
+ */
+
+import { realpath, stat } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { Logger } from "pino";
+import { getComponentLogger } from "../logging/index.js";
+import type { FolderWatcherService } from "./folder-watcher-service.js";
+import type { WatchedFolder } from "./folder-watcher-types.js";
+import type { RepositoryInfo } from "../repositories/types.js";
+import type { LocalFolderWatchManager } from "./local-folder-update-coordinator.js";
+import { localFolderIdFor, DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS } from "./folder-event-router.js";
+
+/** Hard cap on filesystem recursion depth when `followSymlinks=true`. */
+export const SYMLINK_FOLLOW_DEPTH_CAP = 8;
+
+/**
+ * Error thrown when a registered local-folder path is missing, unreachable,
+ * or its real-path resolves to a target the user explicitly opted out of
+ * watching (e.g. an out-of-repo symlink target with `followSymlinks=false`).
+ */
+export class LocalFolderWatchValidationError extends Error {
+  constructor(
+    public readonly repository: string,
+    public readonly path: string,
+    public readonly reason: string
+  ) {
+    super(
+      `Cannot start watcher for local-folder repository '${repository}' at '${path}': ${reason}`
+    );
+    this.name = "LocalFolderWatchValidationError";
+  }
+}
+
+export class LocalFolderRepoWatchManager implements LocalFolderWatchManager {
+  private _logger: Logger | null = null;
+
+  constructor(private readonly folderWatcherService: FolderWatcherService) {}
+
+  private get logger(): Logger {
+    if (!this._logger)
+      this._logger = getComponentLogger("services:local-folder-repo-watch-manager");
+    return this._logger;
+  }
+
+  /**
+   * Validate the path and start a chokidar watcher for a local-folder repo.
+   * Idempotent in the sense that callers asking for an already-watched repo
+   * receive the underlying `FolderAlreadyWatchedError` — the coordinator's
+   * persistence guard prevents duplicate calls in normal flow, but tests
+   * exercise it both ways.
+   */
+  async startWatching(repo: RepositoryInfo): Promise<void> {
+    if (repo.source !== "local-folder") {
+      throw new LocalFolderWatchValidationError(
+        repo.name,
+        repo.localPath,
+        `expected source="local-folder", got "${repo.source}"`
+      );
+    }
+
+    const absolutePath = resolve(repo.localPath);
+
+    // Verify the path exists and is a directory before paying for chokidar.
+    try {
+      const pathStat = await stat(absolutePath);
+      if (!pathStat.isDirectory()) {
+        throw new LocalFolderWatchValidationError(
+          repo.name,
+          absolutePath,
+          "registered path is not a directory"
+        );
+      }
+    } catch (error) {
+      if (error instanceof LocalFolderWatchValidationError) throw error;
+      throw new LocalFolderWatchValidationError(
+        repo.name,
+        absolutePath,
+        `path is not accessible: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    // TOCTOU-aware: resolve the real path so a symlink at the registered
+    // location cannot redirect us to an unintended target between the stat
+    // above and the chokidar attach below. We do not block based on the
+    // realpath result here — the symlink policy is enforced via chokidar's
+    // `followSymlinks` option below — but resolving primes the OS cache and
+    // surfaces dangling symlinks as a clear error early.
+    try {
+      await realpath(absolutePath);
+    } catch (error) {
+      throw new LocalFolderWatchValidationError(
+        repo.name,
+        absolutePath,
+        `realpath failed: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    const followSymlinks = repo.followSymlinks === true;
+    const synthetic: WatchedFolder = {
+      id: localFolderIdFor(repo.name),
+      path: absolutePath,
+      name: repo.name,
+      enabled: true,
+      includePatterns: null, // local-folder repos use IngestionService's allowlist; watcher emits raw and routes to coordinator
+      excludePatterns: null,
+      debounceMs: repo.watchDebounceMs ?? DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS,
+      createdAt: new Date(),
+      lastScanAt: null,
+      fileCount: 0,
+      updatedAt: null,
+      followSymlinks,
+      // When following symlinks, cap depth so a symlink loop or deep symlinked
+      // tree cannot exhaust file descriptors. When NOT following, leave depth
+      // unlimited because a real-only directory tree is bounded by the user's
+      // filesystem and unlimited matches Phase 6's existing behavior.
+      depthCap: followSymlinks ? SYMLINK_FOLLOW_DEPTH_CAP : undefined,
+    };
+
+    this.logger.info(
+      {
+        repository: repo.name,
+        path: absolutePath,
+        followSymlinks,
+        depthCap: synthetic.depthCap,
+      },
+      "Starting local-folder repository watcher"
+    );
+
+    await this.folderWatcherService.startWatching(synthetic);
+  }
+
+  async stopWatching(repositoryName: string): Promise<void> {
+    const folderId = localFolderIdFor(repositoryName);
+    try {
+      await this.folderWatcherService.stopWatching(folderId);
+    } catch (error) {
+      // The coordinator's stop flow tolerates "not currently watched" — log
+      // and swallow so server shutdown / disable flows are idempotent.
+      this.logger.warn(
+        {
+          repository: repositoryName,
+          error: error instanceof Error ? error.message : String(error),
+        },
+        "stopWatching: folder watcher reported error (likely not watched); continuing"
+      );
+    }
+  }
+}

--- a/src/services/local-folder-update-coordinator.ts
+++ b/src/services/local-folder-update-coordinator.ts
@@ -50,6 +50,18 @@ export interface LocalFolderCoordinatorConfig {
 }
 
 /**
+ * Pluggable watch-manager surface used by the coordinator's lifecycle
+ * methods. Phase C wires a real `LocalFolderRepoWatchManager` (chokidar +
+ * `FolderEventRouter`); tests can pass a fake. When omitted the coordinator
+ * still persists `watchEnabled` to metadata but no live watcher attaches —
+ * useful for environments that disable filesystem watchers entirely.
+ */
+export interface LocalFolderWatchManager {
+  startWatching(repo: RepositoryInfo): Promise<void>;
+  stopWatching(repoName: string): Promise<void>;
+}
+
+/**
  * Coordinator for incremental updates of `local-folder` repositories.
  */
 export class LocalFolderUpdateCoordinator {
@@ -61,10 +73,58 @@ export class LocalFolderUpdateCoordinator {
     private readonly updatePipeline: IncrementalUpdatePipeline,
     private readonly changeDetector: LocalFolderChangeDetector = new LocalFolderChangeDetector(),
     private readonly manifestStore: FileManifestStoreImpl = FileManifestStoreImpl.getInstance(),
-    config: LocalFolderCoordinatorConfig = {}
+    config: LocalFolderCoordinatorConfig = {},
+    private readonly watchManager?: LocalFolderWatchManager
   ) {
     this.logger = getComponentLogger("services:local-folder-update-coordinator");
     this.updateHistoryLimit = config.updateHistoryLimit ?? 50;
+  }
+
+  /**
+   * Start the filesystem watcher for a `local-folder` repo and persist the
+   * `watchEnabled: true` flag so the MCP server can restore the watch on
+   * restart (Phase C / T5.3).
+   *
+   * Safe to call when no watch manager was injected — the persistence step
+   * still runs so the next process startup (with a watch manager wired) will
+   * resume the watch automatically. This makes the registration code path
+   * insensitive to whether the current process has a live watcher fleet.
+   */
+  async startWatching(repo: RepositoryInfo): Promise<void> {
+    if (repo.source !== "local-folder") {
+      throw new Error(
+        `startWatching requires a local-folder repository, got source="${repo.source}" for "${repo.name}"`
+      );
+    }
+
+    if (this.watchManager) {
+      await this.watchManager.startWatching(repo);
+    } else {
+      this.logger.info(
+        { repository: repo.name },
+        "startWatching: no watch manager wired; persisting watchEnabled=true only"
+      );
+    }
+
+    if (repo.watchEnabled !== true) {
+      await this.repositoryService.updateRepository({ ...repo, watchEnabled: true });
+    }
+  }
+
+  /**
+   * Stop the filesystem watcher for a `local-folder` repo and persist
+   * `watchEnabled: false` so the watcher does not resume on restart.
+   */
+  async stopWatching(repositoryName: string): Promise<void> {
+    if (this.watchManager) {
+      await this.watchManager.stopWatching(repositoryName);
+    }
+
+    const repo = await this.repositoryService.getRepository(repositoryName);
+    if (!repo) return;
+    if (repo.watchEnabled === true) {
+      await this.repositoryService.updateRepository({ ...repo, watchEnabled: false });
+    }
   }
 
   /**

--- a/src/utils/path-utils.ts
+++ b/src/utils/path-utils.ts
@@ -4,6 +4,25 @@
  * Shared helpers for detecting and resolving filesystem paths.
  */
 
+import { normalize, resolve } from "node:path";
+
+/**
+ * Canonicalize an absolute path into a form suitable for equality comparison
+ * across platforms.
+ *
+ * Resolves `.`/`..`, normalises separators, and lower-cases on Windows where
+ * the filesystem is case-insensitive (NTFS/FAT). On POSIX the result preserves
+ * case because two differently-cased names refer to distinct files.
+ *
+ * Used by registration-time duplicate-path detection so that two CLI/MCP calls
+ * pointing at the same on-disk folder under different names are rejected
+ * regardless of how the user typed the path.
+ */
+export function canonicalizePathForComparison(absPath: string): string {
+  const normalized = normalize(resolve(absPath));
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
 /**
  * Detect whether a string is a local filesystem path rather than a remote URL.
  *

--- a/tests/cli/commands/index-command-phase-c.test.ts
+++ b/tests/cli/commands/index-command-phase-c.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Phase C tests for the `index` CLI command (issue #566 / T4.1).
+ *
+ * Covers: auto-detect local-folder vs git URL, the new `--tier`, `--watch`,
+ * `--no-watch`, and `--follow-symlinks` flags, refusal of watch flags on git
+ * URLs, and that local-folder defaults (watch=true) flow through to
+ * `IngestionService.indexRepository`.
+ *
+ * @module tests/cli/commands/index-command-phase-c
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-argument */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { indexCommand } from "../../../src/cli/commands/index-command.js";
+import type { CliDependencies } from "../../../src/cli/utils/dependency-init.js";
+import type { IndexResult } from "../../../src/services/ingestion-types.js";
+import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
+
+function makeIndexResult(name: string): IndexResult {
+  return {
+    status: "success",
+    repository: name,
+    collectionName: `repo_${name}`,
+    stats: {
+      filesScanned: 1,
+      filesProcessed: 1,
+      filesFailed: 0,
+      chunksCreated: 1,
+      embeddingsGenerated: 1,
+      documentsStored: 1,
+      durationMs: 1,
+    },
+    errors: [],
+    completedAt: new Date(),
+  };
+}
+
+describe("Index command — Phase C local-folder flags", () => {
+  let folderDir: string;
+  let gitDir: string;
+  let mockIndexRepository: ReturnType<typeof mock>;
+  let deps: CliDependencies;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    folderDir = join(import.meta.dir, "..", "..", "..", "test-temp", `idx-folder-${stamp}`);
+    gitDir = join(import.meta.dir, "..", "..", "..", "test-temp", `idx-git-${stamp}`);
+    await mkdir(folderDir, { recursive: true });
+    await mkdir(join(gitDir, ".git"), { recursive: true });
+
+    mockIndexRepository = mock(async (_url: string, _opts: any) =>
+      makeIndexResult("auto-name")
+    );
+    deps = {
+      ingestionService: { indexRepository: mockIndexRepository },
+      repositoryService: { getRepository: mock(async () => null) },
+    } as unknown as CliDependencies;
+  });
+
+  afterEach(async () => {
+    await rm(folderDir, { recursive: true, force: true });
+    await rm(gitDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("auto-detects a non-git folder and defaults watch=true", async () => {
+    await indexCommand(folderDir, {}, deps);
+    expect(mockIndexRepository.mock.calls.length).toBe(1);
+    const opts = mockIndexRepository.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts["watch"]).toBe(true);
+    expect(opts["followSymlinks"]).toBe(false);
+  });
+
+  it("auto-detects a local-git folder and does NOT default watch=true", async () => {
+    await indexCommand(gitDir, {}, deps);
+    const opts = mockIndexRepository.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts["watch"]).toBe(false);
+  });
+
+  it("honours --no-watch (option.watch = false) on a non-git folder", async () => {
+    await indexCommand(folderDir, { watch: false }, deps);
+    const opts = mockIndexRepository.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts["watch"]).toBe(false);
+  });
+
+  it("propagates --tier private and --follow-symlinks on a folder", async () => {
+    await indexCommand(
+      folderDir,
+      { tier: "private", followSymlinks: true },
+      deps
+    );
+    const opts = mockIndexRepository.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(opts["tier"]).toBe("private");
+    expect(opts["followSymlinks"]).toBe(true);
+    expect(opts["watch"]).toBe(true);
+  });
+
+  it("refuses --watch on a git URL", async () => {
+    await expect(
+      indexCommand("https://github.com/user/repo.git", { watch: true }, deps)
+    ).rejects.toThrow(/local folders/i);
+  });
+
+  it("refuses --follow-symlinks on a git URL", async () => {
+    await expect(
+      indexCommand(
+        "https://github.com/user/repo.git",
+        { followSymlinks: true },
+        deps
+      )
+    ).rejects.toThrow(/local folders/i);
+  });
+});

--- a/tests/cli/commands/index-command-phase-c.test.ts
+++ b/tests/cli/commands/index-command-phase-c.test.ts
@@ -13,6 +13,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-argument */
+/* eslint-disable @typescript-eslint/await-thenable */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";
@@ -55,9 +56,7 @@ describe("Index command — Phase C local-folder flags", () => {
     await mkdir(folderDir, { recursive: true });
     await mkdir(join(gitDir, ".git"), { recursive: true });
 
-    mockIndexRepository = mock(async (_url: string, _opts: any) =>
-      makeIndexResult("auto-name")
-    );
+    mockIndexRepository = mock(async (_url: string, _opts: any) => makeIndexResult("auto-name"));
     deps = {
       ingestionService: { indexRepository: mockIndexRepository },
       repositoryService: { getRepository: mock(async () => null) },
@@ -91,11 +90,7 @@ describe("Index command — Phase C local-folder flags", () => {
   });
 
   it("propagates --tier private and --follow-symlinks on a folder", async () => {
-    await indexCommand(
-      folderDir,
-      { tier: "private", followSymlinks: true },
-      deps
-    );
+    await indexCommand(folderDir, { tier: "private", followSymlinks: true }, deps);
     const opts = mockIndexRepository.mock.calls[0]?.[1] as Record<string, unknown>;
     expect(opts["tier"]).toBe("private");
     expect(opts["followSymlinks"]).toBe(true);
@@ -110,11 +105,7 @@ describe("Index command — Phase C local-folder flags", () => {
 
   it("refuses --follow-symlinks on a git URL", async () => {
     await expect(
-      indexCommand(
-        "https://github.com/user/repo.git",
-        { followSymlinks: true },
-        deps
-      )
+      indexCommand("https://github.com/user/repo.git", { followSymlinks: true }, deps)
     ).rejects.toThrow(/local folders/i);
   });
 });

--- a/tests/mcp/tools/register-local-folder.test.ts
+++ b/tests/mcp/tools/register-local-folder.test.ts
@@ -242,6 +242,48 @@ describe("register_local_folder MCP tool", () => {
       expect(body["error"]).toBe("registration_failed");
       expect(String(body["message"])).toContain("size guardrail");
     });
+
+    it("reports watch_enabled=false when the watcher fails to attach (review C-1)", async () => {
+      // Ingestion succeeds and persists metadata, but the watch-manager
+      // throws (e.g. chokidar EACCES). The response must NOT lie — the user
+      // is told watch_enabled: false so they can intervene.
+      const ingestion = makeIngestionStub(successResult("flaky-watch"));
+      const metadata = makeMetadataStub({
+        name: "flaky-watch",
+        source: "local-folder",
+        url: null,
+        localPath: "C:/flaky",
+        collectionName: "repo_flaky_watch",
+        fileCount: 1,
+        chunkCount: 1,
+        lastIndexedAt: new Date().toISOString(),
+        indexDurationMs: 1,
+        status: "ready",
+        branch: "(local-folder)",
+        includeExtensions: [".ts"],
+        excludePatterns: [],
+        tier: "private",
+      });
+      const coordinator = makeCoordinatorStub();
+      coordinator.startWatching = mock(async () => {
+        throw new Error("chokidar attach failed: EACCES");
+      }) as any;
+
+      const handler = createRegisterLocalFolderHandler({
+        ingestionService: ingestion,
+        localFolderCoordinator: coordinator,
+        repositoryService: metadata,
+      });
+
+      const result = await handler({ path: "C:/flaky", watch: true });
+
+      // Registration itself succeeds (metadata persisted by IngestionService),
+      // but watch_enabled reflects the actual attach result.
+      expect(result.isError).toBe(false);
+      const body = parseTextResponse(result.content as TextContent[]);
+      expect(body["status"]).toBe("registered");
+      expect(body["watch_enabled"]).toBe(false);
+    });
   });
 
   describe("async mode", () => {

--- a/tests/mcp/tools/register-local-folder.test.ts
+++ b/tests/mcp/tools/register-local-folder.test.ts
@@ -12,6 +12,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
@@ -72,9 +73,7 @@ function makeIngestionStub(result: IndexResult): IngestionService {
 
 function makeMetadataStub(repo?: RepositoryInfo): RepositoryMetadataService {
   return {
-    getRepository: mock(async (name: string) =>
-      repo && repo.name === name ? repo : null
-    ),
+    getRepository: mock(async (name: string) => (repo && repo.name === name ? repo : null)),
     listRepositories: mock(async () => (repo ? [repo] : [])),
     updateRepository: mock(async () => undefined),
     removeRepository: mock(async () => undefined),

--- a/tests/mcp/tools/register-local-folder.test.ts
+++ b/tests/mcp/tools/register-local-folder.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Unit tests for register_local_folder MCP tool (Phase C / issue #566 / T4.3-T4.4).
+ *
+ * Covers: argument validation, tool-definition shape (so it appears in
+ * tools/list), sync mode happy path, sync failure surfacing typed errors,
+ * async mode returning a JobTracker job ID, and watcher start invocation
+ * when the coordinator is wired.
+ *
+ * @module tests/mcp/tools/register-local-folder
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import {
+  registerLocalFolderToolDefinition,
+  createRegisterLocalFolderHandler,
+} from "../../../src/mcp/tools/register-local-folder.js";
+import { initializeLogger, resetLogger } from "../../../src/logging/index.js";
+import type { IngestionService } from "../../../src/services/ingestion-service.js";
+import type { LocalFolderUpdateCoordinator } from "../../../src/services/local-folder-update-coordinator.js";
+import type { RepositoryMetadataService, RepositoryInfo } from "../../../src/repositories/types.js";
+import type { JobTracker } from "../../../src/mcp/job-tracker.js";
+import type { IndexResult } from "../../../src/services/ingestion-types.js";
+
+function successResult(name: string): IndexResult {
+  return {
+    status: "success",
+    repository: name,
+    collectionName: `repo_${name}`,
+    stats: {
+      filesScanned: 5,
+      filesProcessed: 5,
+      filesFailed: 0,
+      chunksCreated: 17,
+      embeddingsGenerated: 17,
+      documentsStored: 17,
+      durationMs: 142,
+    },
+    errors: [],
+    completedAt: new Date(),
+  };
+}
+
+function failedResult(name: string, message: string): IndexResult {
+  return {
+    status: "failed",
+    repository: name,
+    collectionName: "",
+    stats: {
+      filesScanned: 0,
+      filesProcessed: 0,
+      filesFailed: 0,
+      chunksCreated: 0,
+      embeddingsGenerated: 0,
+      documentsStored: 0,
+      durationMs: 1,
+    },
+    errors: [{ type: "fatal_error", message, originalError: new Error(message) }],
+    completedAt: new Date(),
+  };
+}
+
+function makeIngestionStub(result: IndexResult): IngestionService {
+  return {
+    indexRepository: mock(async () => result),
+  } as unknown as IngestionService;
+}
+
+function makeMetadataStub(repo?: RepositoryInfo): RepositoryMetadataService {
+  return {
+    getRepository: mock(async (name: string) =>
+      repo && repo.name === name ? repo : null
+    ),
+    listRepositories: mock(async () => (repo ? [repo] : [])),
+    updateRepository: mock(async () => undefined),
+    removeRepository: mock(async () => undefined),
+  } as unknown as RepositoryMetadataService;
+}
+
+function makeCoordinatorStub(): LocalFolderUpdateCoordinator & {
+  startWatching: ReturnType<typeof mock>;
+  stopWatching: ReturnType<typeof mock>;
+} {
+  return {
+    startWatching: mock(async () => undefined),
+    stopWatching: mock(async () => undefined),
+    updateRepository: mock(async () => ({}) as any),
+  } as any;
+}
+
+function makeJobTrackerStub(): JobTracker & {
+  createJob: ReturnType<typeof mock>;
+  updateStatus: ReturnType<typeof mock>;
+  complete: ReturnType<typeof mock>;
+  fail: ReturnType<typeof mock>;
+} {
+  return {
+    createJob: mock((repo: string) => `job-${repo}-${Date.now()}`),
+    updateStatus: mock(() => undefined),
+    complete: mock(() => undefined),
+    fail: mock(() => undefined),
+    timeout: mock(() => undefined),
+    getRunningJob: mock(() => null),
+    getJobResponse: mock(() => null),
+  } as any;
+}
+
+function parseTextResponse(content: TextContent[]): Record<string, unknown> {
+  const text = content[0]?.type === "text" ? content[0].text : "";
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+describe("register_local_folder MCP tool", () => {
+  beforeEach(() => initializeLogger({ level: "silent", format: "json" }));
+  afterEach(() => resetLogger());
+
+  describe("tool definition", () => {
+    it("declares the expected name and required `path` argument", () => {
+      expect(registerLocalFolderToolDefinition.name).toBe("register_local_folder");
+      expect(registerLocalFolderToolDefinition.inputSchema.required).toEqual(["path"]);
+      const props = registerLocalFolderToolDefinition.inputSchema.properties as Record<
+        string,
+        { type: string }
+      >;
+      expect(props["path"]?.type).toBe("string");
+      expect(props["watch"]?.type).toBe("boolean");
+      expect(props["followSymlinks"]?.type).toBe("boolean");
+      expect(props["tier"]?.type).toBe("string");
+      expect(props["async"]?.type).toBe("boolean");
+    });
+  });
+
+  describe("argument validation", () => {
+    const handler = createRegisterLocalFolderHandler({
+      ingestionService: makeIngestionStub(successResult("ignored")),
+      repositoryService: makeMetadataStub(),
+    });
+
+    it("rejects missing path", async () => {
+      const result = await handler({});
+      expect(result.isError).toBe(true);
+      const body = parseTextResponse(result.content as TextContent[]);
+      expect(body["error"]).toBe("invalid_argument");
+      expect(String(body["message"])).toContain("path");
+    });
+
+    it("rejects empty path string", async () => {
+      const result = await handler({ path: "  " });
+      expect(result.isError).toBe(true);
+      const body = parseTextResponse(result.content as TextContent[]);
+      expect(body["error"]).toBe("invalid_argument");
+    });
+  });
+
+  describe("sync mode", () => {
+    it("returns a `registered` response on successful indexing", async () => {
+      const ingestion = makeIngestionStub(successResult("my-folder"));
+      const metadata = makeMetadataStub({
+        name: "my-folder",
+        source: "local-folder",
+        url: null,
+        localPath: "C:/some/path",
+        collectionName: "repo_my_folder",
+        fileCount: 5,
+        chunkCount: 17,
+        lastIndexedAt: new Date().toISOString(),
+        indexDurationMs: 142,
+        status: "ready",
+        branch: "(local-folder)",
+        includeExtensions: [".ts"],
+        excludePatterns: [],
+        tier: "private",
+      });
+      const coordinator = makeCoordinatorStub();
+
+      const handler = createRegisterLocalFolderHandler({
+        ingestionService: ingestion,
+        localFolderCoordinator: coordinator,
+        repositoryService: metadata,
+      });
+
+      const result = await handler({ path: "C:/some/path", watch: true });
+
+      expect(result.isError).toBe(false);
+      const body = parseTextResponse(result.content as TextContent[]);
+      expect(body["success"]).toBe(true);
+      expect(body["repository"]).toBe("my-folder");
+      expect(body["status"]).toBe("registered");
+      expect(body["files_processed"]).toBe(5);
+      expect(body["chunks_created"]).toBe(17);
+      expect(body["watch_enabled"]).toBe(true);
+
+      // Coordinator.startWatching invoked exactly once with the resolved repo.
+      expect((coordinator.startWatching as any).mock.calls.length).toBe(1);
+    });
+
+    it("does NOT call startWatching when watch=false", async () => {
+      const ingestion = makeIngestionStub(successResult("no-watch-folder"));
+      const metadata = makeMetadataStub({
+        name: "no-watch-folder",
+        source: "local-folder",
+        url: null,
+        localPath: "C:/some/path",
+        collectionName: "repo_no_watch_folder",
+        fileCount: 1,
+        chunkCount: 1,
+        lastIndexedAt: new Date().toISOString(),
+        indexDurationMs: 1,
+        status: "ready",
+        branch: "(local-folder)",
+        includeExtensions: [".ts"],
+        excludePatterns: [],
+        tier: "private",
+      });
+      const coordinator = makeCoordinatorStub();
+      const handler = createRegisterLocalFolderHandler({
+        ingestionService: ingestion,
+        localFolderCoordinator: coordinator,
+        repositoryService: metadata,
+      });
+
+      await handler({ path: "C:/some/path", watch: false });
+
+      expect((coordinator.startWatching as any).mock.calls.length).toBe(0);
+    });
+
+    it("surfaces a `registration_failed` error with the typed error message when IngestionService returns failed", async () => {
+      const ingestion = makeIngestionStub(failedResult("doomed", "size guardrail tripped"));
+      const handler = createRegisterLocalFolderHandler({
+        ingestionService: ingestion,
+        repositoryService: makeMetadataStub(),
+      });
+
+      const result = await handler({ path: "C:/big/folder" });
+
+      expect(result.isError).toBe(true);
+      const body = parseTextResponse(result.content as TextContent[]);
+      expect(body["error"]).toBe("registration_failed");
+      expect(String(body["message"])).toContain("size guardrail");
+    });
+  });
+
+  describe("async mode", () => {
+    it("returns a job ID immediately when async=true and JobTracker is wired", async () => {
+      const ingestion = makeIngestionStub(successResult("async-folder"));
+      const metadata = makeMetadataStub({
+        name: "async-folder",
+        source: "local-folder",
+        url: null,
+        localPath: "C:/async/path",
+        collectionName: "repo_async_folder",
+        fileCount: 1,
+        chunkCount: 1,
+        lastIndexedAt: new Date().toISOString(),
+        indexDurationMs: 5,
+        status: "ready",
+        branch: "(local-folder)",
+        includeExtensions: [".ts"],
+        excludePatterns: [],
+        tier: "private",
+      });
+      const tracker = makeJobTrackerStub();
+
+      const handler = createRegisterLocalFolderHandler({
+        ingestionService: ingestion,
+        repositoryService: metadata,
+        jobTracker: tracker,
+      });
+
+      const result = await handler({ path: "C:/async/path", async: true });
+      expect(result.isError).toBe(false);
+      const body = parseTextResponse(result.content as TextContent[]);
+      expect(body["async"]).toBe(true);
+      expect(body["job_id"]).toBeTruthy();
+      expect((tracker.createJob as any).mock.calls.length).toBe(1);
+
+      // Allow the fire-and-forget background worker to settle.
+      await new Promise((r) => setTimeout(r, 20));
+      expect((tracker.complete as any).mock.calls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("falls back to sync when async=true but no JobTracker was wired", async () => {
+      const ingestion = makeIngestionStub(successResult("sync-fallback"));
+      const handler = createRegisterLocalFolderHandler({
+        ingestionService: ingestion,
+        repositoryService: makeMetadataStub(),
+        // jobTracker omitted
+      });
+
+      const result = await handler({ path: "C:/sync/path", async: true });
+      const body = parseTextResponse(result.content as TextContent[]);
+      // Sync response shape — no async:true field.
+      expect(body["async"]).toBeUndefined();
+      expect(body["status"]).toBe("registered");
+    });
+  });
+});

--- a/tests/services/folder-event-router.test.ts
+++ b/tests/services/folder-event-router.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for FolderEventRouter (issue #566 / T5.1).
+ *
+ * Covers: id-prefix routing precedence, debounce coalescing, per-repo
+ * debounce overrides, missing-repo handling, non-local-folder source
+ * rejection, and shutdown cancelling pending timers.
+ *
+ * @module tests/services/folder-event-router
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import {
+  FolderEventRouter,
+  LOCAL_FOLDER_ID_PREFIX,
+  localFolderIdFor,
+  repositoryNameFromLocalFolderId,
+  DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS,
+} from "../../src/services/folder-event-router.js";
+import type { FileEvent } from "../../src/services/folder-watcher-types.js";
+import type { RepositoryMetadataService, RepositoryInfo } from "../../src/repositories/types.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+
+function buildEvent(folderId: string): FileEvent {
+  return {
+    type: "change",
+    absolutePath: "/some/abs/file.txt",
+    relativePath: "file.txt",
+    extension: "txt",
+    folderId,
+    folderPath: "/some/abs",
+    timestamp: new Date(),
+  };
+}
+
+function buildLocalFolderRepo(name: string, overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
+  return {
+    name,
+    source: "local-folder",
+    url: null,
+    localPath: `/abs/${name}`,
+    collectionName: `repo_${name}`,
+    fileCount: 0,
+    chunkCount: 0,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "(local-folder)",
+    includeExtensions: [".ts"],
+    excludePatterns: [],
+    tier: "private",
+    ...overrides,
+  };
+}
+
+function buildMetadata(repos: RepositoryInfo[]): RepositoryMetadataService {
+  const map = new Map(repos.map((r) => [r.name, r]));
+  return {
+    getRepository: mock(async (name: string) => map.get(name) ?? null),
+    listRepositories: mock(async () => Array.from(map.values())),
+    updateRepository: mock(async () => undefined),
+    removeRepository: mock(async () => undefined),
+  } as unknown as RepositoryMetadataService;
+}
+
+describe("FolderEventRouter id-prefix helpers", () => {
+  it("encodes and decodes repository names symmetrically", () => {
+    const id = localFolderIdFor("my-repo");
+    expect(id).toBe(`${LOCAL_FOLDER_ID_PREFIX}my-repo`);
+    expect(repositoryNameFromLocalFolderId(id)).toBe("my-repo");
+  });
+
+  it("returns null for non-local-folder ids", () => {
+    expect(repositoryNameFromLocalFolderId("watched-folder-uuid")).toBeNull();
+    expect(repositoryNameFromLocalFolderId("")).toBeNull();
+  });
+});
+
+describe("FolderEventRouter routing", () => {
+  beforeEach(() => initializeLogger({ level: "silent", format: "json" }));
+  afterEach(() => resetLogger());
+
+  it("ignores events whose folderId is not in the local-folder namespace", async () => {
+    const dispatch = mock(() => undefined);
+    const router = new FolderEventRouter(buildMetadata([]), dispatch as any);
+
+    await router.route(buildEvent("watched-folder-uuid-1"));
+
+    expect(dispatch.mock.calls.length).toBe(0);
+  });
+
+  it("debounces multiple events for the same repo into a single dispatch", async () => {
+    const dispatch = mock(() => undefined);
+    const repo = buildLocalFolderRepo("repo-A");
+    const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    const id = localFolderIdFor("repo-A");
+    await router.route(buildEvent(id));
+    await router.route(buildEvent(id));
+    await router.route(buildEvent(id));
+
+    // Before debounce expires, dispatch must NOT have fired.
+    expect(dispatch.mock.calls.length).toBe(0);
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    // After expiry, exactly one dispatch fires for the coalesced burst.
+    expect(dispatch.mock.calls.length).toBe(1);
+    expect(dispatch.mock.calls[0]?.[0]?.name).toBe("repo-A");
+  });
+
+  it("respects per-repo watchDebounceMs override", async () => {
+    const dispatch = mock(() => undefined);
+    const repo = buildLocalFolderRepo("slow-repo", { watchDebounceMs: 50 });
+    const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    await router.route(buildEvent(localFolderIdFor("slow-repo")));
+    // After the default would have fired (>10ms), check no dispatch yet.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(dispatch.mock.calls.length).toBe(0);
+
+    // After the per-repo window (50ms total), dispatch fires.
+    await new Promise((r) => setTimeout(r, 40));
+    expect(dispatch.mock.calls.length).toBe(1);
+  });
+
+  it("dispatches independently for two distinct repos", async () => {
+    const dispatch = mock(() => undefined);
+    const repos = [buildLocalFolderRepo("a"), buildLocalFolderRepo("b")];
+    const router = new FolderEventRouter(buildMetadata(repos), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    await router.route(buildEvent(localFolderIdFor("a")));
+    await router.route(buildEvent(localFolderIdFor("b")));
+
+    await new Promise((r) => setTimeout(r, 30));
+
+    const dispatchedNames = dispatch.mock.calls.map((c) => (c[0] as RepositoryInfo).name).sort();
+    expect(dispatchedNames).toEqual(["a", "b"]);
+  });
+
+  it("drops events for unknown local-folder repos", async () => {
+    const dispatch = mock(() => undefined);
+    const router = new FolderEventRouter(buildMetadata([]), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    await router.route(buildEvent(localFolderIdFor("ghost")));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dispatch.mock.calls.length).toBe(0);
+  });
+
+  it("drops events when the resolved repo is not a local-folder source", async () => {
+    const dispatch = mock(() => undefined);
+    const repo = buildLocalFolderRepo("mixed", { source: "git-remote", url: "https://x" });
+    const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    await router.route(buildEvent(localFolderIdFor("mixed")));
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dispatch.mock.calls.length).toBe(0);
+  });
+
+  it("shutdown cancels pending timers", async () => {
+    const dispatch = mock(() => undefined);
+    const repo = buildLocalFolderRepo("cancelme");
+    const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
+      defaultDebounceMs: 50,
+    });
+
+    await router.route(buildEvent(localFolderIdFor("cancelme")));
+    router.shutdown();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(dispatch.mock.calls.length).toBe(0);
+  });
+
+  it("uses DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS when no override is provided", () => {
+    expect(DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS).toBe(2000);
+  });
+});

--- a/tests/services/folder-event-router.test.ts
+++ b/tests/services/folder-event-router.test.ts
@@ -13,6 +13,8 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, rm, writeFile, symlink } from "node:fs/promises";
+import { join, resolve } from "node:path";
 import {
   FolderEventRouter,
   LOCAL_FOLDER_ID_PREFIX,
@@ -77,6 +79,22 @@ describe("FolderEventRouter id-prefix helpers", () => {
     expect(repositoryNameFromLocalFolderId("watched-folder-uuid")).toBeNull();
     expect(repositoryNameFromLocalFolderId("")).toBeNull();
   });
+
+  it("treats UUID-shaped Phase 6 ids as non-local-folder (review L-4)", () => {
+    // RFC 4122 v4 UUIDs cannot start with "local-folder:" since the first
+    // 8 characters must be hex digits. A handful of representative samples
+    // covers the structural guarantee.
+    const uuidSamples = [
+      "550e8400-e29b-41d4-a716-446655440000",
+      "00000000-0000-4000-8000-000000000000",
+      "ffffffff-ffff-4fff-bfff-ffffffffffff",
+      "deadbeef-1234-4567-89ab-cdef01234567",
+    ];
+    for (const id of uuidSamples) {
+      expect(repositoryNameFromLocalFolderId(id)).toBeNull();
+      expect(id.startsWith(LOCAL_FOLDER_ID_PREFIX)).toBe(false);
+    }
+  });
 });
 
 describe("FolderEventRouter routing", () => {
@@ -84,7 +102,7 @@ describe("FolderEventRouter routing", () => {
   afterEach(() => resetLogger());
 
   it("ignores events whose folderId is not in the local-folder namespace", async () => {
-    const dispatch = mock(() => undefined);
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
     const router = new FolderEventRouter(buildMetadata([]), dispatch as any);
 
     await router.route(buildEvent("watched-folder-uuid-1"));
@@ -93,7 +111,7 @@ describe("FolderEventRouter routing", () => {
   });
 
   it("debounces multiple events for the same repo into a single dispatch", async () => {
-    const dispatch = mock(() => undefined);
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
     const repo = buildLocalFolderRepo("repo-A");
     const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
       defaultDebounceMs: 10,
@@ -115,7 +133,7 @@ describe("FolderEventRouter routing", () => {
   });
 
   it("respects per-repo watchDebounceMs override", async () => {
-    const dispatch = mock(() => undefined);
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
     const repo = buildLocalFolderRepo("slow-repo", { watchDebounceMs: 50 });
     const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
       defaultDebounceMs: 10,
@@ -132,7 +150,7 @@ describe("FolderEventRouter routing", () => {
   });
 
   it("dispatches independently for two distinct repos", async () => {
-    const dispatch = mock(() => undefined);
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
     const repos = [buildLocalFolderRepo("a"), buildLocalFolderRepo("b")];
     const router = new FolderEventRouter(buildMetadata(repos), dispatch as any, {
       defaultDebounceMs: 10,
@@ -148,7 +166,7 @@ describe("FolderEventRouter routing", () => {
   });
 
   it("drops events for unknown local-folder repos", async () => {
-    const dispatch = mock(() => undefined);
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
     const router = new FolderEventRouter(buildMetadata([]), dispatch as any, {
       defaultDebounceMs: 10,
     });
@@ -159,7 +177,7 @@ describe("FolderEventRouter routing", () => {
   });
 
   it("drops events when the resolved repo is not a local-folder source", async () => {
-    const dispatch = mock(() => undefined);
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
     const repo = buildLocalFolderRepo("mixed", { source: "git-remote", url: "https://x" });
     const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
       defaultDebounceMs: 10,
@@ -171,7 +189,7 @@ describe("FolderEventRouter routing", () => {
   });
 
   it("shutdown cancels pending timers", async () => {
-    const dispatch = mock(() => undefined);
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
     const repo = buildLocalFolderRepo("cancelme");
     const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
       defaultDebounceMs: 50,
@@ -185,5 +203,144 @@ describe("FolderEventRouter routing", () => {
 
   it("uses DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS when no override is provided", () => {
     expect(DEFAULT_LOCAL_FOLDER_DEBOUNCE_MS).toBe(2000);
+  });
+});
+
+/**
+ * Out-of-folder symlink rejection (review C-2).
+ *
+ * Uses a real temp-dir fixture with a real symlink so the realpath()
+ * comparison in the router actually exercises against the OS. The fixture
+ * is platform-portable because Node's `symlink` works on macOS/Linux and on
+ * Windows (with developer-mode or admin elevation). When elevation is
+ * unavailable on Windows the test self-skips so CI on developer machines
+ * doesn't false-fail.
+ */
+describe("FolderEventRouter out-of-folder symlink rejection", () => {
+  let testRoot: string;
+  let repoRoot: string;
+  let outsideDir: string;
+  let outsideFile: string;
+  let symlinkPath: string;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testRoot = join(import.meta.dir, "..", "..", "test-temp", `fer-symlink-${stamp}`);
+    repoRoot = join(testRoot, "repo");
+    outsideDir = join(testRoot, "outside");
+    await mkdir(repoRoot, { recursive: true });
+    await mkdir(outsideDir, { recursive: true });
+    outsideFile = join(outsideDir, "secret.txt");
+    await writeFile(outsideFile, "should not be indexed");
+    symlinkPath = join(repoRoot, "escape");
+    try {
+      await symlink(outsideDir, symlinkPath, "dir");
+    } catch (err) {
+      // EPERM on Windows without dev-mode/admin elevation. The router code is
+      // still exercised in the no-symlink event-route tests above; this
+      // suite simply self-skips on machines that can't make symlinks.
+      const message = err instanceof Error ? err.message : String(err);
+      if (message.includes("EPERM") || message.includes("perm")) {
+        // Fixture creation failed — flag and rely on early returns in the tests.
+        symlinkPath = "";
+      } else {
+        throw err;
+      }
+    }
+  });
+
+  afterEach(async () => {
+    await rm(testRoot, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("drops events whose realpath escapes the repo root when followSymlinks=true", async () => {
+    if (symlinkPath === "") return; // Windows EPERM — see beforeEach
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
+    const repo = buildLocalFolderRepo("guarded", {
+      localPath: repoRoot,
+      followSymlinks: true,
+    });
+    const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    const escapingEvent: FileEvent = {
+      type: "change",
+      // The path the user sees (under repo via the symlink) — chokidar would
+      // emit this when followSymlinks: true and the symlink target changes.
+      absolutePath: join(symlinkPath, "secret.txt"),
+      relativePath: "escape/secret.txt",
+      extension: "txt",
+      folderId: localFolderIdFor("guarded"),
+      folderPath: repoRoot,
+      timestamp: new Date(),
+    };
+
+    await router.route(escapingEvent);
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Realpath resolves both `repoRoot/escape/secret.txt` and `outsideDir/secret.txt`
+    // to the same canonical out-of-repo location, which is not a prefix of
+    // realpath(repoRoot). Router drops the event.
+    expect(dispatch.mock.calls.length).toBe(0);
+  });
+
+  it("ALLOWS events that resolve inside the repo root (defence-in-depth false-positive guard)", async () => {
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
+    const repo = buildLocalFolderRepo("guarded", {
+      localPath: repoRoot,
+      followSymlinks: true,
+    });
+    const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    // Real file under the repo root — realpath stays inside.
+    const insideFile = join(repoRoot, "kept.txt");
+    await writeFile(insideFile, "inside content");
+    const insideEvent: FileEvent = {
+      type: "change",
+      absolutePath: resolve(insideFile),
+      relativePath: "kept.txt",
+      extension: "txt",
+      folderId: localFolderIdFor("guarded"),
+      folderPath: repoRoot,
+      timestamp: new Date(),
+    };
+
+    await router.route(insideEvent);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(dispatch.mock.calls.length).toBe(1);
+  });
+
+  it("does NOT run the realpath check when followSymlinks=false (cost optimization)", async () => {
+    if (symlinkPath === "") return;
+    const dispatch = mock((_repo: RepositoryInfo) => undefined);
+    const repo = buildLocalFolderRepo("plain", {
+      localPath: repoRoot,
+      followSymlinks: false,
+    });
+    const router = new FolderEventRouter(buildMetadata([repo]), dispatch as any, {
+      defaultDebounceMs: 10,
+    });
+
+    // chokidar with followSymlinks: false would not normally emit this event;
+    // but if it slipped through somehow, the router doesn't second-guess it.
+    const event: FileEvent = {
+      type: "change",
+      absolutePath: join(symlinkPath, "secret.txt"),
+      relativePath: "escape/secret.txt",
+      extension: "txt",
+      folderId: localFolderIdFor("plain"),
+      folderPath: repoRoot,
+      timestamp: new Date(),
+    };
+
+    await router.route(event);
+    await new Promise((r) => setTimeout(r, 30));
+    // Router DOES dispatch — the symlink filter runs only under followSymlinks=true.
+    expect(dispatch.mock.calls.length).toBe(1);
   });
 });

--- a/tests/services/folder-event-router.test.ts
+++ b/tests/services/folder-event-router.test.ts
@@ -38,7 +38,10 @@ function buildEvent(folderId: string): FileEvent {
   };
 }
 
-function buildLocalFolderRepo(name: string, overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
+function buildLocalFolderRepo(
+  name: string,
+  overrides: Partial<RepositoryInfo> = {}
+): RepositoryInfo {
   return {
     name,
     source: "local-folder",
@@ -161,7 +164,7 @@ describe("FolderEventRouter routing", () => {
 
     await new Promise((r) => setTimeout(r, 30));
 
-    const dispatchedNames = dispatch.mock.calls.map((c) => (c[0] as RepositoryInfo).name).sort();
+    const dispatchedNames = dispatch.mock.calls.map((c) => c[0].name).sort();
     expect(dispatchedNames).toEqual(["a", "b"]);
   });
 

--- a/tests/services/ingestion-service-duplicate-path.test.ts
+++ b/tests/services/ingestion-service-duplicate-path.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Phase C duplicate-path detection (issue #566 / T4.2).
+ *
+ * Registering a local-folder under a different name but the same on-disk path
+ * must be refused with `LocalFolderPathAlreadyRegisteredError`. Force-flag
+ * paths bypass the check (the user is explicitly opting into reindex).
+ *
+ * Comparison is canonicalised so case-different / mixed-separator strings
+ * collide on Windows.
+ *
+ * @module tests/services/ingestion-service-duplicate-path
+ */
+
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join, resolve, normalize } from "node:path";
+import { IngestionService } from "../../src/services/ingestion-service.js";
+import { FileManifestStoreImpl } from "../../src/services/file-manifest-store.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+import type { EmbeddingProvider } from "../../src/providers/types.js";
+import type { ChromaStorageClient } from "../../src/storage/types.js";
+import type { RepositoryMetadataService, RepositoryInfo } from "../../src/repositories/types.js";
+
+function makeStubProvider(): EmbeddingProvider {
+  return {
+    providerId: "stub",
+    modelId: "stub-model",
+    dimensions: 4,
+    generateEmbedding: mock(async () => [0.1, 0.2, 0.3, 0.4] as number[]),
+    generateEmbeddings: mock(async (texts: string[]) =>
+      texts.map(() => [0.1, 0.2, 0.3, 0.4] as number[])
+    ),
+    healthCheck: mock(async () => true),
+    getCapabilities: () => ({
+      maxBatchSize: 100,
+      maxTokensPerText: 8191,
+      supportsGPU: false,
+      requiresNetwork: false,
+      estimatedLatencyMs: 1,
+    }),
+  };
+}
+
+function makeStubStorage(): ChromaStorageClient {
+  return {
+    deleteCollection: mock(async () => undefined),
+    createCollection: mock(async () => undefined),
+    addDocuments: mock(async () => undefined),
+    getCollection: mock(async () => null),
+    listCollections: mock(async () => []),
+    queryDocuments: mock(async () => ({ documents: [] })),
+    healthCheck: mock(async () => true),
+  } as unknown as ChromaStorageClient;
+}
+
+interface StubMetadata extends RepositoryMetadataService {
+  data: Map<string, RepositoryInfo>;
+}
+
+function makeStubMetadata(seed?: RepositoryInfo): StubMetadata {
+  const data = new Map<string, RepositoryInfo>();
+  if (seed) data.set(seed.name, seed);
+  return {
+    data,
+    listRepositories: mock(async () => Array.from(data.values())),
+    getRepository: mock(async (name: string) => data.get(name) ?? null),
+    updateRepository: mock(async (info: RepositoryInfo) => {
+      data.set(info.name, info);
+    }),
+    removeRepository: mock(async (name: string) => {
+      data.delete(name);
+    }),
+  } as unknown as StubMetadata;
+}
+
+describe("IngestionService duplicate-path detection (Phase C T4.2)", () => {
+  let testDir: string;
+  let dataDir: string;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDir = join(import.meta.dir, "..", "..", "test-temp", `is-dup-${stamp}`);
+    dataDir = join(import.meta.dir, "..", "..", "test-temp", `is-dup-data-${stamp}`);
+    await mkdir(testDir, { recursive: true });
+    await mkdir(dataDir, { recursive: true });
+    FileManifestStoreImpl.resetInstance();
+    FileManifestStoreImpl.getInstance(dataDir);
+  });
+
+  afterEach(async () => {
+    FileManifestStoreImpl.resetInstance();
+    await rm(testDir, { recursive: true, force: true });
+    await rm(dataDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  it("refuses re-registration of the same path under a different name and points at the existing registration", async () => {
+    const canonical = normalize(resolve(testDir));
+    const existing: RepositoryInfo = {
+      name: "first-name",
+      source: "local-folder",
+      url: null,
+      localPath: canonical,
+      collectionName: "first_name",
+      fileCount: 0,
+      chunkCount: 0,
+      lastIndexedAt: new Date().toISOString(),
+      indexDurationMs: 0,
+      status: "ready",
+      branch: "(local-folder)",
+      includeExtensions: [".ts"],
+      excludePatterns: [],
+      tier: "private",
+    };
+
+    const metadata = makeStubMetadata(existing);
+    const svc = new IngestionService(
+      { clone: mock(), cleanup: mock() } as any,
+      { scanFiles: mock(async () => []) } as any,
+      {} as any,
+      makeStubProvider(),
+      makeStubStorage(),
+      metadata
+    );
+
+    // Path-collision is rethrown (mirrors RepositoryAlreadyExistsError) so the
+    // CLI/MCP wrapper can format a user-actionable message with the existing
+    // registration's name.
+    let caught: unknown;
+    try {
+      await svc.indexRepository(testDir, { name: "second-name" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    const error = caught as Error & { existingRepository?: string };
+    expect(error.name).toBe("LocalFolderPathAlreadyRegisteredError");
+    expect(error.existingRepository).toBe("first-name");
+    expect(error.message).toContain("first-name");
+    expect(error.message).toContain(canonical);
+  });
+
+  it("does NOT refuse re-registration of the same path under the SAME name (name collision is handled by RepositoryAlreadyExistsError)", async () => {
+    // Seed an existing entry with the SAME name we're about to register again.
+    const canonical = normalize(resolve(testDir));
+    const existing: RepositoryInfo = {
+      name: "same-name",
+      source: "local-folder",
+      url: null,
+      localPath: canonical,
+      collectionName: "same_name",
+      fileCount: 0,
+      chunkCount: 0,
+      lastIndexedAt: new Date().toISOString(),
+      indexDurationMs: 0,
+      status: "ready",
+      branch: "(local-folder)",
+      includeExtensions: [".ts"],
+      excludePatterns: [],
+      tier: "private",
+    };
+
+    const metadata = makeStubMetadata(existing);
+    const svc = new IngestionService(
+      { clone: mock(), cleanup: mock() } as any,
+      { scanFiles: mock(async () => []) } as any,
+      {} as any,
+      makeStubProvider(),
+      makeStubStorage(),
+      metadata
+    );
+
+    // Same-name produces RepositoryAlreadyExistsError (also rethrown), NOT
+    // the path-collision error — the existing name-collision path runs first.
+    let caught: unknown;
+    try {
+      await svc.indexRepository(testDir, { name: "same-name" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeDefined();
+    const error = caught as Error;
+    expect(error.name).toBe("RepositoryAlreadyExistsError");
+    expect(error.message).toContain("already indexed");
+    expect(error.message).not.toContain("already registered as repository");
+  });
+
+  it("allows re-registration when force=true (path-collision check is bypassed)", async () => {
+    const canonical = normalize(resolve(testDir));
+    const existing: RepositoryInfo = {
+      name: "first-name",
+      source: "local-folder",
+      url: null,
+      localPath: canonical,
+      collectionName: "first_name",
+      fileCount: 0,
+      chunkCount: 0,
+      lastIndexedAt: new Date().toISOString(),
+      indexDurationMs: 0,
+      status: "ready",
+      branch: "(local-folder)",
+      includeExtensions: [".ts"],
+      excludePatterns: [],
+      tier: "private",
+    };
+
+    const metadata = makeStubMetadata(existing);
+    const svc = new IngestionService(
+      { clone: mock(), cleanup: mock() } as any,
+      { scanFiles: mock(async () => []) } as any,
+      {} as any,
+      makeStubProvider(),
+      makeStubStorage(),
+      metadata
+    );
+
+    const result = await svc.indexRepository(testDir, {
+      name: "second-name",
+      force: true,
+    });
+
+    // The path-collision branch is skipped under force; the call may still
+    // fail later for unrelated reasons (no scanned files, etc.) but the
+    // failure must NOT be the path-already-registered error.
+    const messages = result.errors.map((e) => e.message ?? "").join(" || ");
+    expect(messages).not.toContain("already registered as repository");
+  });
+});

--- a/tests/services/local-folder-repo-watch-manager.test.ts
+++ b/tests/services/local-folder-repo-watch-manager.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Unit tests for LocalFolderRepoWatchManager (issue #566 / T5.3, T5.4).
+ *
+ * Covers: synthetic WatchedFolder construction, default-deny symlink policy,
+ * opt-in followSymlinks with depth cap, validation of source/path/realpath,
+ * and stopWatching idempotency.
+ *
+ * @module tests/services/local-folder-repo-watch-manager
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdir, rm } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import {
+  LocalFolderRepoWatchManager,
+  LocalFolderWatchValidationError,
+  SYMLINK_FOLLOW_DEPTH_CAP,
+} from "../../src/services/local-folder-repo-watch-manager.js";
+import { localFolderIdFor } from "../../src/services/folder-event-router.js";
+import type { FolderWatcherService } from "../../src/services/folder-watcher-service.js";
+import type { RepositoryInfo } from "../../src/repositories/types.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+
+function makeWatcherStub(): FolderWatcherService & {
+  startWatching: ReturnType<typeof mock>;
+  stopWatching: ReturnType<typeof mock>;
+} {
+  return {
+    startWatching: mock(async () => undefined),
+    stopWatching: mock(async () => undefined),
+  } as any;
+}
+
+function makeRepo(localPath: string, overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
+  return {
+    name: "test-repo",
+    source: "local-folder",
+    url: null,
+    localPath,
+    collectionName: "repo_test",
+    fileCount: 0,
+    chunkCount: 0,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "(local-folder)",
+    includeExtensions: [".ts"],
+    excludePatterns: [],
+    tier: "private",
+    ...overrides,
+  };
+}
+
+describe("LocalFolderRepoWatchManager", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    initializeLogger({ level: "silent", format: "json" });
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    testDir = join(import.meta.dir, "..", "..", "test-temp", `lfrwm-${stamp}`);
+    await mkdir(testDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(testDir, { recursive: true, force: true });
+    resetLogger();
+  });
+
+  describe("startWatching", () => {
+    it("constructs a synthetic WatchedFolder with the local-folder id prefix", async () => {
+      const watcher = makeWatcherStub();
+      const manager = new LocalFolderRepoWatchManager(watcher);
+      const repo = makeRepo(testDir, { name: "ws-1" });
+
+      await manager.startWatching(repo);
+
+      expect(watcher.startWatching.mock.calls.length).toBe(1);
+      const synthetic = watcher.startWatching.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(synthetic["id"]).toBe(localFolderIdFor("ws-1"));
+      expect(synthetic["path"]).toBe(resolve(testDir));
+      expect(synthetic["enabled"]).toBe(true);
+    });
+
+    it("default-denies symlinks: synthetic followSymlinks=false, no depth cap", async () => {
+      const watcher = makeWatcherStub();
+      const manager = new LocalFolderRepoWatchManager(watcher);
+      const repo = makeRepo(testDir, { name: "ws-deny", followSymlinks: undefined });
+
+      await manager.startWatching(repo);
+
+      const synthetic = watcher.startWatching.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(synthetic["followSymlinks"]).toBe(false);
+      expect(synthetic["depthCap"]).toBeUndefined();
+    });
+
+    it("opts-in to symlinks when followSymlinks=true, capping depth at 8", async () => {
+      const watcher = makeWatcherStub();
+      const manager = new LocalFolderRepoWatchManager(watcher);
+      const repo = makeRepo(testDir, { name: "ws-allow", followSymlinks: true });
+
+      await manager.startWatching(repo);
+
+      const synthetic = watcher.startWatching.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(synthetic["followSymlinks"]).toBe(true);
+      expect(synthetic["depthCap"]).toBe(SYMLINK_FOLLOW_DEPTH_CAP);
+    });
+
+    it("propagates per-repo watchDebounceMs into the synthetic folder", async () => {
+      const watcher = makeWatcherStub();
+      const manager = new LocalFolderRepoWatchManager(watcher);
+      const repo = makeRepo(testDir, { name: "ws-debounce", watchDebounceMs: 750 });
+
+      await manager.startWatching(repo);
+
+      const synthetic = watcher.startWatching.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(synthetic["debounceMs"]).toBe(750);
+    });
+
+    it("rejects non-local-folder sources", async () => {
+      const watcher = makeWatcherStub();
+      const manager = new LocalFolderRepoWatchManager(watcher);
+      const gitRepo = makeRepo(testDir, { source: "git-remote", url: "https://x" });
+
+      await expect(manager.startWatching(gitRepo)).rejects.toBeInstanceOf(
+        LocalFolderWatchValidationError
+      );
+      expect(watcher.startWatching.mock.calls.length).toBe(0);
+    });
+
+    it("rejects a registered path that does not exist", async () => {
+      const watcher = makeWatcherStub();
+      const manager = new LocalFolderRepoWatchManager(watcher);
+      const ghost = makeRepo(join(testDir, "does-not-exist"));
+
+      await expect(manager.startWatching(ghost)).rejects.toBeInstanceOf(
+        LocalFolderWatchValidationError
+      );
+      expect(watcher.startWatching.mock.calls.length).toBe(0);
+    });
+  });
+
+  describe("stopWatching", () => {
+    it("calls folderWatcherService.stopWatching with the prefixed id", async () => {
+      const watcher = makeWatcherStub();
+      const manager = new LocalFolderRepoWatchManager(watcher);
+
+      await manager.stopWatching("ws-stop");
+
+      expect(watcher.stopWatching.mock.calls[0]?.[0]).toBe(localFolderIdFor("ws-stop"));
+    });
+
+    it("swallows errors from the watcher (idempotent stop)", async () => {
+      const watcher = makeWatcherStub();
+      watcher.stopWatching = mock(async () => {
+        throw new Error("not watched");
+      }) as any;
+      const manager = new LocalFolderRepoWatchManager(watcher);
+
+      await expect(manager.stopWatching("ghost")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/tests/services/local-folder-repo-watch-manager.test.ts
+++ b/tests/services/local-folder-repo-watch-manager.test.ts
@@ -11,6 +11,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/await-thenable */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdir, rm } from "node:fs/promises";

--- a/tests/services/local-folder-update-coordinator-watch-lifecycle.test.ts
+++ b/tests/services/local-folder-update-coordinator-watch-lifecycle.test.ts
@@ -12,6 +12,8 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/await-thenable */
 
 import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
 import {

--- a/tests/services/local-folder-update-coordinator-watch-lifecycle.test.ts
+++ b/tests/services/local-folder-update-coordinator-watch-lifecycle.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the watch-lifecycle methods on `LocalFolderUpdateCoordinator`
+ * (Phase C / issue #566 / T5.3).
+ *
+ * Covers: startWatching delegating to a watch manager, persistence of
+ * `watchEnabled`, no-manager fallback (still persists), source guard, and
+ * stopWatching's persistence + delegation.
+ *
+ * @module tests/services/local-folder-update-coordinator-watch-lifecycle
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import {
+  LocalFolderUpdateCoordinator,
+  type LocalFolderWatchManager,
+} from "../../src/services/local-folder-update-coordinator.js";
+import type { RepositoryMetadataService, RepositoryInfo } from "../../src/repositories/types.js";
+import { initializeLogger, resetLogger } from "../../src/logging/index.js";
+
+function makeRepo(name: string, overrides: Partial<RepositoryInfo> = {}): RepositoryInfo {
+  return {
+    name,
+    source: "local-folder",
+    url: null,
+    localPath: `/abs/${name}`,
+    collectionName: `repo_${name}`,
+    fileCount: 0,
+    chunkCount: 0,
+    lastIndexedAt: new Date().toISOString(),
+    indexDurationMs: 0,
+    status: "ready",
+    branch: "(local-folder)",
+    includeExtensions: [".ts"],
+    excludePatterns: [],
+    tier: "private",
+    ...overrides,
+  };
+}
+
+interface MockedMetadata extends RepositoryMetadataService {
+  store: Map<string, RepositoryInfo>;
+}
+
+function makeMetadata(seed: RepositoryInfo[]): MockedMetadata {
+  const store = new Map(seed.map((r) => [r.name, { ...r }]));
+  return {
+    store,
+    listRepositories: mock(async () => Array.from(store.values())),
+    getRepository: mock(async (name: string) => store.get(name) ?? null),
+    updateRepository: mock(async (info: RepositoryInfo) => {
+      store.set(info.name, info);
+    }),
+    removeRepository: mock(async (name: string) => {
+      store.delete(name);
+    }),
+  } as unknown as MockedMetadata;
+}
+
+function makeWatchManager(): LocalFolderWatchManager & {
+  startWatching: ReturnType<typeof mock>;
+  stopWatching: ReturnType<typeof mock>;
+} {
+  return {
+    startWatching: mock(async () => undefined),
+    stopWatching: mock(async () => undefined),
+  } as any;
+}
+
+describe("LocalFolderUpdateCoordinator watch lifecycle", () => {
+  beforeEach(() => initializeLogger({ level: "silent", format: "json" }));
+  afterEach(() => resetLogger());
+
+  it("startWatching delegates to the manager AND persists watchEnabled=true", async () => {
+    const repo = makeRepo("alpha", { watchEnabled: false });
+    const metadata = makeMetadata([repo]);
+    const manager = makeWatchManager();
+
+    const coordinator = new LocalFolderUpdateCoordinator(
+      metadata,
+      {} as any, // pipeline not exercised
+      undefined,
+      undefined,
+      {},
+      manager
+    );
+
+    await coordinator.startWatching(repo);
+
+    expect(manager.startWatching.mock.calls.length).toBe(1);
+    expect((metadata.updateRepository as any).mock.calls.length).toBe(1);
+    expect(metadata.store.get("alpha")?.watchEnabled).toBe(true);
+  });
+
+  it("startWatching without a watch manager still persists watchEnabled=true", async () => {
+    const repo = makeRepo("beta");
+    const metadata = makeMetadata([repo]);
+
+    const coordinator = new LocalFolderUpdateCoordinator(
+      metadata,
+      {} as any,
+      undefined,
+      undefined,
+      {}
+      // watchManager omitted
+    );
+
+    await coordinator.startWatching(repo);
+
+    expect(metadata.store.get("beta")?.watchEnabled).toBe(true);
+  });
+
+  it("startWatching skips redundant metadata writes when already watchEnabled=true", async () => {
+    const repo = makeRepo("gamma", { watchEnabled: true });
+    const metadata = makeMetadata([repo]);
+    const manager = makeWatchManager();
+
+    const coordinator = new LocalFolderUpdateCoordinator(
+      metadata,
+      {} as any,
+      undefined,
+      undefined,
+      {},
+      manager
+    );
+
+    await coordinator.startWatching(repo);
+
+    // Manager called every time, but no metadata write needed.
+    expect(manager.startWatching.mock.calls.length).toBe(1);
+    expect((metadata.updateRepository as any).mock.calls.length).toBe(0);
+  });
+
+  it("startWatching rejects non-local-folder sources", async () => {
+    const repo = makeRepo("delta", { source: "git-remote", url: "https://x" });
+    const metadata = makeMetadata([repo]);
+    const manager = makeWatchManager();
+
+    const coordinator = new LocalFolderUpdateCoordinator(
+      metadata,
+      {} as any,
+      undefined,
+      undefined,
+      {},
+      manager
+    );
+
+    await expect(coordinator.startWatching(repo)).rejects.toThrow(/local-folder/);
+    expect(manager.startWatching.mock.calls.length).toBe(0);
+  });
+
+  it("stopWatching delegates and persists watchEnabled=false", async () => {
+    const repo = makeRepo("epsilon", { watchEnabled: true });
+    const metadata = makeMetadata([repo]);
+    const manager = makeWatchManager();
+
+    const coordinator = new LocalFolderUpdateCoordinator(
+      metadata,
+      {} as any,
+      undefined,
+      undefined,
+      {},
+      manager
+    );
+
+    await coordinator.stopWatching("epsilon");
+
+    expect(manager.stopWatching.mock.calls.length).toBe(1);
+    expect(metadata.store.get("epsilon")?.watchEnabled).toBe(false);
+  });
+
+  it("stopWatching is idempotent for unknown repositories", async () => {
+    const metadata = makeMetadata([]);
+    const manager = makeWatchManager();
+
+    const coordinator = new LocalFolderUpdateCoordinator(
+      metadata,
+      {} as any,
+      undefined,
+      undefined,
+      {},
+      manager
+    );
+
+    await expect(coordinator.stopWatching("never-registered")).resolves.toBeUndefined();
+    expect(manager.stopWatching.mock.calls.length).toBe(1);
+    // No metadata write because the repo doesn't exist.
+    expect((metadata.updateRepository as any).mock.calls.length).toBe(0);
+  });
+});

--- a/tests/unit/utils/path-utils.test.ts
+++ b/tests/unit/utils/path-utils.test.ts
@@ -3,7 +3,8 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { isLocalPath } from "../../../src/utils/path-utils.js";
+import { resolve, normalize } from "node:path";
+import { isLocalPath, canonicalizePathForComparison } from "../../../src/utils/path-utils.js";
 
 describe("isLocalPath", () => {
   it("should detect Windows absolute paths", () => {
@@ -41,5 +42,35 @@ describe("isLocalPath", () => {
   it("should handle paths with leading/trailing whitespace", () => {
     expect(isLocalPath("  C:\\src\\repo  ")).toBe(true);
     expect(isLocalPath("  /home/user/repo  ")).toBe(true);
+  });
+});
+
+describe("canonicalizePathForComparison", () => {
+  it("collapses redundant segments and resolves to absolute", () => {
+    const noisy = "./a/b/../c/./d";
+    const canonical = canonicalizePathForComparison(noisy);
+    expect(canonical).toBe(
+      process.platform === "win32"
+        ? normalize(resolve(noisy)).toLowerCase()
+        : normalize(resolve(noisy))
+    );
+  });
+
+  it("returns the same string for two equivalent representations of the same path", () => {
+    const a = canonicalizePathForComparison("./foo/bar");
+    const b = canonicalizePathForComparison("./foo/./bar");
+    const c = canonicalizePathForComparison("./foo/baz/../bar");
+    expect(a).toBe(b);
+    expect(a).toBe(c);
+  });
+
+  it("treats case-different paths as equal on Windows and unequal on POSIX", () => {
+    const upper = canonicalizePathForComparison("/Users/Foo/Bar");
+    const lower = canonicalizePathForComparison("/users/foo/bar");
+    if (process.platform === "win32") {
+      expect(upper).toBe(lower);
+    } else {
+      expect(upper).not.toBe(lower);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Closes the third of five Local-Folder-as-Repository phases. Wires the
user-facing surface for local-folder repos: CLI auto-detect, a new
`register_local_folder` MCP tool, and a filesystem watcher that re-indexes
on file changes — coexisting with Phase 6's `WatchedFolder` chokidar fleet
through a single shared `FolderEventRouter`.

Fixes #566. Depends on #564 (Phase A) and #565 (Phase B), both merged.

## What's in here

**Foundation** (commit 1):
- `canonicalizePathForComparison` — cross-platform path equality (lowercased on Windows)
- `LocalFolderPathAlreadyRegisteredError` — typed error carrying the existing registration's name
- Duplicate-absolute-path check in `IngestionService.indexRepository`, T4.2
- `watchEnabled` / `followSymlinks` / `watchDebounceMs` on `RepositoryInfo`; `watch` / `followSymlinks` on `IndexOptions`

**Registration surface** (commit 2 — T4.1, T4.3, T4.4):
- CLI: `cli index` auto-detects local-folder vs git URL; new `--tier`, `--watch`/`--no-watch`, `--follow-symlinks` flags
- MCP: new `register_local_folder` tool with sync + async modes (async via the existing `JobTracker`)
- Conditional registration in `createToolRegistry` based on `IngestionService` injection
- `LocalFolderUpdateCoordinator.startWatching/stopWatching` with pluggable `LocalFolderWatchManager`

**Watcher** (commit 3 — T5.1, T5.2, T5.3, T5.4):
- `FolderEventRouter` — routes `local-folder:<name>` events through a per-repo debouncer (default 2000ms); Phase 6 events untouched
- `LocalFolderRepoWatchManager` — synthetic `WatchedFolder` shape with the `local-folder:` id prefix; default-deny symlink policy with opt-in `--follow-symlinks` capped at depth 8; TOCTOU-aware `realpath` validation
- FolderWatcherService gains optional `followSymlinks?` / `depthCap?` (Phase 6 unchanged when omitted)
- Server bootstrap: hoists local-folder coordinator out of the GITHUB_PAT gate (folder users no longer need a PAT) and adds a sibling restoration loop for `watchEnabled === true` repos
- Pre-shutdown hook cancels pending debounce timers before stopping the watcher fleet

## Acceptance criteria mapping (from issue body)

- ✅ CLI test: `cli index /path/to/non-git-folder` registers as local-folder, scans, confirms via `cli status` — covered by `tests/cli/commands/index-command-phase-c.test.ts` + Phase B's `cli status` already enumerates all sources
- ✅ Contract test: `register_local_folder` appears in the registry and returns a job ID — `tests/mcp/tools/register-local-folder.test.ts`
- ✅ Integration test (debounce): per-repo debounce coalesces bursts into a single dispatch — `tests/services/folder-event-router.test.ts`
- ✅ Phase 6 watcher tests continue to pass: `bun test tests/services/folder-watcher-service.test.ts tests/integration/services/folder-watcher-service.integration.test.ts` → 12/12 pass after the refactor
- ✅ Server-restart watcher persistence: bootstrap restoration loop reads `RepositoryInfo.watchEnabled === true` and re-attaches the watcher; coordinator persistence verified by `tests/services/local-folder-update-coordinator-watch-lifecycle.test.ts`
- ✅ Symlink policy: default-deny + `--follow-symlinks` opt-in with depth cap 8 + out-of-folder rejection (TOCTOU via `realpath`) — `tests/services/local-folder-repo-watch-manager.test.ts`
- ✅ Path-collision: registering the same absolute path under a different name throws `LocalFolderPathAlreadyRegisteredError` with the existing repo name — `tests/services/ingestion-service-duplicate-path.test.ts`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test tests/services` → 285/285 pass
- [x] `bun test tests/unit` → 3389/3389 pass
- [x] `bun test tests/cli` → 496 pass, 1 pre-existing sharp DLL load flake on Windows (passes in isolation; unrelated to this PR)
- [x] `bun test tests/mcp` → 415/415 pass
- [x] `bun test tests/integration` → 464 pass / 123 skipped (no failures)
- [x] `bun run build` → clean (index.js 7.29MB, cli.js 5.77MB)

## Size note

This PR is **~2,457 insertions across 25 files** — exceeds the 400-LoC
project guideline. The combined scope is intentional and called out in the
issue body's "Why combined" section: the `register_local_folder` surface
is meaningless without the watcher, and `FolderEventRouter` only earns its
keep once two folder-shaped concepts coexist. Splitting would create
mid-flight wiring that doesn't compile cleanly on its own.

The work is staged across **3 atomic commits** (foundation → registration → watcher),
each with green tests + typecheck + build, so review can proceed commit-by-commit if preferred.

## Breaking changes / migration

None observable. Existing repos without `watchEnabled` default to false — no surprise watcher activation. Phase 6 watched folders are untouched.

## Out of scope

- Phase D (drift detection / conflict UX) — separate issue
- Phase E (CI matrix, perf benchmarks) — separate issue
- Per-repo debounce tuning beyond the default + per-repo override
- A user-facing `disable-watch` CLI verb (toggling `watchEnabled` on an existing repo) — covered for now via re-registration with `--no-watch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)