### PR TITLE
docs(#568): Phase E — ADR-0009 + README + CLI/MCP help polish for local-folder repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,18 @@ Personal Knowledge MCP provides a comprehensive suite of AI-powered code intelli
 | **Token Authentication** | Secure API access with scoped tokens | Complete |
 | **Rate Limiting** | Configurable per-minute/per-hour limits | Complete |
 | **OIDC Framework** | Microsoft Entra ID, Auth0, Okta support | Framework Ready |
+| **Local Folder as Repository** | Index any local folder as a first-class repository (code + docs + graph) | Complete |
+| **Document Graph Extraction** | Markdown links, headings, and `[[wikilinks]]` participate in the knowledge graph | Complete |
+
+### Supported Repository Sources
+
+Repositories can be registered from three different source types. All three are first-class at the MCP tool layer — `list_indexed_repositories`, `semantic_search`, and the graph tools (`get_dependencies`, `get_dependents`, `get_architecture`, `find_path`, `get_graph_metrics`) work identically across them.
+
+| Source | `RepositoryInfo.source` | How to register | Notes |
+|--------|------------------------|-----------------|-------|
+| GitHub / git remote | `git-remote` | `pk-mcp index <git-url>` | Cloned to `./data/repositories/` and refreshed via the GitHub Compare API. |
+| Local git checkout | `local-git` | `pk-mcp index <local-path>` (auto-detected when the path contains a `.git` dir) | Uses the existing local checkout; `git pull` drives incremental updates. |
+| Local folder (no git) | `local-folder` | `pk-mcp index <local-path>` or the `register_local_folder` MCP tool | Per-repo manifest tracks `mtime`/`size`/SHA-256 for change detection. `tier='public'` is refused. See [ADR-0009](docs/architecture/adr/0009-local-folder-as-repository.md). |
 
 ### When to Use What
 
@@ -41,6 +53,7 @@ Personal Knowledge MCP provides a comprehensive suite of AI-powered code intelli
 | Understand structure | `get_architecture` | "Show me the module organization" |
 | Trace execution flow | `find_path` | "How does login connect to database?" |
 | Repository health | `get_graph_metrics` | "Show dependency statistics" |
+| Register a local folder as a repo | `register_local_folder` | Index `D:\notes` as a `local-folder` source with the watcher enabled |
 
 ### Key Features
 
@@ -52,6 +65,7 @@ Personal Knowledge MCP provides a comprehensive suite of AI-powered code intelli
 - **Flexible Embedding Providers**: OpenAI (highest quality), Transformers.js (zero-config local), Ollama (GPU acceleration)
 - **Multi-Transport Support**: stdio for Claude Code, HTTP/SSE for Cursor and VS Code
 - **Local-First Deployment**: Runs entirely on localhost with Docker Compose
+- **Local Folder as Repository**: Register a local folder as a first-class repository — same MCP tools, same lifecycle, no git remote required
 
 ## Use Cases
 
@@ -683,6 +697,34 @@ Check the status of an async incremental update job.
 
 **Note**: Jobs are automatically cleaned up after 1 hour.
 
+### register_local_folder
+
+Register a local filesystem folder as a `local-folder` repository. The folder is scanned, embeddings are generated, and (by default) a filesystem watcher is started so the index re-syncs as files change. See [ADR-0009](docs/architecture/adr/0009-local-folder-as-repository.md) for the design rationale.
+
+**Parameters**:
+- `path` (string, required): Absolute or relative path to the folder to register
+- `name` (string, optional): Repository display name. Defaults to the basename of the resolved path
+- `tier` (string, optional): Security tier — `"private"` (default) or `"work"`. `"public"` is **refused** for local folders
+- `force` (boolean, optional): Re-register even if a repo with the same name or absolute path is already registered (default: `false`)
+- `watch` (boolean, optional): Start the filesystem watcher after the initial scan (default: `true`)
+- `followSymlinks` (boolean, optional): Follow filesystem symlinks inside the folder. Out-of-folder targets are rejected even when this is `true` (default: `false`)
+- `async` (boolean, optional): If `true`, return a job ID immediately and run registration in the background. Poll `get_update_status` with the `job_id` (default: `false`)
+
+**Example**:
+```json
+{
+  "path": "D:\\notes",
+  "name": "research-notes",
+  "tier": "private",
+  "watch": true
+}
+```
+
+**Notes**:
+- The registered folder appears in `list_indexed_repositories` with `source: "local-folder"` and the absolute path.
+- All graph and search MCP tools accept the registered name as a `repository` filter.
+- Markdown files participate in the document graph (headings, links, `[[wikilinks]]`); PDF/DOCX participate at lower fidelity (edges carry a `confidence` attribute).
+
 ## Embedding Providers
 
 Personal Knowledge MCP is designed to work **fully offline** with local embedding providers. No external API keys are required.
@@ -751,24 +793,27 @@ pk-mcp --help
 
 ### Commands
 
-#### index - Index a Repository
+#### index - Index a Repository or Local Folder
 
-Clone and index a repository for semantic search.
+Index a git repository **or** a local folder for semantic search. The first argument is auto-detected: a git URL is cloned, an absolute or relative filesystem path is registered as a local folder. A local path that contains a `.git` directory is registered as a `local-git` source; otherwise it is registered as `local-folder`.
 
 ```bash
-pk-mcp index <repository-url> [options]
+pk-mcp index <url-or-path> [options]
 ```
 
 **Options:**
-- `-n, --name <name>` - Custom repository name (defaults to repo name from URL)
-- `-b, --branch <branch>` - Branch to clone (defaults to repository default branch)
-- `-f, --force` - Force reindexing if repository already exists
+- `-n, --name <name>` - Custom repository name (defaults to repo name from URL or basename of the path)
+- `-b, --branch <branch>` - Branch to clone (git only; ignored for local folders)
+- `-f, --force` - Force reindexing if a repository with this name or path is already registered
 - `--provider <provider>` - Embedding provider (openai, transformersjs, ollama)
+- `--tier <tier>` - Security tier: `private` | `work` | `public`. Local folders default to `private`; `public` is **refused** for local folders
+- `--watch` / `--no-watch` - Enable / disable the filesystem watcher for a local folder (default: enabled)
+- `--follow-symlinks` - Follow filesystem symlinks inside a local folder. Out-of-folder targets are rejected even when set (default: skip)
 
 **Examples:**
 
 ```bash
-# Index a public repository
+# Index a public git repository
 pk-mcp index https://github.com/user/my-project.git
 
 # Index with custom name and specific branch
@@ -776,7 +821,15 @@ pk-mcp index https://github.com/user/repo.git --name my-repo --branch develop
 
 # Reindex an existing repository
 pk-mcp index https://github.com/user/repo.git --force
+
+# Register a local folder as a repository (auto-detected from the path)
+pk-mcp index D:\notes --name research-notes --tier private
+
+# Register a local folder without starting the filesystem watcher
+pk-mcp index ./scratch-project --no-watch
 ```
+
+> See [ADR-0009](docs/architecture/adr/0009-local-folder-as-repository.md) for the design rationale behind the `local-folder` source type and how it relates to Phase 6 WatchedFolders.
 
 #### search - Semantic Search
 
@@ -1151,33 +1204,33 @@ Development workflow:
 
 ## Code Statistics
 
-Generated with [cloc](https://github.com/AlDanial/cloc) v2.06 (excluding node_modules, dist, .bun-cache, coverage, data):
-
 | Language | Files | Blank | Comment | Code |
 |:---------|------:|------:|--------:|-----:|
-| TypeScript | 500 | 27,034 | 45,373 | 122,663 |
-| Markdown | 72 | 9,422 | 9 | 29,588 |
-| YAML | 68 | 332 | 588 | 3,185 |
-| JSON | 14 | 5 | 0 | 2,548 |
-| Bourne Shell | 10 | 479 | 527 | 1,958 |
+| TypeScript | 536 | 28,099 | 47,525 | 130,407 |
+| Markdown | 82 | 10,478 | 9 | 32,928 |
+| YAML | 68 | 332 | 597 | 3,185 |
+| Bourne Shell | 7 | 471 | 526 | 1,934 |
 | PowerShell | 4 | 399 | 281 | 1,232 |
-| C# | 9 | 219 | 315 | 1,022 |
+| C# | 6 | 219 | 312 | 1,009 |
+| JSON | 8 | 5 | 0 | 743 |
 | Go | 1 | 38 | 40 | 154 |
 | Rust | 1 | 42 | 47 | 150 |
 | Java | 3 | 28 | 58 | 104 |
 | SQL | 4 | 77 | 213 | 94 |
-| Text | 3 | 31 | 0 | 91 |
 | PHP | 1 | 22 | 70 | 87 |
 | C++ | 1 | 22 | 15 | 65 |
 | Python | 5 | 44 | 59 | 59 |
-| INI | 2 | 0 | 0 | 50 |
+| Text | 1 | 31 | 0 | 40 |
 | C | 1 | 12 | 20 | 38 |
 | Dockerfile | 1 | 22 | 38 | 36 |
 | Ruby | 1 | 10 | 20 | 35 |
 | JavaScript | 2 | 7 | 9 | 33 |
-| XML | 2 | 0 | 0 | 27 |
+| Visual Studio Solution | 1 | 0 | 1 | 31 |
 | TOML | 1 | 12 | 20 | 15 |
-| **SUM** | **710** | **38,268** | **47,721** | **163,297** |
+| MSBuild script | 1 | 3 | 0 | 14 |
+| **SUM** | **736** | **40,373** | **49,860** | **172,393** |
+
+*Generated with `cloc --vcs=git --md .` against `main @ 086043d` on 2026-05-06.*
 
 ## License
 

--- a/docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md
+++ b/docs/architecture/Local-Folder-As-Repository-Implementation-Plan.md
@@ -4,7 +4,7 @@
 **Date:** 2026-05-04
 **Owner:** Architecture
 **Related PRD:** `docs/pm/Phase6-Document-Ingestion-PRD.md` (Phase 6 — parallel WatchedFolder concept)
-**Related ADR (to author):** `docs/architecture/adr/0007-local-folder-as-repository.md`
+**Related ADR:** [`docs/architecture/adr/0009-local-folder-as-repository.md`](./adr/0009-local-folder-as-repository.md)
 
 ---
 

--- a/docs/architecture/adr/0009-local-folder-as-repository.md
+++ b/docs/architecture/adr/0009-local-folder-as-repository.md
@@ -113,7 +113,7 @@ The following sub-decisions are recorded as part of this ADR:
 
 - `--follow-symlinks` defaults to **off**. Out-of-folder targets are rejected even when the flag is set, to prevent accidental escape from the registered tree.
 
-## Positive Consequences
+### Positive Consequences
 
 - A local folder is indistinguishable from a git-cloned repository at the MCP tool layer.
 - Existing tests and operational tooling apply unchanged to local-folder repositories.
@@ -121,13 +121,13 @@ The following sub-decisions are recorded as part of this ADR:
 - `chokidar` watcher infrastructure and `IncrementalUpdatePipeline` are reused, not re-implemented.
 - The `back-compat read path` keeps existing installations working without a one-shot upgrade dance.
 
-## Negative Consequences
+### Negative Consequences
 
 - `IngestionService` grows a top-level `switch (source)` and a small set of source-shaped seams. Each future source type compounds this, modestly.
 - Two folder concepts (WatchedFolder and `local-folder` repo source) coexist. Documentation and `--help` text must keep their distinction crisp; the `FolderEventRouter` is the only piece of code that bridges them.
 - Manifests are host-local. A user who restores a backup on a different machine gets a fresh manifest and a full re-scan on first update. ADR-0008 addresses registry-level portability; per-folder manifest portability is deferred.
 
-## Risks and Mitigations
+### Risks and Mitigations
 
 | Risk | Mitigation |
 |------|------------|

--- a/docs/architecture/adr/0009-local-folder-as-repository.md
+++ b/docs/architecture/adr/0009-local-folder-as-repository.md
@@ -1,0 +1,187 @@
+# ADR-0009: Local Folder as First-Class Repository Source
+
+**Status:** Accepted
+
+**Date:** 2026-05-06
+
+**Deciders:** Architecture Team
+
+**Technical Story:** Implements the [Local Folder as Repository PRD](../../pm/Local-Folder-As-Repository-PRD.md) and the [Implementation Plan](../Local-Folder-As-Repository-Implementation-Plan.md). Tracking issues: #564 (Phase A — data model), #565 (Phase B — lifecycle), #566 (Phase C — user-facing surface), #567 (Phase D — document graph), #568 (this ADR + polish).
+
+## Context and Problem Statement
+
+Before this work, "repository" in Personal Knowledge MCP implicitly meant *a cloned git remote*. Users with a local working tree they had not pushed (a scratch project, a private monorepo checkout, an Obsidian vault, a folder of mixed code and documentation) could not achieve parity with the git-cloned experience.
+
+Phase 6 introduced a parallel concept — **WatchedFolder** — that intentionally targets unstructured documents (`.md`/`.txt`/`.pdf`/`.docx`) and is exposed via a separate `list_watched_folders` MCP surface. WatchedFolders are docs-only and do not flow through the AST/graph pipeline. The result was a **two-class citizen problem**: a local folder was either treated as documents-only or it had to be promoted to a git remote.
+
+We needed an abstraction that registers a local folder as a first-class repository in the existing repository registry, indistinguishable from a git-cloned repository at the MCP tool layer, while coexisting with both git-sourced repositories and Phase 6 WatchedFolders without replacing either.
+
+## Decision Drivers
+
+- **MCP-layer parity.** A registered local folder must appear in `list_indexed_repositories`, be searchable via `semantic_search` and `search_documents`, and be exposed to all graph tools (`get_dependencies`, `get_dependents`, `get_architecture`, `find_path`, `get_graph_metrics`) — identically to a git-sourced repository.
+- **Mixed-content support.** A single registered folder may contain source code, documentation, PDFs, and other indexable artifacts. Each file must be routed to the appropriate ingestion pipeline.
+- **Pipeline reuse.** The existing `IncrementalUpdatePipeline.processChanges()` contract already accepts `FileChange[]` and is agnostic to how the diff was produced. Reusing it keeps the new source type cheap.
+- **Watcher reuse.** Phase 6's `chokidar`-based filesystem watcher infrastructure should service both WatchedFolders and local-folder repositories.
+- **Instance-tier safety.** The `public` tier exposes content to unauthenticated readers. Allowing arbitrary local-folder content into `public` would make accidental leakage one CLI flag away.
+- **No migration burden on Phase 6 users.** Existing WatchedFolder entries must continue to work unchanged.
+- **Back-compat with existing `repositories.json`.** Installations that pre-date this work have no `source` field on any entry; they must continue to load and behave as git-cloned repositories.
+- **Minimal refactor.** We are one person with one codebase; a sprawling abstraction layer competes with future feature work.
+
+## Considered Options
+
+### Option A: Promote `WatchedFolder` into a full repository
+
+**Description:** Reuse the Phase 6 `WatchedFolder` concept as the substrate for local-folder repositories. Extend it to support the AST/graph pipeline.
+
+**Pros:**
+- Single concept to teach users.
+- No new top-level type to introduce.
+
+**Cons:**
+- Couples a deliberately-scoped docs-only path to the full code+graph machinery. Phase 6 chose its scope for a reason; widening it is a regression in clarity.
+- Forces every existing WatchedFolder consumer (`list_watched_folders`, `search_documents`) to handle the broader concern.
+- Migration of existing WatchedFolder entries is not free — we either grandfather them or break callers.
+
+### Option B: Parallel `local-folder` source with its own pipeline
+
+**Description:** Add `source: "local-folder"` to `RepositoryInfo` but build a parallel ingestion pipeline that bypasses the existing `IncrementalUpdatePipeline.processChanges()`.
+
+**Pros:**
+- Clean separation; no branching inside the existing pipeline.
+
+**Cons:**
+- Diverges from the `IncrementalUpdatePipeline` contract. Every future improvement to incremental updates would have to be back-ported.
+- Re-implements change detection, chunking, embedding upserts, and graph deltas.
+- Two near-identical pipelines is exactly the maintenance trap we are trying to avoid.
+
+### Option C (chosen): `local-folder` as a `RepositoryInfo.source` discriminator with branching at the source-shaped seams
+
+**Description:** Add `source: "local-folder"` to the existing `RepositoryInfo` discriminator (`"git-remote" | "local-git" | "local-folder"`). The `IngestionService` branches on `source` only at the points where the source genuinely differs (clone vs. no-clone, git-revparse vs. file-manifest), and otherwise feeds the existing `FileScanner → FileChunker/DocumentChunker → ChromaDB + GraphIngestionService` flow. Change detection for non-git sources is provided by a small new `LocalFolderChangeDetector` that emits the same `FileChange[]` shape consumed by `IncrementalUpdatePipeline.processChanges()`.
+
+**Pros:**
+- Full MCP parity at the boundary; existing tools are untouched.
+- The blast radius of the change is contained to the genuinely-different seams.
+- Existing tests, utilities, and operational tooling apply unchanged.
+- Forward-compatible: future source types (e.g., archive-on-disk) can add another discriminator value.
+
+**Cons:**
+- `IngestionService` grows a `switch (source)` at the top.
+- Two folder concepts now coexist in the system: `WatchedFolder` (Phase 6, docs-only) and `RepositoryInfo where source="local-folder"`. Mitigated by clear naming and by the `FolderEventRouter` dispatching by lookup, not inheritance.
+
+## Decision Outcome
+
+**Chosen option:** Option C — add `local-folder` as a `RepositoryInfo.source` discriminator and branch only at the source-shaped seams.
+
+The following sub-decisions are recorded as part of this ADR:
+
+### Source discriminator and back-compat
+
+- `RepositoryInfo.source` is `"git-remote" | "local-git" | "local-folder"`. See `src/mcp/tools/list-indexed-repositories.ts` and `src/repositories/metadata-store.ts` for the canonical definition.
+- On read, an entry without a `source` field is synthesized as `source = "git-remote"`. This is implemented in `src/repositories/metadata-store.ts` (back-compat read path around line 456). Existing installations therefore upgrade in place with no `repositories.json` rewrite required.
+- `url` is required for git-sourced repositories; `null` is permitted only when `source === "local-folder"`.
+
+### Manifest design
+
+- Each local-folder repository owns a per-repo `manifest.json` keyed by relative path. Each entry records `mtime`, `size`, and a SHA-256 content hash.
+- Change detection uses a fast-path comparison: when the new `(mtime, size)` pair matches the manifest entry, the file is presumed unchanged. The SHA-256 is computed only as a tie-breaker when `mtime` or `size` differs, or when the user requests a forced re-scan.
+- The manifest is host-local. Cross-machine portability is explicitly deferred (see ADR-0008, which addresses portability for the registry-level path model only).
+
+### Document graph scope
+
+- Markdown gets full-fidelity extraction: headings, internal links, Obsidian-style `[[wikilinks]]`, and file-to-file mentions. Extraction lives in `src/graph/extraction/DocEntityExtractor.ts` and is invoked by `GraphIngestionService` for any document file regardless of repository source.
+- PDF and DOCX get low-fidelity extraction. Edges produced from these sources carry a `confidence` attribute so that graph-tool consumers can filter or weight them.
+- Code retains AST-level precision via the existing `CodeEntityExtractor`. The graph schema is unchanged for code.
+
+### `FolderEventRouter` shared component
+
+- A single new component, `src/services/folder-event-router.ts`, dispatches filesystem events from the shared `chokidar` infrastructure to either:
+  - `FolderDocumentIndexingService` (Phase 6, when the folder ID resolves to a `WatchedFolder`), or
+  - `LocalFolderUpdateCoordinator` (when the folder path resolves to a `RepositoryInfo` with `source = "local-folder"`).
+- The router dispatches **by lookup**, not by inheritance. `WatchedFolder` and the `local-folder` repo source remain intentionally separate concepts; the router is the only place that knows about both.
+
+### Tier handling: `public` is refused for local-folder sources
+
+- Registration with `tier = "public"` for a local folder returns a clear error directing the user to `private` or `work`.
+- This is enforced at both the CLI (`src/cli/index.ts` `index` command) and the MCP tool (`src/mcp/tools/register-local-folder.ts`). The MCP tool's input schema accepts only `"private" | "work"`; the CLI accepts the string and rejects it downstream so that the user receives a uniform error message.
+- Rationale: the `public` tier serves unauthenticated readers. Local content is by definition unvetted; moving it into `public` should be a deliberate, documented act, not the side effect of a registration flag.
+
+### Watcher default
+
+- `--watch` defaults to **enabled** for local-folder registrations. `--no-watch` disables it. Rationale: the primary motivation for registering a local folder is live editing; the surprising default would be to *not* re-index on save. Users who want a snapshot-only registration can pass `--no-watch`.
+
+### Symlink default
+
+- `--follow-symlinks` defaults to **off**. Out-of-folder targets are rejected even when the flag is set, to prevent accidental escape from the registered tree.
+
+## Positive Consequences
+
+- A local folder is indistinguishable from a git-cloned repository at the MCP tool layer.
+- Existing tests and operational tooling apply unchanged to local-folder repositories.
+- Phase 6 WatchedFolder users are unaffected; no migration is required.
+- `chokidar` watcher infrastructure and `IncrementalUpdatePipeline` are reused, not re-implemented.
+- The `back-compat read path` keeps existing installations working without a one-shot upgrade dance.
+
+## Negative Consequences
+
+- `IngestionService` grows a top-level `switch (source)` and a small set of source-shaped seams. Each future source type compounds this, modestly.
+- Two folder concepts (WatchedFolder and `local-folder` repo source) coexist. Documentation and `--help` text must keep their distinction crisp; the `FolderEventRouter` is the only piece of code that bridges them.
+- Manifests are host-local. A user who restores a backup on a different machine gets a fresh manifest and a full re-scan on first update. ADR-0008 addresses registry-level portability; per-folder manifest portability is deferred.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| User accidentally registers a huge tree (`$HOME`, a system root) and exhausts disk / embeddings quota. | Soft and hard size guardrails at registration time; documented in the PRD and surfaced in the CLI/MCP help text. |
+| Drift when a registered folder is moved or deleted. | Existing `drift_detected` status path is reused; the `LocalFolderChangeDetector` raises drift through the same channel as git sources. |
+| Confusion between WatchedFolder and `local-folder` repo source. | `--help` text on `index` and on `register_local_folder` explicitly contrasts the two; this ADR is linked from both docs. |
+| Doc-graph edges from low-fidelity extractors (PDF/DOCX) get treated as authoritative. | `confidence` attribute on edges; consumers filter or weight as needed. |
+| Cross-OS path handling on the manifest. | Paths are stored as repo-relative POSIX strings inside the manifest; the consumer rejoins with the host's `path.sep`. |
+
+## Implementation Notes
+
+| Concern | Component | File |
+|---|---|---|
+| Per-file content fingerprint store | `FileManifestStore` | `src/services/file-manifest-store.ts` |
+| Non-git change detection | `LocalFolderChangeDetector` | `src/services/local-folder-change-detector.ts` |
+| Update orchestration for `local-folder` repos | `LocalFolderUpdateCoordinator` | `src/services/local-folder-update-coordinator.ts` |
+| Routing watcher events | `FolderEventRouter` | `src/services/folder-event-router.ts` |
+| Markdown / doc graph extraction | `DocEntityExtractor` | `src/graph/extraction/DocEntityExtractor.ts` |
+| `.gitignore` honoring during scan | `GitignoreFilter` | `src/ingestion/gitignore-filter.ts` |
+| MCP tool to register a folder | `register_local_folder` | `src/mcp/tools/register-local-folder.ts` |
+
+What does NOT change:
+
+- ChromaDB collection naming (`repo_<sanitized_name>` for repos, `folder_<id>` for Phase 6 WatchedFolders — kept distinct).
+- The `IncrementalUpdatePipeline.processChanges()` contract.
+- All graph MCP tools (`get_dependencies`, `get_dependents`, `get_architecture`, `find_path`, `get_graph_metrics`).
+- All search MCP tools (`semantic_search`, `search_documents`, `search_images`).
+- Phase 6 `WatchedFolder` and `FolderDocumentIndexingService`.
+
+## What Was Deferred and Why
+
+- **Cross-machine portability of a local-folder repository's index.** Indexes are host-local. The manifest's `mtime` semantics differ across filesystems and a backup-on-Windows / restore-on-Linux flow would force a full re-scan anyway. ADR-0008 addresses registry-level path portability; per-folder manifest portability is a separate, larger problem.
+- **Cross-repo linking.** A wikilink that points outside the registered folder does not produce a graph edge to a different repository. Cross-repo linking would require a global symbol table, which is outside V1 scope.
+- **`.pkmignore`.** Users supply include/exclude globs at registration time, and `.gitignore` at the folder root is honored automatically. A dedicated `.pkmignore` is deferred until there is concrete demand.
+- **Retroactive doc-graph for existing `WatchedFolder` entries.** No migration is provided. A user who wants graph tools on their notes registers the folder as a `local-folder` repository instead of (or in addition to) a `WatchedFolder`. Doc-graph extraction is a forward-compatible capability that `WatchedFolder` may adopt later.
+- **Cloud / network-share folder sources** (OneDrive, Google Drive, SMB shares) and **two-way sync** to the source folder.
+
+## Links
+
+- [Local Folder as Repository PRD](../../pm/Local-Folder-As-Repository-PRD.md)
+- [Implementation Plan](../Local-Folder-As-Repository-Implementation-Plan.md)
+- [Phase 6 Document Ingestion PRD](../../pm/Phase6-Document-Ingestion-PRD.md) (parallel WatchedFolder concept)
+- [ADR-0001](./0001-incremental-update-trigger-strategy.md) — incremental update trigger strategy
+- [ADR-0004](./0004-graph-database-migration-neo4j-to-falkordb.md) — graph DB migration to FalkorDB
+- [ADR-0007](./0007-cross-store-consistency-model.md) — cross-store consistency between Chroma and FalkorDB
+- [ADR-0008](./0008-repositories-json-path-model.md) — `repositories.json` path model for cross-OS migration
+
+## Validation Criteria
+
+This ADR is validated when, against the merged main:
+
+- `pk-mcp index <local-path>` registers the folder, scans it, and emits embeddings + graph entities.
+- `list_indexed_repositories` returns the folder with `source: "local-folder"` and the absolute path.
+- `semantic_search`, `get_dependencies`, `get_dependents`, `get_architecture`, `find_path`, and `get_graph_metrics` all accept the local-folder repository name as a `repository` filter and behave identically to a git-sourced repository.
+- Editing a file inside a watched folder triggers an incremental update without manual intervention.
+- `pk-mcp index <path> --tier public` returns the documented refusal error.
+- An existing `repositories.json` from before this work loads cleanly and its entries report `source: "git-remote"` via the back-compat read path.

--- a/docs/feature-summary.md
+++ b/docs/feature-summary.md
@@ -23,6 +23,7 @@ Personal Knowledge MCP provides a comprehensive AI-first knowledge management se
 | `get_graph_metrics` Tool | Complete | Repository health statistics |
 | `trigger_incremental_update` Tool | Complete | Update repository index after changes |
 | `get_update_status` Tool | Complete | Track async update job status |
+| `register_local_folder` Tool | Complete | Register a local folder as a first-class repository (see [ADR-0009](architecture/adr/0009-local-folder-as-repository.md)) |
 | Rate Limiting | Complete | Configurable per-minute/per-hour limits |
 | CORS Support | Complete | Browser client compatibility |
 | Error Handling | Complete | MCP-compliant error responses |
@@ -31,7 +32,7 @@ Personal Knowledge MCP provides a comprehensive AI-first knowledge management se
 
 | Command | Status | Description |
 |---------|--------|-------------|
-| `index <url>` | Complete | Index a GitHub repository |
+| `index <url-or-path>` | Complete | Index a git repository **or** a local folder (auto-detected). Flags: `--name`, `--branch`, `--force`, `--provider`, `--tier`, `--watch` / `--no-watch`, `--follow-symlinks` |
 | `search <query>` | Complete | Search indexed repositories |
 | `status` | Complete | List repositories and their status |
 | `remove <name>` | Complete | Remove repository from index |
@@ -105,6 +106,23 @@ Personal Knowledge MCP provides a comprehensive AI-first knowledge management se
 | Graph MCP Tools | Complete | 5 tools for dependency analysis |
 | Incremental Graph Updates | Complete | Integrated with update pipeline |
 | Graph Query Metrics | Complete | Performance monitoring |
+
+### Local Folder as Repository
+
+A local folder can be registered as a first-class repository. It is indistinguishable from a git-cloned repository at the MCP tool layer. See [ADR-0009](architecture/adr/0009-local-folder-as-repository.md) for the design rationale.
+
+| Feature | Status | Description |
+|---------|--------|-------------|
+| `local-folder` Source Type | Complete | New `RepositoryInfo.source` discriminator alongside `git-remote` and `local-git` |
+| `register_local_folder` MCP Tool | Complete | Register a folder, scan it, and (by default) start the filesystem watcher |
+| CLI Auto-Detection | Complete | `pk-mcp index <path>` auto-detects local paths vs. git URLs (paths with a `.git` dir become `local-git`) |
+| Per-Repo File Manifest | Complete | Tracks `mtime` / `size` / SHA-256 for fast non-git change detection |
+| Filesystem Watcher | Complete | `chokidar`-based watcher; default `--watch=true`, opt-out via `--no-watch` |
+| Document Graph Extraction | Complete | Markdown headings, links, and `[[wikilinks]]` participate in the graph; PDF/DOCX at lower fidelity |
+| `.gitignore` Honored | Complete | When a `.gitignore` is present at the folder root |
+| `tier='public'` Refused | Complete | Local folders accept `private` or `work` only; `public` returns a clear error |
+| Symlink Handling | Complete | `--follow-symlinks` opt-in; out-of-folder targets always rejected |
+| `FolderEventRouter` | Complete | Routes filesystem events to either a Phase 6 `WatchedFolder` or a `local-folder` repo |
 
 ## Performance Targets
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -113,21 +113,37 @@ program
 // Index command
 program
   .command("index")
-  .description("Index a git repository OR a local folder (auto-detected) for semantic search")
-  .argument("<url>", "Git URL or absolute / relative local folder path")
-  .option("-n, --name <name>", "Custom repository name")
-  .option("-b, --branch <branch>", "Branch to clone (git only)")
-  .option("-f, --force", "Force reindexing if repository already exists")
+  .description(
+    "Index a git repository or a local folder for semantic + graph search. " +
+      "The argument is auto-detected: a git URL is cloned; a filesystem path is registered as " +
+      "'local-git' (when it contains a .git directory) or 'local-folder' (otherwise)."
+  )
+  .argument(
+    "<url>",
+    "Git URL (e.g. https://github.com/user/repo.git) OR an absolute or relative local folder path"
+  )
+  .option(
+    "-n, --name <name>",
+    "Repository display name. Defaults to the repo name from the URL or the basename of the path"
+  )
+  .option("-b, --branch <branch>", "Branch to clone (git remotes only; ignored for local sources)")
+  .option(
+    "-f, --force",
+    "Force reindexing if a repository with this name or path is already registered"
+  )
   .option("-p, --provider <provider>", "Embedding provider (openai, transformersjs, local, ollama)")
   .option(
     "--tier <tier>",
-    "Security tier: private | work | public (local folders default to private; public is refused for folders)"
+    "Security tier: private | work | public. Local folders default to 'private'; 'public' is refused"
   )
-  .option("--watch", "Enable filesystem watcher after indexing a local folder (default: enabled)")
-  .option("--no-watch", "Disable filesystem watcher even for local folders")
+  .option(
+    "--watch",
+    "Enable the filesystem watcher after indexing a local folder (default: enabled for local folders)"
+  )
+  .option("--no-watch", "Disable the filesystem watcher (local folders only)")
   .option(
     "--follow-symlinks",
-    "Follow symlinks inside the local folder (default: skip; out-of-folder targets are rejected even when set)"
+    "Follow symlinks inside the local folder. Out-of-folder targets are rejected even when set (default: skip)"
   )
   .action(async (url: string, options: Record<string, unknown>) => {
     try {

--- a/src/mcp/tools/register-local-folder.ts
+++ b/src/mcp/tools/register-local-folder.ts
@@ -78,50 +78,57 @@ interface ErrorResponse {
 export const registerLocalFolderToolDefinition: Tool = {
   name: "register_local_folder",
   description:
-    "Registers a local filesystem folder as a `local-folder` repository in the knowledge base. " +
-    "Scans the folder, generates embeddings, and (by default) starts a filesystem watcher " +
-    "that re-indexes the folder when its files change. The path may be absolute or relative; " +
-    "for `local-folder` sources `tier='public'` is refused. Use `async: true` to return a job " +
-    "ID immediately and poll `get_update_status` for completion.",
+    "Registers a local filesystem folder as a first-class `local-folder` repository — " +
+    "indistinguishable from a git-cloned repository at the MCP tool layer. After registration the " +
+    "folder appears in `list_indexed_repositories` and is searchable via `semantic_search`, " +
+    "`search_documents`, and the graph tools (`get_dependencies`, `get_dependents`, `get_architecture`, " +
+    "`find_path`, `get_graph_metrics`). The path may be absolute or relative. By default the call " +
+    "scans the folder, generates embeddings, populates the knowledge graph, and starts a filesystem " +
+    "watcher that re-indexes on file changes. `tier='public'` is refused for local folders; choose " +
+    "'private' or 'work'. Use `async: true` to return a job ID immediately and poll " +
+    "`get_update_status` for completion. See ADR-0009 for the design rationale.",
   inputSchema: {
     type: "object",
     properties: {
       path: {
         type: "string",
-        description: "Absolute or relative path to the folder to register.",
+        description:
+          "Absolute or relative path to the folder to register. The resolved absolute path is the deduplication key.",
         minLength: 1,
       },
       name: {
         type: "string",
-        description: "Optional repository name. Defaults to the basename of the resolved path.",
+        description:
+          "Repository display name. Defaults to the basename of the resolved path. Must be unique across all registered repositories (git or local).",
       },
       tier: {
         type: "string",
         enum: ["private", "work"],
-        description: "Security tier. Defaults to 'private'. 'public' is refused for local folders.",
+        description:
+          "Security tier. Defaults to 'private'. 'public' is refused for local folders — local content is unvetted and the public tier serves unauthenticated readers.",
       },
       force: {
         type: "boolean",
         description:
-          "Force re-registration even if a repo with this name (or absolute path) is already registered.",
+          "Force re-registration when a repository with this name or absolute path is already registered. Existing chunks and graph data are cleared and the folder is re-scanned.",
         default: false,
       },
       watch: {
         type: "boolean",
-        description: "Start the filesystem watcher after the initial scan. Defaults to true.",
+        description:
+          "Start the filesystem watcher after the initial scan so the index re-syncs as files change. Defaults to true; set to false for snapshot-only registration.",
         default: true,
       },
       followSymlinks: {
         type: "boolean",
         description:
-          "Follow filesystem symlinks inside the folder (out-of-folder targets are still rejected).",
+          "Follow filesystem symlinks inside the folder. Out-of-folder targets are rejected even when this is true, to prevent accidental escape from the registered tree.",
         default: false,
       },
       async: {
         type: "boolean",
         description:
-          "If true, return a job ID immediately and run registration in the background. " +
-          "Use get_update_status with the job_id to poll for completion. Defaults to false.",
+          "If true, return a job ID immediately and run registration in the background. Poll `get_update_status` with the returned job_id for completion. Defaults to false.",
         default: false,
       },
     },


### PR DESCRIPTION
## Summary

Final phase of the **Local Folder as First-Class Repository** capability (Phases A–D shipped via #564–#567). Doc-only PR — no behavioural changes.

- `docs/architecture/adr/0009-local-folder-as-repository.md` (new) — captures the source-discriminator decision (`"git-remote" | "local-git" | "local-folder"` with back-compat read), manifest design (per-repo `manifest.json` with mtime+size fast-path and SHA-256 tie-breaker), doc-graph scope (markdown full-fidelity; PDF/DOCX low-fidelity with a `confidence` attribute), `FolderEventRouter` rationale, `refuse-public` tier handling, and the deferred items (cross-machine portability, cross-repo linking, `.pkmignore`, retroactive WatchedFolder doc-graph).
- README.md — adds rows for the new capability, a "Supported Repository Sources" table, an MCP-tool block for `register_local_folder`, new CLI examples for local folders, and a refreshed **Code Statistics** section (`cloc --vcs=git --md .` against `main @ 086043d` on 2026-05-06).
- `docs/feature-summary.md` — adds `register_local_folder` to the MCP Server tools table and a new Local Folder as Repository feature section. Updates the `index` row for URL/path auto-detection and the new flags.
- CLI / MCP help text — light wording polish on `src/cli/index.ts` (`index` command + options) and on the `register_local_folder` tool description / per-property descriptions. No schema or behaviour changes.

## Heads-up: ADR numbering

The issue title called the new ADR **0007**, but `adr/0007-cross-store-consistency-model.md` and `adr/0008-repositories-json-path-model.md` already exist. Filed as **`0009-local-folder-as-repository.md`**. Updated `Local-Folder-As-Repository-Implementation-Plan.md` to point at the new filename.

Closes #568.

## Test plan

- [x] `bun run typecheck` passes (`tsc --noEmit` against the worktree)
- [x] `bun run build` passes (1931 + 1637 modules bundled cleanly)
- [x] `pk-mcp index --help` renders the polished options block correctly
- [x] ADR-0009 markdown renders in GitHub preview
- [x] Code Statistics table refreshed with the standard CLAUDE.md footnote (cloc command + commit + date)
- [ ] **Note**: `bun test` exits 1 with no summary on `main @ 086043d` even before this PR's changes (verified by `git stash && bun test` on main — same 139-line truncated output). This PR does not introduce that failure. Filing a separate issue is recommended.

## Follow-up issues to file (out of scope here)

1. `docs/architecture/README.md` still references Neo4j as the graph DB (stale since ADR-0004 promoted FalkorDB).
2. `docs/feature-summary.md` sections beyond what this PR touches predate Phases A–D and have additional staleness to clean up.
3. Investigate the pre-existing `bun test` no-summary / exit 1 mode on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)