### PR TITLE
fix(#580 follow-up): wire graphIngestionService into IngestionService bootstrap

### DIFF
--- a/src/cli/utils/dependency-init.ts
+++ b/src/cli/utils/dependency-init.ts
@@ -321,17 +321,12 @@ export async function initializeDependencies(
     const documentChunker = new DocumentChunker();
     const documentTypeDetector = new DocumentTypeDetector();
 
-    // Step 9: Initialize ingestion service (with document support)
-    const ingestionService = new IngestionServiceImpl(
-      repositoryCloner,
-      fileScanner,
-      fileChunker,
-      embeddingProvider,
-      chromaClient,
-      repositoryService,
-      { documentChunker, documentTypeDetector }
-    );
-    logger.debug("Ingestion service initialized (with document support)");
+    // Step 9 (deferred): The ingestion service is constructed AFTER the
+    // graph adapter is initialized below, so the optional
+    // `graphIngestionService` dependency can be threaded through. With the
+    // previous ordering, the Phase 5 wiring added in PR #583 (issue #580)
+    // silently no-op'd because `graphIngestionService` was always undefined
+    // at construction time.
 
     // Step 10: Initialize GitHub client
     const githubClient = new GitHubClientImpl({
@@ -424,6 +419,24 @@ export async function initializeDependencies(
       process.once("SIGINT", () => signalHandler("SIGINT"));
       process.once("SIGTERM", () => signalHandler("SIGTERM"));
     }
+
+    // Step 9 (now): Initialize ingestion service with document AND graph
+    // support. This MUST run after the graph adapter init above so the
+    // optional `graphIngestionService` is threaded through; `cli index`
+    // depends on this to run the Phase 5 graph step (PR #583, issue #580).
+    const ingestionService = new IngestionServiceImpl(
+      repositoryCloner,
+      fileScanner,
+      fileChunker,
+      embeddingProvider,
+      chromaClient,
+      repositoryService,
+      { documentChunker, documentTypeDetector, graphIngestionService }
+    );
+    logger.debug(
+      { graphEnabled: !!graphIngestionService },
+      "Ingestion service initialized (with document + graph support)"
+    );
 
     // Step 13: Initialize incremental update pipeline (with optional graph ingestion service)
     const updatePipeline = new IncrementalUpdatePipeline(

--- a/src/index.ts
+++ b/src/index.ts
@@ -469,10 +469,6 @@ async function main(): Promise<void> {
         // Create file chunker with default config
         const fileChunker = new FileChunker();
 
-        // graphIngestionService is hoisted to the graph-adapter block above
-        // (Step 3c) so it's shared with the registration IngestionService
-        // and the Phase 5 wiring in `cli index` actually has access to it.
-
         // Create document processing dependencies for incremental pipeline
         const documentTypeDetector = new DocumentTypeDetector();
         const documentChunker = new DocumentChunker();

--- a/src/index.ts
+++ b/src/index.ts
@@ -217,9 +217,23 @@ async function main(): Promise<void> {
 
     // Step 3c: Initialize graph service (if adapter available)
     let graphService: GraphService | undefined;
+    let graphIngestionService: GraphIngestionService | undefined;
     if (graphAdapter) {
       graphService = new GraphServiceImpl(graphAdapter);
       logger.info("Graph service initialized");
+
+      // Hoisted out of the per-feature blocks below so every consumer
+      // (incremental pipeline, register_local_folder ingestion service)
+      // shares one instance and the Phase 5 graph step in `IngestionService`
+      // (issue #580) actually fires when graph storage is configured.
+      const entityExtractor = new EntityExtractor();
+      const relationshipExtractor = new RelationshipExtractor();
+      graphIngestionService = new GraphIngestionService(
+        graphAdapter,
+        entityExtractor,
+        relationshipExtractor
+      );
+      logger.debug("Graph ingestion service initialized");
     }
 
     // Step 4: Initialize repository metadata service (singleton)
@@ -455,18 +469,9 @@ async function main(): Promise<void> {
         // Create file chunker with default config
         const fileChunker = new FileChunker();
 
-        // Create graph ingestion service if graph adapter is available
-        let graphIngestionService: GraphIngestionService | undefined;
-        if (graphAdapter) {
-          const entityExtractor = new EntityExtractor();
-          const relationshipExtractor = new RelationshipExtractor();
-          graphIngestionService = new GraphIngestionService(
-            graphAdapter,
-            entityExtractor,
-            relationshipExtractor
-          );
-          logger.debug("Graph ingestion service initialized for incremental updates");
-        }
+        // graphIngestionService is hoisted to the graph-adapter block above
+        // (Step 3c) so it's shared with the registration IngestionService
+        // and the Phase 5 wiring in `cli index` actually has access to it.
 
         // Create document processing dependencies for incremental pipeline
         const documentTypeDetector = new DocumentTypeDetector();
@@ -608,9 +613,19 @@ async function main(): Promise<void> {
       {
         documentChunker: registrationDocChunker,
         documentTypeDetector: registrationDocTypeDetector,
+        // Issue #580 follow-up: wire the hoisted graphIngestionService so
+        // `register_local_folder` (and any other consumer of this instance)
+        // gets the Phase 5 code+doc graph populated automatically when graph
+        // storage is configured. Undefined here means the caller didn't
+        // configure FalkorDB/Neo4j — IngestionService gates the graph step
+        // on this field, so ChromaDB-only behavior is preserved.
+        graphIngestionService,
       }
     );
-    logger.debug("Ingestion service initialized for register_local_folder MCP tool");
+    logger.debug(
+      { graphEnabled: !!graphIngestionService },
+      "Ingestion service initialized for register_local_folder MCP tool"
+    );
 
     // Step 6: Create MCP server
     logger.info("Creating MCP server");


### PR DESCRIPTION
## Summary

PR #583 added an optional `graphIngestionService` dependency to `IngestionService.indexRepository` so `cli index` would populate the code+doc graph in one pass. The wiring tests pass — but in production both bootstrap paths constructed `IngestionService` with `graphIngestionService = undefined`, so the new Phase 5 graph step short-circuited every time. The doc-graph extractors in PR #583 were re-introduced as runtime dead code via a different path than the original #580 bug.

Verified end-to-end on the user's real folder: re-indexed `divorce-su-wei-lee` (255 files) with `cli index --force --provider transformersjs`. Before this fix, FalkorDB had zero `:Document` nodes after the run. After this fix:

| Metric | Count |
|--------|-------|
| `:Document` nodes (`divorce-su-wei-lee`) | 255 (222 PDF / 6 DOCX / 27 markdown) |
| `:Section` nodes | 789 |
| `LINKS_TO` → `:ExternalLink` edges | 4 |
| `cli search "child custody"` top result | 80% match on relevant petition form |

## Two construction sites needed the fix

### `src/cli/utils/dependency-init.ts` (used by `cli index`, `cli update`, etc.)

`IngestionServiceImpl` was constructed at Step 9 (line 325) BEFORE the graph adapter and `graphIngestionService` were initialized at Step 12 (line 378). Moved the construction to after the graph adapter init block and threaded `graphIngestionService` into the options bag. Left a forward-reference comment at the original location so the file's numbered-step structure still reads cleanly.

### `src/index.ts` (MCP server bootstrap, including `register_local_folder` tool)

Two issues:

1. `graphIngestionService` was created INSIDE the `if (githubPat)` block (around line 459), so it was only in scope for the incremental update pipeline — not for the `register_local_folder` `IngestionService` constructed at line 601 outside that block.
2. That registration `IngestionService` didn't pass `graphIngestionService` in its options regardless.

Hoisted `graphIngestionService` initialization next to the existing `graphService = new GraphServiceImpl(graphAdapter)` block at Step 3c (around line 218). Both consumers now share one instance.

## No new tests

The existing wiring tests added in PR #583 (`tests/services/ingestion-service-doc-graph.test.ts`, `tests/services/incremental-update-pipeline-doc-graph.test.ts`) already prove `IngestionService`'s doc-graph behavior when `graphIngestionService` is passed. This PR simply ensures the production bootstrap actually does the passing — there's no behavior change inside `IngestionService` or `IncrementalUpdatePipeline` to test.

The bug class — "wired in tests, not in bootstrap" — is fundamentally a coverage gap that unit tests can't close (they instantiate services directly, bypassing the bootstrap). A bootstrap-shaped integration test is a future-PR consideration; out of scope here.

## Pre-PR verification

- `bun run typecheck` — clean
- `bun test tests/services/ingestion-service-doc-graph.test.ts tests/services/incremental-update-pipeline-doc-graph.test.ts` — 14 pass / 0 fail
- `bun test tests/cli/commands/index-command.test.ts tests/cli/commands/index-command-phase-c.test.ts` — 30 pass / 0 fail
- `bun run build` — clean
- `npx prettier --check` + `npx eslint` on the 2 changed files — clean

Manual verification on the real `divorce-su-wei-lee` folder is documented in the table above.

## Out of scope (deferred)

- Adding a bootstrap-level integration test that catches "wired but not threaded" regressions. Would need to drive `dependency-init.ts` end-to-end with mocked external deps.
- The two follow-up issues from PR #583's review (symmetric `removeRepository` graph delete, streaming `IngestionService.codeFilesForGraph`).

Refs #580