### PR TITLE
fix(#589): prevent oversized chunks from silently destroying vector index data

### DIFF
--- a/src/documents/DocumentChunker.ts
+++ b/src/documents/DocumentChunker.ts
@@ -382,8 +382,22 @@ export class DocumentChunker extends FileChunker {
     for (const paragraph of paragraphs) {
       const paragraphTokens = estimateTokens(paragraph.content);
 
-      // If single paragraph exceeds limit, chunk it with sentence/word fallbacks
-      if (paragraphTokens > this.maxTokens && currentParagraphs.length === 0) {
+      // If single paragraph exceeds limit, chunk it with line/sentence/word
+      // fallbacks. This must happen regardless of group state — pushing an
+      // oversized paragraph into a group would emit a chunk far above
+      // maxTokens, which embedding providers reject (issue #589: a ~50KB
+      // markdown table produced a ~12.5k-token chunk; OpenAI's limit is 8192).
+      if (paragraphTokens > this.maxTokens) {
+        // Flush any in-progress group first to preserve ordering
+        if (currentParagraphs.length > 0) {
+          allChunks.push(
+            this.createChunkFromParagraphs(currentParagraphs, filePath, source, fileInfo)
+          );
+          const posIndex = Math.min(overlapCount, currentParagraphs.length - 1);
+          positions.push({ charOffset: currentParagraphs[posIndex]!.charOffset });
+          currentParagraphs = [];
+          currentTokens = 0;
+        }
         const subResult = this.chunkOversizedParagraph(paragraph, fileInfo, source, filePath);
         allChunks.push(...subResult.chunks);
         positions.push(...subResult.positions);

--- a/src/repositories/types.ts
+++ b/src/repositories/types.ts
@@ -476,6 +476,18 @@ export interface UpdateHistoryEntry {
   chunksDeleted: number;
 
   /**
+   * Number of chunks skipped because their estimated token count exceeded the
+   * embedding input ceiling (issue #589).
+   *
+   * Optional so legacy history entries (written before this field existed) and
+   * partial mocks remain valid. A non-zero value means pathological chunks were
+   * dropped before embedding rather than poisoning their batch.
+   *
+   * @example 1
+   */
+  chunksSkipped?: number;
+
+  /**
    * Duration of the pipeline processing in milliseconds
    *
    * Time spent processing file changes, excluding git operations

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -541,21 +541,36 @@ export class IncrementalUpdateCoordinator {
         );
       }
 
+      // Status taxonomy (issue #589, review H1):
+      //
+      // Both SHA-blocking guards (`allEligibleFiltered` and `zeroUpsertFailure`)
+      // MUST classify as "incomplete", NOT "failed". A "failed" historyStatus
+      // sets the repo `status` to "error" (see below), which excludes the repo
+      // from update-all-command.ts and graph-populate-all-command.ts (both filter
+      // on `status === "ready"`). For a zero-upsert failure the SHA is held, so an
+      // "error" status would drop the repo from every future bulk update —
+      // reintroducing the silent-permanent-loss failure mode this PR fixes. By
+      // routing both guards to "incomplete" the repo stays "ready" (searchable)
+      // and is retried on the next update. The zeroUpsertFailure-specific warn
+      // log is emitted separately above; the allEligibleFiltered branch keeps its
+      // own warn log here.
       let historyStatus: "success" | "partial" | "failed" | "incomplete";
-      if (allEligibleFiltered) {
+      if (allEligibleFiltered || zeroUpsertFailure) {
         historyStatus = "incomplete";
-        logger.warn(
-          {
-            operation: "coordinator_sha_guard",
-            repository: repositoryName,
-            eligibleChanges: pipelineResult.filterStats.eligibleChanges,
-            totalChanges: pipelineResult.filterStats.totalChanges,
-            filteredChanges: pipelineResult.filterStats.filteredChanges,
-          },
-          "SHA advancement blocked: eligible files existed but none were processed. " +
-            "This likely indicates a filtering misconfiguration. " +
-            "Index remains at previous commit to prevent data loss."
-        );
+        if (allEligibleFiltered) {
+          logger.warn(
+            {
+              operation: "coordinator_sha_guard",
+              repository: repositoryName,
+              eligibleChanges: pipelineResult.filterStats.eligibleChanges,
+              totalChanges: pipelineResult.filterStats.totalChanges,
+              filteredChanges: pipelineResult.filterStats.filteredChanges,
+            },
+            "SHA advancement blocked: eligible files existed but none were processed. " +
+              "This likely indicates a filtering misconfiguration. " +
+              "Index remains at previous commit to prevent data loss."
+          );
+        }
       } else if (pipelineResult.errors.length === 0) {
         historyStatus = "success";
       } else if (totalFilesProcessed === 0) {
@@ -582,6 +597,10 @@ export class IncrementalUpdateCoordinator {
         durationMs: pipelineResult.stats.durationMs,
         errorCount: pipelineResult.errors.length,
         status: historyStatus,
+        // Surface oversized-chunk skips (issue #589) when the pipeline reported any.
+        ...(pipelineResult.stats.chunksSkipped !== undefined && {
+          chunksSkipped: pipelineResult.stats.chunksSkipped,
+        }),
         skippedFileCount: pipelineResult.filterStats.skippedChanges,
         eligibleFileCount: pipelineResult.filterStats.eligibleChanges,
         // Include graph stats if graph service was configured

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -498,6 +498,36 @@ export class IncrementalUpdateCoordinator {
         totalFilesProcessed === 0 &&
         pipelineResult.errors.length === 0;
 
+      // Guard (issue #589): Content-producing changes existed but nothing was
+      // stored and errors occurred — e.g., the embed/store step failed after
+      // the per-file chunk deletes already ran. Advancing the SHA would make
+      // the loss permanent because the next update would see "no changes".
+      // Keep the SHA at the previous commit so the next run retries the diff.
+      const zeroUpsertFailure =
+        pipelineResult.stats.filesAdded + pipelineResult.stats.filesModified > 0 &&
+        pipelineResult.stats.chunksUpserted === 0 &&
+        pipelineResult.errors.length > 0;
+
+      // SHA must not advance under either guard condition
+      const blockShaAdvancement = allEligibleFiltered || zeroUpsertFailure;
+
+      if (zeroUpsertFailure) {
+        logger.warn(
+          {
+            operation: "coordinator_sha_guard",
+            repository: repositoryName,
+            filesAdded: pipelineResult.stats.filesAdded,
+            filesModified: pipelineResult.stats.filesModified,
+            chunksUpserted: pipelineResult.stats.chunksUpserted,
+            chunksDeleted: pipelineResult.stats.chunksDeleted,
+            errorCount: pipelineResult.errors.length,
+          },
+          "SHA advancement blocked: changed files produced no stored chunks and errors occurred " +
+            "(embed/store likely failed). Index remains at previous commit so the next " +
+            "incremental update retries these files."
+        );
+      }
+
       let historyStatus: "success" | "partial" | "failed" | "incomplete";
       if (allEligibleFiltered) {
         historyStatus = "incomplete";
@@ -529,8 +559,8 @@ export class IncrementalUpdateCoordinator {
         timestamp: new Date().toISOString(),
         // Validated above - throws MissingCommitShaError if undefined
         previousCommit: repo.lastIndexedCommitSha,
-        // If guard triggered, don't record HEAD as newCommit (SHA not advanced)
-        newCommit: allEligibleFiltered ? repo.lastIndexedCommitSha : headCommit.sha,
+        // If a guard triggered, don't record HEAD as newCommit (SHA not advanced)
+        newCommit: blockShaAdvancement ? repo.lastIndexedCommitSha : headCommit.sha,
         filesAdded: pipelineResult.stats.filesAdded,
         filesModified: pipelineResult.stats.filesModified,
         filesDeleted: pipelineResult.stats.filesDeleted,
@@ -563,8 +593,9 @@ export class IncrementalUpdateCoordinator {
       const updatedMetadata: RepositoryInfo = {
         ...repo,
         updateHistory: updatedHistory,
-        // Only advance SHA when files were actually processed (or no eligible files existed)
-        lastIndexedCommitSha: allEligibleFiltered ? repo.lastIndexedCommitSha : headCommit.sha,
+        // Only advance SHA when files were actually processed AND their chunks
+        // were stored (or no eligible files existed)
+        lastIndexedCommitSha: blockShaAdvancement ? repo.lastIndexedCommitSha : headCommit.sha,
         lastIncrementalUpdateAt: new Date().toISOString(),
         incrementalUpdateCount: (repo.incrementalUpdateCount || 0) + 1,
         // Update file and chunk counts based on pipeline results
@@ -582,7 +613,11 @@ export class IncrementalUpdateCoordinator {
             ? `Incremental update completed with ${pipelineResult.errors.length} error(s)`
             : allEligibleFiltered
               ? `Incremental update incomplete: ${pipelineResult.filterStats.eligibleChanges} eligible file(s) were filtered out`
-              : undefined,
+              : zeroUpsertFailure
+                ? `Incremental update incomplete: no chunks were stored for ` +
+                  `${pipelineResult.stats.filesAdded + pipelineResult.stats.filesModified} changed file(s); ` +
+                  `SHA not advanced, next update will retry`
+                : undefined,
         // Clear the in-progress flag (update completed successfully or with partial errors)
         updateInProgress: false,
         updateStartedAt: undefined,
@@ -609,10 +644,13 @@ export class IncrementalUpdateCoordinator {
       const durationMs = Date.now() - startTime;
 
       let resultStatus: CoordinatorResult["status"];
-      if (allEligibleFiltered) {
-        resultStatus = "incomplete";
-      } else if (historyStatus === "failed") {
+      if (historyStatus === "failed") {
         resultStatus = "failed";
+      } else if (blockShaAdvancement) {
+        // Covers allEligibleFiltered and zeroUpsertFailure (issue #589):
+        // the index was not brought up to the head commit, so the caller
+        // should know the update must be retried.
+        resultStatus = "incomplete";
       } else {
         resultStatus = "updated"; // includes partial success
       }

--- a/src/services/incremental-update-pipeline.ts
+++ b/src/services/incremental-update-pipeline.ts
@@ -83,12 +83,20 @@ export class IncrementalUpdatePipeline {
    *
    * OpenAI's hard input limit is 8,192 tokens per text. `estimateTokens` uses a
    * chars/4 heuristic that can under-estimate for token-dense content (tables,
-   * code), so this is set well below 8,192. Correctly chunked content is at
-   * most ~500 estimated tokens; anything above this threshold is pathological
-   * (issue #589) and is skipped with an error rather than poisoning its whole
-   * embedding batch.
+   * code), so this ceiling is kept below 8,192. Correctly chunked content is at
+   * most ~`CHUNK_MAX_TOKENS` estimated tokens; anything above this threshold is
+   * pathological (issue #589) and is skipped with an error rather than poisoning
+   * its whole embedding batch.
+   *
+   * Derived from the operator's `CHUNK_MAX_TOKENS` override (the same env var the
+   * FileChunker/DocumentChunker honor) so that raising the chunk size does not
+   * silently cause every chunk to exceed a hard-coded skip threshold — that
+   * would turn a valid config into total data loss. The ceiling is `2x` the
+   * configured chunk size to leave headroom for the chars/4 estimator's
+   * under-counting, with a floor of 6,000 (the historical default) and a cap of
+   * 8,000 to stay below the provider's 8,192 hard limit.
    */
-  private readonly MAX_EMBEDDING_INPUT_TOKENS = 6000;
+  private readonly MAX_EMBEDDING_INPUT_TOKENS: number;
 
   /**
    * Doc-graph helper instance — stateless aside from cached extractor objects
@@ -116,7 +124,16 @@ export class IncrementalUpdatePipeline {
     private readonly graphIngestionService?: GraphIngestionService,
     private readonly documentTypeDetector?: DocumentTypeDetector,
     private readonly documentChunker?: DocumentChunker
-  ) {}
+  ) {
+    // Derive the per-chunk skip ceiling from the operator's CHUNK_MAX_TOKENS
+    // override so a larger configured chunk size doesn't cause every chunk to be
+    // skipped against a fixed limit. Floor at 6,000 (historical default), cap at
+    // 8,000 to stay under the provider's 8,192 hard input limit.
+    const envMax = process.env["CHUNK_MAX_TOKENS"];
+    const parsed = envMax ? parseInt(envMax, 10) : NaN;
+    const configured = !isNaN(parsed) && parsed > 0 ? parsed : 500;
+    this.MAX_EMBEDDING_INPUT_TOKENS = Math.min(8000, Math.max(6000, configured * 2));
+  }
 
   /**
    * Validate file path to prevent path traversal attacks.
@@ -204,6 +221,7 @@ export class IncrementalUpdatePipeline {
       filesDeleted: 0,
       chunksUpserted: 0,
       chunksDeleted: 0,
+      chunksSkipped: 0,
       durationMs: 0,
     };
 
@@ -964,6 +982,7 @@ export class IncrementalUpdatePipeline {
     for (const chunk of chunks) {
       const estimatedTokens = estimateTokens(chunk.content);
       if (estimatedTokens > this.MAX_EMBEDDING_INPUT_TOKENS) {
+        stats.chunksSkipped = (stats.chunksSkipped ?? 0) + 1;
         errors.push({
           path: chunk.filePath,
           error:

--- a/src/services/incremental-update-pipeline.ts
+++ b/src/services/incremental-update-pipeline.ts
@@ -29,6 +29,7 @@ import type { InternalChunk } from "./ingestion-types.js";
 import type { GraphIngestionService } from "../graph/ingestion/GraphIngestionService.js";
 import { EntityExtractor } from "../graph/extraction/EntityExtractor.js";
 import { DEFAULT_EXTENSIONS } from "../ingestion/default-extensions.js";
+import { estimateTokens } from "../ingestion/chunk-utils.js";
 import type { DocumentTypeDetector } from "../documents/DocumentTypeDetector.js";
 import type { DocumentChunker } from "../documents/DocumentChunker.js";
 import type { ExtractionResult } from "../documents/types.js";
@@ -76,6 +77,18 @@ export class IncrementalUpdatePipeline {
    * and ensures efficient batching.
    */
   private readonly EMBEDDING_BATCH_SIZE = 100;
+
+  /**
+   * Maximum estimated tokens for a single chunk sent to the embedding provider.
+   *
+   * OpenAI's hard input limit is 8,192 tokens per text. `estimateTokens` uses a
+   * chars/4 heuristic that can under-estimate for token-dense content (tables,
+   * code), so this is set well below 8,192. Correctly chunked content is at
+   * most ~500 estimated tokens; anything above this threshold is pathological
+   * (issue #589) and is skipped with an error rather than poisoning its whole
+   * embedding batch.
+   */
+  private readonly MAX_EMBEDDING_INPUT_TOKENS = 6000;
 
   /**
    * Doc-graph helper instance — stateless aside from cached extractor objects
@@ -347,10 +360,12 @@ export class IncrementalUpdatePipeline {
       }
     }
 
-    // If we have chunks to embed and store, do it in batches
+    // If we have chunks to embed and store, do it in batches. Per-batch and
+    // per-chunk failures are collected into `errors` inside; this catch is a
+    // last resort for unexpected failures outside the batch loop.
     if (allChunks.length > 0) {
       try {
-        await this.embedAndStoreChunks(allChunks, options.collectionName, stats, logger);
+        await this.embedAndStoreChunks(allChunks, options.collectionName, stats, errors, logger);
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         const errorType = error instanceof Error ? error.constructor.name : "Unknown";
@@ -919,32 +934,73 @@ export class IncrementalUpdatePipeline {
    * Generate embeddings for chunks and store them in ChromaDB.
    *
    * Batches embedding generation in groups of EMBEDDING_BATCH_SIZE to stay
-   * within API limits. Creates DocumentInput objects and upserts to ChromaDB.
+   * within API limits. Each batch is embedded and upserted independently so a
+   * failure affects at most EMBEDDING_BATCH_SIZE chunks instead of the whole
+   * update (issue #589: a single oversized chunk previously caused every chunk
+   * in the update to be lost after their predecessors were already deleted).
+   *
+   * Chunks whose estimated token count exceeds MAX_EMBEDDING_INPUT_TOKENS are
+   * skipped up-front with a per-chunk error so they cannot poison a batch.
    *
    * @param chunks - All chunks to embed and store
    * @param collectionName - Target ChromaDB collection
    * @param stats - Statistics to update
+   * @param errors - Error collector for skipped chunks and failed batches
+   * @param logger - Correlation-aware logger
    */
   private async embedAndStoreChunks(
     chunks: InternalChunk[],
     collectionName: string,
     stats: UpdateStats,
+    errors: FileProcessingError[],
     logger: Logger
   ): Promise<void> {
     const startTime = Date.now();
 
+    // Safety net: skip pathologically large chunks instead of letting them
+    // fail an entire embedding request. With correct chunking this never
+    // trips, but a chunker regression must degrade per-chunk, not per-update.
+    const safeChunks: InternalChunk[] = [];
+    for (const chunk of chunks) {
+      const estimatedTokens = estimateTokens(chunk.content);
+      if (estimatedTokens > this.MAX_EMBEDDING_INPUT_TOKENS) {
+        errors.push({
+          path: chunk.filePath,
+          error:
+            `Chunk ${chunk.id} skipped: estimated ${estimatedTokens} tokens exceeds ` +
+            `embedding input limit (${this.MAX_EMBEDDING_INPUT_TOKENS})`,
+        });
+        logger.warn(
+          {
+            operation: "pipeline_embed_chunks",
+            chunkId: chunk.id,
+            filePath: chunk.filePath,
+            estimatedTokens,
+            limit: this.MAX_EMBEDDING_INPUT_TOKENS,
+          },
+          "Skipping oversized chunk - exceeds embedding input limit"
+        );
+        continue;
+      }
+      safeChunks.push(chunk);
+    }
+
     logger.info(
-      { operation: "pipeline_embed_chunks", chunkCount: chunks.length },
+      {
+        operation: "pipeline_embed_chunks",
+        chunkCount: safeChunks.length,
+        skippedOversized: chunks.length - safeChunks.length,
+      },
       "Generating embeddings for chunks"
     );
 
-    // Batch embedding generation (max 100 texts per request)
-    const allEmbeddings: number[][] = [];
-    const batchCount = Math.ceil(chunks.length / this.EMBEDDING_BATCH_SIZE);
+    // Embed and upsert per batch (max 100 texts per request). Batches are
+    // independent: a failed batch is recorded as an error and the remaining
+    // batches still get stored.
+    const batchCount = Math.ceil(safeChunks.length / this.EMBEDDING_BATCH_SIZE);
 
-    for (let i = 0; i < chunks.length; i += this.EMBEDDING_BATCH_SIZE) {
-      const batch = chunks.slice(i, i + this.EMBEDDING_BATCH_SIZE);
-      const batchTexts = batch.map((c) => c.content);
+    for (let i = 0; i < safeChunks.length; i += this.EMBEDDING_BATCH_SIZE) {
+      const batch = safeChunks.slice(i, i + this.EMBEDDING_BATCH_SIZE);
       const batchIndex = Math.floor(i / this.EMBEDDING_BATCH_SIZE) + 1;
       const batchStartTime = Date.now();
 
@@ -953,91 +1009,101 @@ export class IncrementalUpdatePipeline {
           operation: "pipeline_embed_batch",
           batchIndex,
           batchCount,
-          batchSize: batchTexts.length,
+          batchSize: batch.length,
         },
         "Generating embeddings for batch"
       );
 
-      const embeddings = await this.embeddingProvider.generateEmbeddings(batchTexts);
-      allEmbeddings.push(...embeddings);
+      try {
+        const embeddings = await this.embeddingProvider.generateEmbeddings(
+          batch.map((c) => c.content)
+        );
 
-      logger.debug(
-        {
-          operation: "pipeline_embed_batch",
-          batchIndex,
-          durationMs: Date.now() - batchStartTime,
-        },
-        "Batch embedding completed"
-      );
+        // Create DocumentInput objects for this batch
+        const documents: DocumentInput[] = batch.map((chunk, index) => {
+          const embedding = embeddings[index];
+          if (!embedding) {
+            throw new Error(`Missing embedding for chunk ${chunk.id} (batch index ${index})`);
+          }
+
+          return {
+            id: chunk.id,
+            content: chunk.content,
+            embedding,
+            metadata: {
+              file_path: chunk.filePath,
+              repository: chunk.repository,
+              chunk_index: chunk.chunkIndex,
+              total_chunks: chunk.totalChunks,
+              chunk_start_line: chunk.startLine,
+              chunk_end_line: chunk.endLine,
+              file_extension: chunk.extension,
+              language: chunk.language,
+              file_size_bytes: chunk.fileSizeBytes,
+              content_hash: chunk.contentHash,
+              indexed_at: new Date().toISOString(),
+              file_modified_at: chunk.fileModifiedAt.toISOString(),
+              // Document-specific metadata (only present for document chunks)
+              ...(chunk.documentMetadata && {
+                document_type: chunk.documentMetadata.documentType,
+                ...(chunk.documentMetadata.pageNumber !== undefined && {
+                  page_number: chunk.documentMetadata.pageNumber,
+                }),
+                ...(chunk.documentMetadata.sectionHeading && {
+                  section_heading: chunk.documentMetadata.sectionHeading,
+                }),
+                ...(chunk.documentMetadata.documentTitle && {
+                  document_title: chunk.documentMetadata.documentTitle,
+                }),
+                ...(chunk.documentMetadata.documentAuthor && {
+                  document_author: chunk.documentMetadata.documentAuthor,
+                }),
+              }),
+            },
+          };
+        });
+
+        await this.storageClient.upsertDocuments(collectionName, documents);
+        stats.chunksUpserted += documents.length;
+
+        logger.debug(
+          {
+            operation: "pipeline_embed_batch",
+            batchIndex,
+            upsertedCount: documents.length,
+            durationMs: Date.now() - batchStartTime,
+          },
+          "Batch embedded and upserted"
+        );
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        const affectedFiles = [...new Set(batch.map((c) => c.filePath))];
+        errors.push({
+          path: `(embedding batch ${batchIndex}/${batchCount})`,
+          error: `${errorMessage} (${batch.length} chunks across ${affectedFiles.length} files lost)`,
+        });
+        logger.error(
+          {
+            operation: "pipeline_embed_batch",
+            batchIndex,
+            batchCount,
+            batchSize: batch.length,
+            affectedFiles,
+            error: errorMessage,
+          },
+          "Embedding batch failed - continuing with remaining batches"
+        );
+      }
     }
 
-    // Create DocumentInput objects from InternalChunks
-    const documents: DocumentInput[] = chunks.map((chunk, index) => {
-      const embedding = allEmbeddings[index];
-      if (!embedding) {
-        throw new Error(`Missing embedding for chunk ${index}`);
-      }
-
-      return {
-        id: chunk.id,
-        content: chunk.content,
-        embedding,
-        metadata: {
-          file_path: chunk.filePath,
-          repository: chunk.repository,
-          chunk_index: chunk.chunkIndex,
-          total_chunks: chunk.totalChunks,
-          chunk_start_line: chunk.startLine,
-          chunk_end_line: chunk.endLine,
-          file_extension: chunk.extension,
-          language: chunk.language,
-          file_size_bytes: chunk.fileSizeBytes,
-          content_hash: chunk.contentHash,
-          indexed_at: new Date().toISOString(),
-          file_modified_at: chunk.fileModifiedAt.toISOString(),
-          // Document-specific metadata (only present for document chunks)
-          ...(chunk.documentMetadata && {
-            document_type: chunk.documentMetadata.documentType,
-            ...(chunk.documentMetadata.pageNumber !== undefined && {
-              page_number: chunk.documentMetadata.pageNumber,
-            }),
-            ...(chunk.documentMetadata.sectionHeading && {
-              section_heading: chunk.documentMetadata.sectionHeading,
-            }),
-            ...(chunk.documentMetadata.documentTitle && {
-              document_title: chunk.documentMetadata.documentTitle,
-            }),
-            ...(chunk.documentMetadata.documentAuthor && {
-              document_author: chunk.documentMetadata.documentAuthor,
-            }),
-          }),
-        },
-      };
-    });
-
-    // Upsert to ChromaDB
-    const upsertStartTime = Date.now();
-
     logger.info(
       {
         operation: "pipeline_upsert_documents",
-        documentCount: documents.length,
-        collection: collectionName,
-      },
-      "Upserting documents to ChromaDB"
-    );
-
-    await this.storageClient.upsertDocuments(collectionName, documents);
-    stats.chunksUpserted += documents.length;
-
-    logger.info(
-      {
-        operation: "pipeline_upsert_documents",
-        upsertedCount: documents.length,
-        durationMs: Date.now() - upsertStartTime,
+        upsertedCount: stats.chunksUpserted,
+        skippedOversized: chunks.length - safeChunks.length,
         totalDurationMs: Date.now() - startTime,
       },
-      "Successfully upserted chunks to ChromaDB"
+      "Embed and store completed"
     );
   }
 

--- a/src/services/incremental-update-types.ts
+++ b/src/services/incremental-update-types.ts
@@ -344,6 +344,19 @@ export interface UpdateStats {
   durationMs: number;
 
   /**
+   * Number of chunks skipped because their estimated token count exceeded the
+   * embedding input ceiling (MAX_EMBEDDING_INPUT_TOKENS).
+   *
+   * Optional so existing partial-stats objects (mocks, the coordinator's
+   * zero-stats helpers) remain valid. A non-zero value indicates pathological
+   * chunks were dropped before embedding (issue #589) rather than poisoning
+   * their batch — the affected files also appear in `errors`.
+   *
+   * @example 1
+   */
+  chunksSkipped?: number;
+
+  /**
    * Graph database update statistics (optional).
    *
    * Only present when a GraphIngestionService is configured.

--- a/src/services/local-folder-update-coordinator.ts
+++ b/src/services/local-folder-update-coordinator.ts
@@ -309,6 +309,10 @@ export class LocalFolderUpdateCoordinator {
         durationMs: pipelineResult.stats.durationMs,
         errorCount: pipelineResult.errors.length,
         status: historyStatus,
+        // Surface oversized-chunk skips (issue #589) when the pipeline reported any.
+        ...(pipelineResult.stats.chunksSkipped !== undefined && {
+          chunksSkipped: pipelineResult.stats.chunksSkipped,
+        }),
         skippedFileCount: pipelineResult.filterStats.skippedChanges,
         eligibleFileCount: pipelineResult.filterStats.eligibleChanges,
         ...(pipelineResult.stats.graph && {

--- a/tests/integration/services/change-detection-service.integration.test.ts
+++ b/tests/integration/services/change-detection-service.integration.test.ts
@@ -455,16 +455,24 @@ describe("ChangeDetectionService Integration", () => {
 
       await folderWatcher.startWatching(testFolder);
 
-      // Create multiple files
-      await fs.promises.writeFile(path.join(testFolder.path, "error1.md"), "content1");
-      await fs.promises.writeFile(path.join(testFolder.path, "error2.md"), "content2");
+      // Sequence the writes deterministically: confirm the first event was
+      // delivered (and threw) before triggering the second. Two parallel
+      // writes raced the watcher on CI runners and the second event was
+      // sometimes never observed within any reasonable window.
+      const pollUntil = async (cond: () => boolean): Promise<void> => {
+        const deadline = Date.now() + 5000;
+        while (!cond() && Date.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+      };
 
-      // Poll instead of a fixed sleep: watcher event latency varies with host
-      // load (a fixed 500ms wait intermittently missed the second event on CI)
-      const deadline = Date.now() + 5000;
-      while ((errorCount < 1 || successChanges.length < 1) && Date.now() < deadline) {
-        await new Promise((resolve) => setTimeout(resolve, 50));
-      }
+      // First file: the handler throws on this event
+      await fs.promises.writeFile(path.join(testFolder.path, "error1.md"), "content1");
+      await pollUntil(() => errorCount >= 1);
+
+      // Second file: the handler must still receive subsequent events
+      await fs.promises.writeFile(path.join(testFolder.path, "error2.md"), "content2");
+      await pollUntil(() => successChanges.length >= 1);
 
       // First event threw, but subsequent events should still work
       // (The handler recovered after the first error)

--- a/tests/integration/services/change-detection-service.integration.test.ts
+++ b/tests/integration/services/change-detection-service.integration.test.ts
@@ -459,7 +459,12 @@ describe("ChangeDetectionService Integration", () => {
       await fs.promises.writeFile(path.join(testFolder.path, "error1.md"), "content1");
       await fs.promises.writeFile(path.join(testFolder.path, "error2.md"), "content2");
 
-      await new Promise((resolve) => setTimeout(resolve, 500));
+      // Poll instead of a fixed sleep: watcher event latency varies with host
+      // load (a fixed 500ms wait intermittently missed the second event on CI)
+      const deadline = Date.now() + 5000;
+      while ((errorCount < 1 || successChanges.length < 1) && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
 
       // First event threw, but subsequent events should still work
       // (The handler recovered after the first error)

--- a/tests/services/incremental-update-coordinator.test.ts
+++ b/tests/services/incremental-update-coordinator.test.ts
@@ -716,8 +716,16 @@ describe("IncrementalUpdateCoordinator", () => {
       expect(historyEntry.status).toBe("partial");
     });
 
-    it("should record 'failed' status when all files fail", async () => {
-      // Mock pipeline with errors >= total files changed
+    it("should record 'incomplete' status (not 'failed') when changed files stored zero chunks with errors", async () => {
+      // Semantic change (issue #589, review H1): this shape — content-producing
+      // files changed (filesAdded+filesModified > 0), zero chunks upserted, and
+      // errors present — is a `zeroUpsertFailure`. It used to classify as
+      // "failed", which set the repo status to "error". An "error" repo is
+      // excluded from update-all-command.ts and graph-populate-all-command.ts
+      // (both filter on `status === "ready"`), so the repo would be silently
+      // dropped from every future bulk update — and because the SHA is held, it
+      // would never recover. Routing this shape to "incomplete" keeps the repo
+      // "ready" (searchable) and retryable on the next update.
       mockUpdatePipeline.processChanges = mock(async () => ({
         stats: {
           filesAdded: 1,
@@ -750,7 +758,63 @@ describe("IncrementalUpdateCoordinator", () => {
       if (!historyEntry) throw new Error("History entry not found");
 
       expect(historyEntry.errorCount).toBe(2);
-      expect(historyEntry.status).toBe("failed");
+      // Was "failed" before H1; now "incomplete" so the repo stays usable.
+      expect(historyEntry.status).toBe("incomplete");
+      // Repo status must stay "ready" so bulk update commands don't drop it.
+      expect(updatedRepo?.status).toBe("ready");
+      // SHA must NOT advance — next update retries these files.
+      expect(updatedRepo?.lastIndexedCommitSha).toBe(testRepo.lastIndexedCommitSha);
+    });
+
+    it("should record 'incomplete' for a single-file all-oversized update (issue #589)", async () => {
+      // Real-world shape: one modified file whose chunks were all skipped as
+      // oversized. Its old chunks were already deleted (chunksDeleted > 0) and
+      // nothing new was stored (chunksUpserted === 0) with one per-chunk skip
+      // error. This is a zeroUpsertFailure (filesModified > 0) and must be
+      // "incomplete" (review H1) so the repo stays "ready" and retryable rather
+      // than being permanently dropped from bulk updates.
+      mockUpdatePipeline.processChanges = mock(async () => ({
+        stats: {
+          filesAdded: 0,
+          filesModified: 1,
+          filesDeleted: 0,
+          chunksUpserted: 0,
+          chunksDeleted: 4,
+          chunksSkipped: 1,
+          durationMs: 250,
+        },
+        errors: [
+          {
+            path: "docs/huge.md",
+            error: "Chunk docs/huge.md:0 skipped: estimated 9000 tokens exceeds limit (8000)",
+          },
+        ],
+        filterStats: {
+          totalChanges: 1,
+          eligibleChanges: 1,
+          filteredChanges: 1,
+          skippedChanges: 0,
+        },
+      }));
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("incomplete");
+
+      const updateCalls = (mockRepositoryService.updateRepository as ReturnType<typeof mock>).mock
+        .calls;
+      const updatedRepo = updateCalls[updateCalls.length - 1]?.[0] as RepositoryInfo | undefined;
+      expect(updatedRepo).toBeDefined();
+      if (!updatedRepo) throw new Error("Updated repo not found");
+
+      // Repo stays searchable and eligible for the next bulk update.
+      expect(updatedRepo.status).toBe("ready");
+      // SHA held at the previous commit so the next update retries the file.
+      expect(updatedRepo.lastIndexedCommitSha).toBe(testRepo.lastIndexedCommitSha);
+
+      const historyEntry = updatedRepo.updateHistory?.[0];
+      expect(historyEntry?.status).toBe("incomplete");
+      expect(historyEntry?.newCommit).toBe(testRepo.lastIndexedCommitSha);
     });
 
     it("should append to existing history (newest first)", async () => {
@@ -1415,10 +1479,11 @@ describe("IncrementalUpdateCoordinator", () => {
         expect(updatedRepo.status).toBe("ready");
         expect(updatedRepo.errorMessage).toContain("no chunks were stored");
 
-        // History records partial (graph work may have succeeded) but the
-        // commit pointer does not move
+        // History records "incomplete" (review H1): a zeroUpsertFailure now
+        // classifies as "incomplete" rather than "partial"/"failed" so the repo
+        // status stays "ready" and the commit pointer does not move.
         const historyEntry = updatedRepo.updateHistory?.[0];
-        expect(historyEntry?.status).toBe("partial");
+        expect(historyEntry?.status).toBe("incomplete");
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         expect(historyEntry?.newCommit).toBe(testRepo.lastIndexedCommitSha);
       }

--- a/tests/services/incremental-update-coordinator.test.ts
+++ b/tests/services/incremental-update-coordinator.test.ts
@@ -1374,6 +1374,119 @@ describe("IncrementalUpdateCoordinator", () => {
       }
     });
 
+    it("should NOT advance SHA when changed files stored zero chunks with errors (issue #589)", async () => {
+      // Shape of the 2026-06-05 Muzehub-code incident: 139 files changed, the
+      // embed/store step failed wholesale, chunk deletes had already run.
+      mockUpdatePipeline.processChanges = mock(async () => ({
+        stats: {
+          filesAdded: 9,
+          filesModified: 130,
+          filesDeleted: 0,
+          chunksUpserted: 0,
+          chunksDeleted: 945,
+          durationMs: 113808,
+        },
+        errors: [
+          {
+            path: "(embedding batch 1/18)",
+            error: "Client error: 400 Invalid 'input[8]': maximum input length is 8192 tokens.",
+          },
+        ],
+        filterStats: {
+          totalChanges: 139,
+          eligibleChanges: 139,
+          filteredChanges: 139,
+          skippedChanges: 0,
+        },
+      }));
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("incomplete");
+
+      const updateCalls = (mockRepositoryService.updateRepository as ReturnType<typeof mock>).mock
+        .calls;
+      const updatedRepo = updateCalls[updateCalls.length - 1]?.[0] as RepositoryInfo | undefined;
+      expect(updatedRepo).toBeDefined();
+      if (updatedRepo) {
+        // SHA must remain at the old value so the next update retries the diff
+        expect(updatedRepo.lastIndexedCommitSha).toBe(testRepo.lastIndexedCommitSha);
+        // Repo stays searchable - existing chunks are intact
+        expect(updatedRepo.status).toBe("ready");
+        expect(updatedRepo.errorMessage).toContain("no chunks were stored");
+
+        // History records partial (graph work may have succeeded) but the
+        // commit pointer does not move
+        const historyEntry = updatedRepo.updateHistory?.[0];
+        expect(historyEntry?.status).toBe("partial");
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        expect(historyEntry?.newCommit).toBe(testRepo.lastIndexedCommitSha);
+      }
+    });
+
+    it("should advance SHA for delete-only updates with zero upserts", async () => {
+      // Deletions legitimately store no chunks; errors elsewhere must not
+      // trigger the zero-upsert guard when no added/modified files exist.
+      mockUpdatePipeline.processChanges = mock(async () => ({
+        stats: {
+          filesAdded: 0,
+          filesModified: 0,
+          filesDeleted: 3,
+          chunksUpserted: 0,
+          chunksDeleted: 12,
+          durationMs: 90,
+        },
+        errors: [{ path: "old/gone.ts", error: "Graph cleanup warning" }],
+        filterStats: {
+          totalChanges: 3,
+          eligibleChanges: 3,
+          filteredChanges: 3,
+          skippedChanges: 0,
+        },
+      }));
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("updated");
+
+      const updateCalls = (mockRepositoryService.updateRepository as ReturnType<typeof mock>).mock
+        .calls;
+      const updatedRepo = updateCalls[updateCalls.length - 1]?.[0] as RepositoryInfo | undefined;
+      expect(updatedRepo?.lastIndexedCommitSha).toBe(headCommit.sha);
+    });
+
+    it("should advance SHA when some chunks were stored despite batch errors", async () => {
+      // Per-batch isolation: one failed batch, others stored. Progress was
+      // made, so the SHA advances and the run records partial status.
+      mockUpdatePipeline.processChanges = mock(async () => ({
+        stats: {
+          filesAdded: 5,
+          filesModified: 20,
+          filesDeleted: 0,
+          chunksUpserted: 150,
+          chunksDeleted: 130,
+          durationMs: 60000,
+        },
+        errors: [{ path: "(embedding batch 2/3)", error: "rate limit" }],
+        filterStats: {
+          totalChanges: 25,
+          eligibleChanges: 25,
+          filteredChanges: 25,
+          skippedChanges: 0,
+        },
+      }));
+
+      const result = await coordinator.updateRepository("test-repo");
+
+      expect(result.status).toBe("updated");
+
+      const updateCalls = (mockRepositoryService.updateRepository as ReturnType<typeof mock>).mock
+        .calls;
+      const updatedRepo = updateCalls[updateCalls.length - 1]?.[0] as RepositoryInfo | undefined;
+      expect(updatedRepo?.lastIndexedCommitSha).toBe(headCommit.sha);
+      expect(updatedRepo?.status).toBe("ready");
+    });
+
     it("should include skippedFileCount and eligibleFileCount in history entry", async () => {
       // Normal successful update with some filtered files
       await coordinator.updateRepository("test-repo");

--- a/tests/services/incremental-update-pipeline.test.ts
+++ b/tests/services/incremental-update-pipeline.test.ts
@@ -760,6 +760,9 @@ describe("IncrementalUpdatePipeline", () => {
       expect(result.errors[0]?.path).toBe("src/minified.ts");
       expect(result.errors[0]?.error).toContain("exceeds embedding input limit");
 
+      // The skip is surfaced in the stats (issue #589, review L1)
+      expect(result.stats.chunksSkipped).toBe(1);
+
       // The normal file's chunk was still embedded and stored
       expect(result.stats.chunksUpserted).toBeGreaterThan(0);
 
@@ -769,6 +772,51 @@ describe("IncrementalUpdatePipeline", () => {
       ).mock.calls.flatMap((c) => c[0] as string[]);
       for (const text of sentTexts) {
         expect(text.length).toBeLessThan(24000);
+      }
+    });
+
+    it("derives the embedding ceiling from CHUNK_MAX_TOKENS so a raised chunk size is not skipped (issue #589)", async () => {
+      // Regression for review M1: the per-chunk skip ceiling must scale with the
+      // operator's CHUNK_MAX_TOKENS override. With the historical hard-coded
+      // 6000 ceiling, raising CHUNK_MAX_TOKENS above 6000 would skip every chunk
+      // — valid config becomes total data loss. A ~26,000-char single line is
+      // ~6,500 estimated tokens (chars/4): above the old 6000 ceiling but below
+      // the derived 8000 ceiling (min(8000, max(6000, 7000 * 2))).
+      const savedChunkMaxTokens = process.env["CHUNK_MAX_TOKENS"];
+      process.env["CHUNK_MAX_TOKENS"] = "7000";
+      try {
+        // The shared beforeEach instances were built WITHOUT the env var, so
+        // construct fresh ones that pick up the override.
+        const envFileChunker = new FileChunker();
+        const envPipeline = new IncrementalUpdatePipeline(
+          envFileChunker,
+          mockEmbeddingProvider,
+          mockStorageClient,
+          logger
+        );
+
+        await mkdir(join(testDir, "src"), { recursive: true });
+        // ~26,000 chars on one line → ~6,500 estimated tokens, one chunk
+        // (line-based chunking cannot split a single line).
+        const bigLine = `export const blob = "${"a".repeat(26000)}";`;
+        await writeFile(join(testDir, "src/bigline.ts"), bigLine);
+
+        const changes: FileChange[] = [{ path: "src/bigline.ts", status: "added" }];
+        const options: UpdateOptions = { ...baseOptions, localPath: testDir };
+
+        const result = await envPipeline.processChanges(changes, options);
+
+        // Chunk was embedded and stored, not skipped.
+        expect(result.errors).toHaveLength(0);
+        expect(result.stats.chunksSkipped).toBe(0);
+        expect(result.stats.chunksUpserted).toBeGreaterThan(0);
+        expect(mockStorageClient.upsertDocuments).toHaveBeenCalled();
+      } finally {
+        if (savedChunkMaxTokens === undefined) {
+          delete process.env["CHUNK_MAX_TOKENS"];
+        } else {
+          process.env["CHUNK_MAX_TOKENS"] = savedChunkMaxTokens;
+        }
       }
     });
   });

--- a/tests/services/incremental-update-pipeline.test.ts
+++ b/tests/services/incremental-update-pipeline.test.ts
@@ -686,10 +686,90 @@ describe("IncrementalUpdatePipeline", () => {
 
       // File was "added" in stats but embedding failed
       expect(result.stats.filesAdded).toBe(1);
-      // Error should be captured
+      // Error should be captured (per-batch since issue #589)
       expect(result.errors).toHaveLength(1);
-      expect(result.errors[0]?.path).toBe("(batch embedding/storage)");
+      expect(result.errors[0]?.path).toBe("(embedding batch 1/1)");
       expect(result.errors[0]?.error).toContain("rate limit");
+      expect(result.stats.chunksUpserted).toBe(0);
+    });
+
+    it("should isolate embedding failures per batch (issue #589)", async () => {
+      // Generate enough chunks for two embedding batches (>100 chunks total).
+      // FileChunker caps a single file at MAX_CHUNKS_PER_FILE (100), so use two
+      // files. Each line is ~85 chars (~22 estimated tokens); 500-token chunks
+      // give ~70 chunks per 1700-line file → ~140 chunks across both files.
+      await mkdir(join(testDir, "src"), { recursive: true });
+      const makeLines = (tag: string): string =>
+        Array.from(
+          { length: 1700 },
+          (_, i) => `export const ${tag}${i} = "padding-padding-padding-padding-padding-${i}";`
+        ).join("\n");
+      await writeFile(join(testDir, "src/big1.ts"), makeLines("alpha"));
+      await writeFile(join(testDir, "src/big2.ts"), makeLines("beta"));
+
+      // First embedding call fails (e.g., oversized input rejected by the API),
+      // subsequent calls succeed.
+      let call = 0;
+      mockEmbeddingProvider.generateEmbeddings = mock(async (texts: string[]) => {
+        call++;
+        if (call === 1) {
+          throw new Error("Invalid 'input[8]': maximum input length is 8192 tokens.");
+        }
+        return texts.map(() => new Array(1536).fill(0.1) as number[]);
+      });
+
+      const changes: FileChange[] = [
+        { path: "src/big1.ts", status: "added" },
+        { path: "src/big2.ts", status: "added" },
+      ];
+      const options: UpdateOptions = { ...baseOptions, localPath: testDir };
+
+      const result = await pipeline.processChanges(changes, options);
+
+      // More than one batch must have been attempted
+      expect(call).toBeGreaterThan(1);
+
+      // Exactly one batch failed; its error is recorded with batch context
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.path).toMatch(/^\(embedding batch 1\/\d+\)$/);
+      expect(result.errors[0]?.error).toContain("maximum input length");
+
+      // Remaining batches were still embedded and stored
+      expect(result.stats.chunksUpserted).toBeGreaterThan(0);
+      expect(mockStorageClient.upsertDocuments).toHaveBeenCalled();
+    });
+
+    it("should skip oversized chunks instead of failing the batch (issue #589)", async () => {
+      // A single-line file produces a single chunk regardless of size (line-based
+      // chunking cannot split it), far above the embedding input limit.
+      await mkdir(join(testDir, "src"), { recursive: true });
+      const giantLine = `export const blob = "${"a".repeat(30000)}";`;
+      await writeFile(join(testDir, "src/minified.ts"), giantLine);
+      await writeFile(join(testDir, "src/normal.ts"), "export const ok = 1;");
+
+      const changes: FileChange[] = [
+        { path: "src/minified.ts", status: "added" },
+        { path: "src/normal.ts", status: "added" },
+      ];
+      const options: UpdateOptions = { ...baseOptions, localPath: testDir };
+
+      const result = await pipeline.processChanges(changes, options);
+
+      // The oversized chunk is skipped with a per-chunk error
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]?.path).toBe("src/minified.ts");
+      expect(result.errors[0]?.error).toContain("exceeds embedding input limit");
+
+      // The normal file's chunk was still embedded and stored
+      expect(result.stats.chunksUpserted).toBeGreaterThan(0);
+
+      // The oversized content was never sent to the embedding provider
+      const sentTexts = (
+        mockEmbeddingProvider.generateEmbeddings as ReturnType<typeof mock>
+      ).mock.calls.flatMap((c) => c[0] as string[]);
+      for (const text of sentTexts) {
+        expect(text.length).toBeLessThan(24000);
+      }
     });
   });
 

--- a/tests/unit/documents/DocumentChunker.test.ts
+++ b/tests/unit/documents/DocumentChunker.test.ts
@@ -337,6 +337,48 @@ describe("DocumentChunker", () => {
       }
     });
 
+    test("oversized paragraph arriving mid-group is still sub-chunked (issue #589)", () => {
+      const chunker = createChunker({
+        maxChunkTokens: 100,
+        overlapTokens: 20,
+        respectParagraphs: true,
+        respectPageBoundaries: false,
+      });
+
+      // Regression for issue #589: a large markdown table (single newlines, so
+      // one paragraph block) arriving while a paragraph group was in progress
+      // bypassed chunkOversizedParagraph and was emitted whole as a single
+      // chunk far above maxChunkTokens, which embedding providers reject.
+      const intro = "This is an introductory paragraph that starts a group before the table.";
+      const tableRows = Array.from(
+        { length: 100 },
+        (_, i) => `| 4.${i} | 2026-03-${(i % 28) + 1} | Project Management | Added task ${i} |`
+      );
+      const table = [
+        "| Version | Date | Author | Changes |",
+        "|---------|------|--------|---------|",
+        ...tableRows,
+      ].join("\n");
+      const outro = "A concluding paragraph after the table.";
+      const content = `${intro}\n\n${table}\n\n${outro}`;
+
+      const result = createMockExtractionResult({ content });
+      const chunks = chunker.chunkDocument(result, TEST_FILE_PATH, TEST_SOURCE);
+
+      expect(chunks.length).toBeGreaterThan(1);
+
+      // No chunk may exceed the configured token limit
+      for (const chunk of chunks) {
+        expect(estimateTokens(chunk.content)).toBeLessThanOrEqual(100);
+      }
+
+      // No content lost: intro, last table row, and outro all present
+      const reassembled = chunks.map((c) => c.content).join("\n");
+      expect(reassembled).toContain("introductory paragraph");
+      expect(reassembled).toContain("| 4.99 |");
+      expect(reassembled).toContain("concluding paragraph");
+    });
+
     test("multi-line oversized paragraph still uses line-level splitting", () => {
       const chunker = createChunker({
         maxChunkTokens: 50,
@@ -1188,9 +1230,13 @@ describe("DocumentChunker", () => {
     });
 
     test("Windows CRLF line endings produce same paragraph split as LF equivalents", () => {
-      // Each paragraph is ~6-7 tokens; use limit of 6 to force separate chunks
+      // Each paragraph is 6-7 tokens; use limit of 7 so every paragraph fits in
+      // exactly one chunk while any two paragraphs together exceed the limit.
+      // (Was 6 before issue #589: a 7-token paragraph then slid through as a
+      // single over-limit chunk; the fixed chunker now correctly sub-chunks it,
+      // which would change the count this test pins.)
       const chunker = createChunker({
-        maxChunkTokens: 6,
+        maxChunkTokens: 7,
         overlapTokens: 0,
         respectParagraphs: true,
         respectPageBoundaries: false,

--- a/tests/unit/services/change-detection-service.test.ts
+++ b/tests/unit/services/change-detection-service.test.ts
@@ -386,7 +386,12 @@ describe("ChangeDetectionService", () => {
       await fs.promises.writeFile(path.join(testFolder.path, "file1.md"), "content 1");
       await fs.promises.writeFile(path.join(testFolder.path, "file2.md"), "content 2");
 
-      await new Promise((resolve) => setTimeout(resolve, 300));
+      // Poll instead of a fixed sleep: watcher event latency varies with host
+      // load (a fixed 300ms wait intermittently missed the second event on CI)
+      const deadline = Date.now() + 5000;
+      while (changeDetection.getTrackedFileCount() < 2 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
 
       expect(changeDetection.getTrackedFileCount()).toBe(2);
     });


### PR DESCRIPTION
Fixes #589

## Summary

Three-layer fix for the 2026-06-05 incident where a single >8,192-token markdown-table chunk in `Muzehub-code` caused **945 chunks (139 files) to be deleted from the vector index with nothing written back**, while the commit SHA advanced anyway — making the loss silent and permanent.

```
EmbeddingValidationError: Client error: 400 Invalid 'input[8]': maximum input length is 8192 tokens.
```

## Changes

### 1. `DocumentChunker.chunkByParagraphs` — root cause
An oversized paragraph was only routed to `chunkOversizedParagraph()` when the current paragraph group was empty. With a group in progress (near-certain due to overlap seeding), the giant paragraph was pushed whole and flushed as a single chunk far above `maxTokens`. Markdown tables have no blank lines, so a ~50KB changelog table = one "paragraph" (~12,500 estimated tokens).

**Fix:** oversized paragraphs now always flush the in-progress group first, then sub-chunk via the existing line/sentence/word fallback hierarchy.

### 2. `IncrementalUpdatePipeline.embedAndStoreChunks` — blast-radius containment
Previously all chunks for the update (1,752 in the incident) were embedded and upserted as one all-or-nothing operation, after the per-file chunk deletes had already run. One bad chunk = total vector data loss for every changed file.

**Fix:** embedding + upsert now run per batch (100 chunks) with per-batch error isolation. Additionally, chunks whose estimated size exceeds `MAX_EMBEDDING_INPUT_TOKENS` (6,000 estimated; OpenAI hard limit is 8,192 real) are skipped up-front with a per-chunk error — defense in depth against future chunker regressions (e.g., single-line minified files in the line-based `FileChunker` can still exceed the limit).

### 3. `IncrementalUpdateCoordinator` — no silent SHA advancement
**Fix:** when changed files produced zero stored chunks alongside errors, `lastIndexedCommitSha` no longer advances, the run returns `incomplete`, and `errorMessage` says retry will occur. Repo status stays `ready` so existing chunks remain searchable. Delete-only updates and partial-success updates (some chunks stored) advance normally.

The local-folder coordinator shares `IncrementalUpdatePipeline.processChanges`, so it inherits fixes 1–2 automatically (it has no commit SHA, so fix 3 doesn't apply).

## Test adjustments (pre-existing tests)

Two existing tests pinned the buggy behavior and required minimal updates:
- **CRLF/LF equivalence test**: `maxChunkTokens` 6 → 7. Test paragraphs are 6–7 tokens; under the old code a 7-token paragraph slid through as one over-limit chunk, keeping the count at 3. The fixed chunker correctly sub-chunks it. Raising the limit to 7 preserves the test's actual purpose (CRLF vs LF equivalence with one chunk per paragraph).
- **Embedding-failure test**: error path label updated from `(batch embedding/storage)` to per-batch `(embedding batch 1/1)`.

## New tests

- Regression: oversized markdown-table paragraph arriving mid-group is sub-chunked; no chunk exceeds the limit; no content lost
- Per-batch isolation: first batch fails, remaining batches still stored, failure recorded with batch context
- Oversized-chunk skip: giant single-line file skipped per-chunk, sibling file still embedded, oversized text never sent to the provider
- SHA guard: incident-shaped run (139 files, 0 upserts, 1 error) does not advance SHA, repo stays `ready`; delete-only and partial-success runs still advance

## Verification

- `bun run typecheck` — clean
- `bun run test:coverage` — 5,278 pass / 1 fail: `RoslynParser` beforeEach hook timeout (dotnet warmup contention under full-suite load); passes 35/35 in isolation; unrelated to this change
- Coverage: 91.10% funcs / 92.22% lines (≥90% standard)
- `bun run build` — clean
- ESLint/Prettier on changed files — clean (CRLF `␍` noise from autocrlf checkout excluded; CI runs on LF)

## Notes

- PR is 453 insertions, slightly over the 400-line guideline — it is a single cohesive fix + its regression tests for one incident; splitting would separate the fix layers from the tests that prove them.
- Index repair for the damaged `Muzehub-code` / `PersonalKnowledgeMCP` indexes will be run against this build after review (SHA rollback + incremental re-run; details in follow-up comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
