### PR TITLE
fix(#591): resolve embedding provider per repository in incremental updates

### DIFF
--- a/src/cli/utils/dependency-init.ts
+++ b/src/cli/utils/dependency-init.ts
@@ -19,6 +19,7 @@ import { IngestionService as IngestionServiceImpl } from "../../services/ingesti
 import { ChromaStorageClientImpl } from "../../storage/chroma-client.js";
 import { createEmbeddingProvider } from "../../providers/factory.js";
 import { embeddingProviderFactory } from "../../providers/EmbeddingProviderFactory.js";
+import { RepositoryEmbeddingProviderResolver } from "../../providers/repository-provider-resolver.js";
 import { resolveEmbeddingDefaults } from "../../providers/provider-defaults.js";
 import { RepositoryMetadataStoreImpl } from "../../repositories/metadata-store.js";
 import { RepositoryCloner } from "../../ingestion/repository-cloner.js";
@@ -250,6 +251,13 @@ export async function initializeDependencies(
       "Embedding provider initialized"
     );
 
+    // Per-repository provider resolution (#591): updates embed with the
+    // provider each repository was indexed with, not the CLI-resolved default.
+    const providerResolver = new RepositoryEmbeddingProviderResolver(
+      embeddingProviderFactory,
+      embeddingProvider
+    );
+
     // Step 4: Initialize ChromaDB storage client
     const chromaClient = new ChromaStorageClientImpl({
       host: config.chromadb.host,
@@ -446,7 +454,8 @@ export async function initializeDependencies(
       getComponentLogger("services:incremental-update-pipeline"),
       graphIngestionService,
       documentTypeDetector,
-      documentChunker
+      documentChunker,
+      providerResolver
     );
     logger.debug(
       { graphEnabled: !!graphIngestionService },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { PersonalKnowledgeMCPServer } from "./mcp/server.js";
 import { SearchServiceImpl } from "./services/search-service.js";
 import { createEmbeddingProvider } from "./providers/factory.js";
 import { embeddingProviderFactory } from "./providers/EmbeddingProviderFactory.js";
+import { RepositoryEmbeddingProviderResolver } from "./providers/repository-provider-resolver.js";
 import { resolveEmbeddingDefaults } from "./providers/provider-defaults.js";
 import { RepositoryMetadataStoreImpl } from "./repositories/metadata-store.js";
 import { initializeLogger, getComponentLogger, type LogLevel } from "./logging/index.js";
@@ -160,6 +161,14 @@ async function main(): Promise<void> {
         dimensions: embeddingProvider.dimensions,
       },
       "Embedding provider initialized"
+    );
+
+    // Per-repository provider resolution (#591): one shared resolver so update
+    // pipelines embed with the provider each repository was indexed with
+    // instead of the process-global default. Shares one provider cache.
+    const providerResolver = new RepositoryEmbeddingProviderResolver(
+      embeddingProviderFactory,
+      embeddingProvider
     );
 
     // Step 3: Initialize instance router and ChromaDB storage client
@@ -360,7 +369,8 @@ async function main(): Promise<void> {
       getComponentLogger("services:folder-update-pipeline"),
       undefined, // No graph ingestion for folder watching (can be added later)
       folderDocTypeDetector,
-      folderDocChunker
+      folderDocChunker,
+      providerResolver
     );
     const folderDocumentIndexingService = new FolderDocumentIndexingService(
       folderUpdatePipeline,
@@ -481,7 +491,8 @@ async function main(): Promise<void> {
           getComponentLogger("services:incremental-update-pipeline"),
           graphIngestionService,
           documentTypeDetector,
-          documentChunker
+          documentChunker,
+          providerResolver
         );
 
         // Create completeness checker

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -59,3 +59,7 @@ export { createEmbeddingProvider } from "./factory.js";
 // Factory class (for advanced usage and discovery)
 export { EmbeddingProviderFactory, embeddingProviderFactory } from "./EmbeddingProviderFactory.js";
 export type { ProviderInfo, ProviderType } from "./EmbeddingProviderFactory.js";
+
+// Per-repository provider resolution (#591)
+export { RepositoryEmbeddingProviderResolver } from "./repository-provider-resolver.js";
+export type { EmbeddingMetadataLike, ProviderFactoryLike } from "./repository-provider-resolver.js";

--- a/src/providers/repository-provider-resolver.ts
+++ b/src/providers/repository-provider-resolver.ts
@@ -1,0 +1,153 @@
+/**
+ * Per-repository embedding provider resolution.
+ *
+ * Repositories record the embedding provider they were indexed with
+ * (`embeddingProvider` / `embeddingModel` / `embeddingDimensions` in repository
+ * metadata, mirrored as `app:embedding_*` keys in their ChromaDB collection
+ * metadata). Any operation that generates embeddings against an existing
+ * collection — query-time search and incremental updates alike — must use that
+ * provider, not whatever the process-global default happens to be (issue #591:
+ * a transformersjs/384 repo updated by a server whose global provider was
+ * openai/1536 had every vector rejected by ChromaDB).
+ *
+ * This resolver extracts the provider-cache pattern previously duplicated in
+ * SearchService.getOrCreateProvider and
+ * DocumentSearchService.getProviderForRepository so all consumers share one
+ * implementation (and one cache when wired with a shared instance).
+ *
+ * @see GitHub issue #591
+ * @module providers/repository-provider-resolver
+ */
+
+import type { EmbeddingProvider, EmbeddingProviderConfig } from "./types.js";
+import type { ProviderType } from "./EmbeddingProviderFactory.js";
+import { resolveEmbeddingDefaults } from "./provider-defaults.js";
+
+/**
+ * Structural factory contract accepted by the resolver.
+ *
+ * `EmbeddingProviderFactory` satisfies this; consumers that inject a narrower
+ * factory (e.g., SearchService's structural factory interface) do too.
+ * `resolveProviderType` is optional — without it, provider-aware defaults fall
+ * back to pass-through behavior for unrecognized providers.
+ */
+export interface ProviderFactoryLike {
+  /** Create a provider from full configuration. */
+  createProvider(config: EmbeddingProviderConfig): EmbeddingProvider;
+  /** Resolve a provider id/alias to its canonical type (optional). */
+  resolveProviderType?(providerId: string): ProviderType | undefined;
+}
+
+/**
+ * The subset of repository (or collection) metadata needed to resolve a
+ * provider. Matches the optional embedding fields on `RepositoryInfo` and the
+ * parsed `app:embedding_*` collection metadata (`ParsedEmbeddingMetadata`).
+ */
+export interface EmbeddingMetadataLike {
+  /** Provider identifier (e.g., "openai", "transformersjs", "ollama"). */
+  provider?: string;
+  /** Model identifier (e.g., "text-embedding-3-small", "Xenova/all-MiniLM-L6-v2"). */
+  model?: string;
+  /** Embedding vector dimensions (e.g., 1536, 384, 768). */
+  dimensions?: number;
+}
+
+/**
+ * Resolves embedding providers from repository/collection metadata with
+ * caching and a default-provider short-circuit.
+ *
+ * Resolution rules:
+ * - No `provider` in the metadata → the default provider (repos indexed before
+ *   per-repository provider support).
+ * - Missing `model`/`dimensions` → filled from provider-aware defaults
+ *   (`resolveEmbeddingDefaults`, the #581 helper), so a bare provider id still
+ *   resolves to a working configuration.
+ * - Matching the default provider's `provider:model:dimensions` triple reuses
+ *   the default instance instead of constructing a duplicate.
+ * - Construction failures propagate the factory's typed `EmbeddingError`
+ *   subclasses unchanged (e.g., `EmbeddingValidationError` for unsupported
+ *   providers or missing credentials).
+ *
+ * @example
+ * ```typescript
+ * const resolver = new RepositoryEmbeddingProviderResolver(factory, defaultProvider);
+ * const provider = resolver.resolve({
+ *   provider: repo.embeddingProvider,
+ *   model: repo.embeddingModel,
+ *   dimensions: repo.embeddingDimensions,
+ * });
+ * ```
+ */
+export class RepositoryEmbeddingProviderResolver {
+  /**
+   * Cache of created providers keyed by `provider:model:dimensions`.
+   *
+   * Providers are stateless beyond their loaded model/connection, so reusing
+   * an instance per configuration avoids repeated model loads (significant
+   * for transformersjs, where construction implies ONNX model initialization).
+   */
+  private readonly providerCache = new Map<string, EmbeddingProvider>();
+
+  /**
+   * @param factory - Factory used to construct non-default providers
+   * @param defaultProvider - Process-global provider used when metadata names
+   *   no provider, and reused when metadata matches its configuration
+   */
+  constructor(
+    private readonly factory: ProviderFactoryLike,
+    private readonly defaultProvider: EmbeddingProvider
+  ) {}
+
+  /**
+   * Resolve the embedding provider for the given repository/collection metadata.
+   *
+   * @param meta - Embedding metadata (provider/model/dimensions, all optional)
+   * @returns A provider matching the metadata, or the default provider when no
+   *   provider is named
+   * @throws {EmbeddingValidationError} If the named provider is unsupported or
+   *   its required credentials/configuration are missing
+   */
+  resolve(meta: EmbeddingMetadataLike): EmbeddingProvider {
+    if (!meta.provider) {
+      return this.defaultProvider;
+    }
+
+    // Fill missing model/dimensions with provider-aware defaults (#581). The
+    // recorded model (when present) belongs to the recorded provider, so it is
+    // passed through; only absent fields get defaults.
+    const providerType = this.factory.resolveProviderType?.(meta.provider);
+    const defaults = resolveEmbeddingDefaults(providerType, meta.model, meta.dimensions);
+    const model = meta.model ?? defaults.model;
+    const dimensions = meta.dimensions ?? defaults.dimensions;
+
+    const cacheKey = `${meta.provider}:${model}:${dimensions}`;
+
+    const cached = this.providerCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    // Reuse the default instance when the metadata describes it exactly
+    if (
+      meta.provider === this.defaultProvider.providerId &&
+      model === this.defaultProvider.modelId &&
+      dimensions === this.defaultProvider.dimensions
+    ) {
+      this.providerCache.set(cacheKey, this.defaultProvider);
+      return this.defaultProvider;
+    }
+
+    const config: EmbeddingProviderConfig = {
+      provider: meta.provider,
+      model,
+      dimensions,
+      batchSize: 100,
+      maxRetries: 3,
+      timeoutMs: 30000,
+    };
+
+    const provider = this.factory.createProvider(config);
+    this.providerCache.set(cacheKey, provider);
+    return provider;
+  }
+}

--- a/src/services/document-search-service.ts
+++ b/src/services/document-search-service.ts
@@ -11,7 +11,9 @@
 
 import { z } from "zod";
 import type { Logger } from "pino";
-import type { EmbeddingProvider, EmbeddingProviderConfig } from "../providers/types.js";
+import type { EmbeddingProvider } from "../providers/types.js";
+import { RepositoryEmbeddingProviderResolver } from "../providers/repository-provider-resolver.js";
+import type { ProviderFactoryLike } from "../providers/repository-provider-resolver.js";
 import type { ChromaStorageClient, SimilarityResult, MetadataFilter } from "../storage/types.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../repositories/types.js";
 import type {
@@ -89,13 +91,6 @@ const DocumentSearchQuerySchema = z
 type ValidatedDocumentSearchQuery = z.infer<typeof DocumentSearchQuerySchema>;
 
 /**
- * Interface for creating embedding providers on-demand
- */
-interface EmbeddingProviderFactory {
-  createProvider(config: EmbeddingProviderConfig): EmbeddingProvider;
-}
-
-/**
  * Implementation of DocumentSearchService using ChromaDB for vector similarity search
  *
  * Searches document collections in ChromaDB, filtering by document type and folder.
@@ -122,17 +117,23 @@ export class DocumentSearchServiceImpl implements DocumentSearchService {
   private _logger: Logger | null = null;
 
   /**
-   * Cache of created providers to avoid recreating for same provider/model combo
-   * Key format: "{providerId}:{modelId}:{dimensions}"
+   * Shared per-repository provider resolution (#591) — caches created
+   * providers by provider/model/dimensions and applies provider-aware
+   * defaults for incomplete metadata.
    */
-  private readonly providerCache = new Map<string, EmbeddingProvider>();
+  private readonly providerResolver: RepositoryEmbeddingProviderResolver;
 
   constructor(
     private readonly defaultEmbeddingProvider: EmbeddingProvider,
-    private readonly embeddingProviderFactory: EmbeddingProviderFactory,
+    embeddingProviderFactory: ProviderFactoryLike,
     private readonly storageClient: ChromaStorageClient,
     private readonly repositoryService: RepositoryMetadataService
-  ) {}
+  ) {
+    this.providerResolver = new RepositoryEmbeddingProviderResolver(
+      embeddingProviderFactory,
+      defaultEmbeddingProvider
+    );
+  }
 
   /**
    * Lazy-initialized logger
@@ -438,42 +439,25 @@ export class DocumentSearchServiceImpl implements DocumentSearchService {
   }
 
   /**
-   * Get or create the embedding provider for a repository
+   * Get or create the embedding provider for a repository.
+   *
+   * Delegates to the shared RepositoryEmbeddingProviderResolver (#591). Note:
+   * missing model/dimensions are now filled with provider-aware defaults
+   * (#581) instead of the default provider's model — previously a repo
+   * recording only `embeddingProvider: "transformersjs"` would have been
+   * paired with the default provider's (e.g., OpenAI) model name.
    */
   private getProviderForRepository(repo?: RepositoryInfo): EmbeddingProvider {
     if (!repo?.embeddingProvider) {
       return this.defaultEmbeddingProvider;
     }
 
-    const cacheKey = `${repo.embeddingProvider}:${repo.embeddingModel}:${repo.embeddingDimensions}`;
-    const cached = this.providerCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    // Check if it matches default
-    if (
-      repo.embeddingProvider === this.defaultEmbeddingProvider.providerId &&
-      repo.embeddingModel === this.defaultEmbeddingProvider.modelId
-    ) {
-      this.providerCache.set(cacheKey, this.defaultEmbeddingProvider);
-      return this.defaultEmbeddingProvider;
-    }
-
-    // Create new provider
     try {
-      const config: EmbeddingProviderConfig = {
+      return this.providerResolver.resolve({
         provider: repo.embeddingProvider,
-        model: repo.embeddingModel ?? this.defaultEmbeddingProvider.modelId,
-        dimensions: repo.embeddingDimensions ?? this.defaultEmbeddingProvider.dimensions,
-        batchSize: 100,
-        maxRetries: 3,
-        timeoutMs: 30000,
-      };
-
-      const provider = this.embeddingProviderFactory.createProvider(config);
-      this.providerCache.set(cacheKey, provider);
-      return provider;
+        model: repo.embeddingModel,
+        dimensions: repo.embeddingDimensions,
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new ProviderUnavailableError(repo.embeddingProvider, message);

--- a/src/services/incremental-update-coordinator-errors.ts
+++ b/src/services/incremental-update-coordinator-errors.ts
@@ -191,3 +191,37 @@ export class ConcurrentUpdateError extends CoordinatorError {
     Object.setPrototypeOf(this, ConcurrentUpdateError.prototype);
   }
 }
+
+/**
+ * Error thrown when the resolved embedding provider's dimensions do not match
+ * the target collection's recorded dimensions.
+ *
+ * Raised by the update pipeline BEFORE any chunk deletion so a provider
+ * misconfiguration cannot destroy existing index data (issue #591: embedding
+ * with a 1536-dim provider against a 384-dim collection had every vector
+ * rejected after the per-file deletes already ran). Not retryable — the
+ * provider configuration or repository metadata must be corrected first.
+ *
+ * @example
+ * ```typescript
+ * throw new UpdateDimensionMismatchError("my-api", 384, 1536, "openai");
+ * ```
+ */
+export class UpdateDimensionMismatchError extends CoordinatorError {
+  constructor(
+    public readonly repositoryName: string,
+    public readonly collectionDimensions: number,
+    public readonly providerDimensions: number,
+    public readonly providerId: string
+  ) {
+    super(
+      `Embedding dimension mismatch for repository '${repositoryName}': ` +
+        `collection expects ${collectionDimensions} dimensions but provider ` +
+        `'${providerId}' produces ${providerDimensions}. No chunks were modified. ` +
+        `Verify the repository's embedding provider metadata or re-index with the intended provider.`,
+      false
+    );
+    this.name = "UpdateDimensionMismatchError";
+    Object.setPrototypeOf(this, UpdateDimensionMismatchError.prototype);
+  }
+}

--- a/src/services/incremental-update-coordinator.ts
+++ b/src/services/incremental-update-coordinator.ts
@@ -482,6 +482,13 @@ export class IncrementalUpdateCoordinator {
         includeExtensions: repo.includeExtensions,
         excludePatterns: repo.excludePatterns,
         correlationId,
+        // Per-repository provider fallback for legacy collections without
+        // embedding metadata (#591)
+        repoEmbedding: {
+          provider: repo.embeddingProvider,
+          model: repo.embeddingModel,
+          dimensions: repo.embeddingDimensions,
+        },
       });
 
       logger.info(

--- a/src/services/incremental-update-pipeline.ts
+++ b/src/services/incremental-update-pipeline.ts
@@ -11,9 +11,11 @@
 import { join, resolve } from "node:path";
 import ignore from "ignore";
 import type { Logger } from "pino";
-import type { ChromaStorageClient } from "../storage/index.js";
+import type { ChromaStorageClient, ParsedEmbeddingMetadata } from "../storage/index.js";
 import type { FileChunker } from "../ingestion/file-chunker.js";
 import type { EmbeddingProvider } from "../providers/index.js";
+import type { RepositoryEmbeddingProviderResolver } from "../providers/index.js";
+import { UpdateDimensionMismatchError } from "./incremental-update-coordinator-errors.js";
 import type { FileInfo, FileChunk } from "../ingestion/types.js";
 import type { DocumentInput } from "../storage/index.js";
 import type {
@@ -109,12 +111,16 @@ export class IncrementalUpdatePipeline {
    * Create an incremental update pipeline.
    *
    * @param fileChunker - Service for splitting files into chunks
-   * @param embeddingProvider - Service for generating embeddings
+   * @param embeddingProvider - Default service for generating embeddings (used
+   *   when no per-repository provider can be resolved)
    * @param storageClient - ChromaDB client for vector storage
    * @param logger - Logger instance
    * @param graphIngestionService - Optional graph ingestion service for graph database updates
    * @param documentTypeDetector - Optional detector for routing document files to extractors
    * @param documentChunker - Optional document-aware chunker for PDF, DOCX, Markdown
+   * @param providerResolver - Optional per-repository provider resolver (#591).
+   *   When present, each update embeds with the provider recorded in the target
+   *   collection's metadata (or `options.repoEmbedding`) instead of the default.
    */
   constructor(
     private readonly fileChunker: FileChunker,
@@ -123,7 +129,8 @@ export class IncrementalUpdatePipeline {
     private readonly logger: Logger,
     private readonly graphIngestionService?: GraphIngestionService,
     private readonly documentTypeDetector?: DocumentTypeDetector,
-    private readonly documentChunker?: DocumentChunker
+    private readonly documentChunker?: DocumentChunker,
+    private readonly providerResolver?: RepositoryEmbeddingProviderResolver
   ) {
     // Derive the per-chunk skip ceiling from the operator's CHUNK_MAX_TOKENS
     // override so a larger configured chunk size doesn't cause every chunk to be
@@ -300,6 +307,74 @@ export class IncrementalUpdatePipeline {
       "Filtered changes by extension and exclusion patterns"
     );
 
+    // Per-repository embedding provider selection (#591). Updates must embed
+    // with the provider the collection was indexed with, not the process-global
+    // default — otherwise vectors with the wrong dimensions are rejected
+    // wholesale by ChromaDB. Selection order: collection embedding metadata
+    // (ground truth) → options.repoEmbedding (repository metadata, for legacy
+    // collections) → the pipeline's default provider. Resolved BEFORE the
+    // per-file loop so a dimension mismatch fails fast without deleting any
+    // existing chunks.
+    const hasContentChanges = filteredChanges.some((c) => c.status !== "deleted");
+    let embeddingProvider = this.embeddingProvider;
+    if (hasContentChanges) {
+      let collectionMeta: ParsedEmbeddingMetadata | null = null;
+      try {
+        collectionMeta = await this.storageClient.getCollectionEmbeddingMetadata(
+          options.collectionName
+        );
+      } catch (error) {
+        // Metadata lookup failures must not block the update — fall through to
+        // repo metadata / default provider (pre-#591 behavior).
+        logger.debug(
+          {
+            operation: "pipeline_provider_resolution",
+            collection: options.collectionName,
+            error: error instanceof Error ? error.message : String(error),
+          },
+          "Could not read collection embedding metadata - using repo metadata or default provider"
+        );
+      }
+
+      const providerMeta = collectionMeta?.provider
+        ? collectionMeta
+        : options.repoEmbedding?.provider
+          ? options.repoEmbedding
+          : null;
+
+      if (providerMeta && this.providerResolver) {
+        embeddingProvider = this.providerResolver.resolve(providerMeta);
+        if (embeddingProvider !== this.embeddingProvider) {
+          logger.info(
+            {
+              operation: "pipeline_provider_resolution",
+              repository: options.repository,
+              provider: embeddingProvider.providerId,
+              model: embeddingProvider.modelId,
+              dimensions: embeddingProvider.dimensions,
+              source: collectionMeta?.provider ? "collection_metadata" : "repository_metadata",
+            },
+            "Using repository-specific embedding provider"
+          );
+        }
+      }
+
+      // Fail fast on dimension mismatch BEFORE any chunk deletion. The
+      // destructive failure mode this prevents: per-file deletes run first,
+      // then every embed batch is rejected, leaving files unindexed (#591).
+      if (
+        collectionMeta?.dimensions !== undefined &&
+        embeddingProvider.dimensions !== collectionMeta.dimensions
+      ) {
+        throw new UpdateDimensionMismatchError(
+          options.repository,
+          collectionMeta.dimensions,
+          embeddingProvider.dimensions,
+          embeddingProvider.providerId
+        );
+      }
+    }
+
     // Collect all chunks from added/modified/renamed files for batch embedding.
     // Uses InternalChunk to support both code files (via FileChunker) and
     // document files (via DocumentChunker) in a single accumulator.
@@ -383,7 +458,14 @@ export class IncrementalUpdatePipeline {
     // last resort for unexpected failures outside the batch loop.
     if (allChunks.length > 0) {
       try {
-        await this.embedAndStoreChunks(allChunks, options.collectionName, stats, errors, logger);
+        await this.embedAndStoreChunks(
+          allChunks,
+          options.collectionName,
+          stats,
+          errors,
+          logger,
+          embeddingProvider
+        );
       } catch (error) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         const errorType = error instanceof Error ? error.constructor.name : "Unknown";
@@ -965,13 +1047,16 @@ export class IncrementalUpdatePipeline {
    * @param stats - Statistics to update
    * @param errors - Error collector for skipped chunks and failed batches
    * @param logger - Correlation-aware logger
+   * @param embeddingProvider - Provider selected for this update (#591) — the
+   *   repository's recorded provider when resolvable, else the default
    */
   private async embedAndStoreChunks(
     chunks: InternalChunk[],
     collectionName: string,
     stats: UpdateStats,
     errors: FileProcessingError[],
-    logger: Logger
+    logger: Logger,
+    embeddingProvider: EmbeddingProvider
   ): Promise<void> {
     const startTime = Date.now();
 
@@ -1034,7 +1119,7 @@ export class IncrementalUpdatePipeline {
       );
 
       try {
-        const embeddings = await this.embeddingProvider.generateEmbeddings(
+        const embeddings = await embeddingProvider.generateEmbeddings(
           batch.map((c) => c.content)
         );
 

--- a/src/services/incremental-update-pipeline.ts
+++ b/src/services/incremental-update-pipeline.ts
@@ -1119,9 +1119,7 @@ export class IncrementalUpdatePipeline {
       );
 
       try {
-        const embeddings = await embeddingProvider.generateEmbeddings(
-          batch.map((c) => c.content)
-        );
+        const embeddings = await embeddingProvider.generateEmbeddings(batch.map((c) => c.content));
 
         // Create DocumentInput objects for this batch
         const documents: DocumentInput[] = batch.map((chunk, index) => {

--- a/src/services/incremental-update-types.ts
+++ b/src/services/incremental-update-types.ts
@@ -132,6 +132,31 @@ export interface UpdateOptions {
    * @example "update-1734367200-a3c9f"
    */
   correlationId?: string;
+
+  /**
+   * Embedding configuration recorded in the repository's metadata (#591).
+   *
+   * Used as the provider-selection fallback when the target collection has no
+   * embedding metadata of its own (collections created before per-repository
+   * provider support). The pipeline prefers the collection's `app:embedding_*`
+   * metadata as ground truth; this field covers legacy collections so updates
+   * still embed with the provider the repository was indexed with rather than
+   * the process-global default.
+   *
+   * Optional so existing callers and test mocks remain valid; when omitted and
+   * the collection has no metadata, the pipeline's default provider is used
+   * (pre-#591 behavior).
+   *
+   * @example { provider: "transformersjs", model: "Xenova/all-MiniLM-L6-v2", dimensions: 384 }
+   */
+  repoEmbedding?: {
+    /** Provider identifier (e.g., "openai", "transformersjs", "ollama"). */
+    provider?: string;
+    /** Model identifier the repository was indexed with. */
+    model?: string;
+    /** Embedding vector dimensions the repository was indexed with. */
+    dimensions?: number;
+  };
 }
 
 // =============================================================================

--- a/src/services/index-repair-service.ts
+++ b/src/services/index-repair-service.ts
@@ -269,6 +269,13 @@ export class IndexRepairService {
         collectionName: repo.collectionName,
         includeExtensions: repo.includeExtensions,
         excludePatterns: repo.excludePatterns,
+        // Per-repository provider fallback for legacy collections without
+        // embedding metadata (#591)
+        repoEmbedding: {
+          provider: repo.embeddingProvider,
+          model: repo.embeddingModel,
+          dimensions: repo.embeddingDimensions,
+        },
       });
       chunksUpserted = pipelineResult.stats.chunksUpserted;
       // FileProcessingError.path is the failed file (relative to repo root).

--- a/src/services/local-folder-update-coordinator.ts
+++ b/src/services/local-folder-update-coordinator.ts
@@ -243,6 +243,13 @@ export class LocalFolderUpdateCoordinator {
         collectionName: repo.collectionName,
         includeExtensions: repo.includeExtensions,
         excludePatterns: repo.excludePatterns,
+        // Per-repository provider fallback for legacy collections without
+        // embedding metadata (#591)
+        repoEmbedding: {
+          provider: repo.embeddingProvider,
+          model: repo.embeddingModel,
+          dimensions: repo.embeddingDimensions,
+        },
       });
 
       const totalFilesProcessed =

--- a/src/services/search-service.ts
+++ b/src/services/search-service.ts
@@ -9,7 +9,9 @@
 
 import { z } from "zod";
 import type { Logger } from "pino";
-import type { EmbeddingProvider, EmbeddingProviderConfig } from "../providers/types.js";
+import type { EmbeddingProvider } from "../providers/types.js";
+import { RepositoryEmbeddingProviderResolver } from "../providers/repository-provider-resolver.js";
+import type { ProviderFactoryLike } from "../providers/repository-provider-resolver.js";
 import type { ChromaStorageClient, SimilarityResult } from "../storage/types.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../repositories/types.js";
 import type {
@@ -56,14 +58,6 @@ const LANGUAGE_TO_EXTENSIONS: Record<string, string[]> = {
   html: [".html", ".htm"],
   css: [".css", ".scss", ".sass", ".less"],
 };
-
-/**
- * Interface for creating embedding providers on-demand
- * Used for multi-provider search to create providers dynamically
- */
-interface EmbeddingProviderFactory {
-  createProvider(config: EmbeddingProviderConfig): EmbeddingProvider;
-}
 
 /**
  * Group of repositories that share the same embedding provider
@@ -133,17 +127,23 @@ export class SearchServiceImpl implements SearchService {
   private _logger: Logger | null = null;
 
   /**
-   * Cache of created providers to avoid recreating for same provider/model combo
-   * Key format: "{providerId}:{modelId}:{dimensions}"
+   * Shared per-repository provider resolution (#591) — caches created
+   * providers by provider/model/dimensions and applies provider-aware
+   * defaults for incomplete metadata.
    */
-  private readonly providerCache = new Map<string, EmbeddingProvider>();
+  private readonly providerResolver: RepositoryEmbeddingProviderResolver;
 
   constructor(
     private readonly defaultEmbeddingProvider: EmbeddingProvider,
-    private readonly embeddingProviderFactory: EmbeddingProviderFactory,
+    embeddingProviderFactory: ProviderFactoryLike,
     private readonly storageClient: ChromaStorageClient,
     private readonly repositoryService: RepositoryMetadataService
-  ) {}
+  ) {
+    this.providerResolver = new RepositoryEmbeddingProviderResolver(
+      embeddingProviderFactory,
+      defaultEmbeddingProvider
+    );
+  }
 
   /**
    * Lazy-initialized logger
@@ -435,45 +435,16 @@ export class SearchServiceImpl implements SearchService {
    * @throws {ProviderUnavailableError} If provider cannot be created
    */
   private getOrCreateProvider(group: ProviderGroup): EmbeddingProvider {
-    const cacheKey = `${group.providerId}:${group.modelId}:${group.dimensions}`;
-
-    // Check cache first
-    const cached = this.providerCache.get(cacheKey);
-    if (cached) {
-      return cached;
-    }
-
-    // Check if this matches the default provider
-    if (
-      group.providerId === this.defaultEmbeddingProvider.providerId &&
-      group.modelId === this.defaultEmbeddingProvider.modelId &&
-      group.dimensions === this.defaultEmbeddingProvider.dimensions
-    ) {
-      this.providerCache.set(cacheKey, this.defaultEmbeddingProvider);
-      return this.defaultEmbeddingProvider;
-    }
-
-    // Create new provider via factory
+    // Delegates to the shared RepositoryEmbeddingProviderResolver (#591),
+    // which owns the cache and the default-provider short-circuit. Group
+    // fields are always populated (filled from the default provider during
+    // grouping), so resolution is deterministic.
     try {
-      const config: EmbeddingProviderConfig = {
-        provider: group.providerId,
-        model: group.modelId,
-        dimensions: group.dimensions,
-        batchSize: 100, // Default batch size
-        maxRetries: 3,
-        timeoutMs: 30000,
-      };
-
-      const provider = this.embeddingProviderFactory.createProvider(config);
-      this.providerCache.set(cacheKey, provider);
-
-      this.logger.debug("Created new embedding provider", {
+      return this.providerResolver.resolve({
         provider: group.providerId,
         model: group.modelId,
         dimensions: group.dimensions,
       });
-
-      return provider;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       throw new ProviderUnavailableError(group.providerId, message);

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -41,6 +41,8 @@ export type {
   CollectionStats,
   MetadataFilter,
   DocumentQueryResult,
+  CollectionEmbeddingMetadata,
+  ParsedEmbeddingMetadata,
 } from "./types.js";
 
 // Export all error classes

--- a/tests/services/incremental-update-coordinator.test.ts
+++ b/tests/services/incremental-update-coordinator.test.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../src/services/github-client-types.js";
 import type { RepositoryMetadataService, RepositoryInfo } from "../../src/repositories/types.js";
 import type { IncrementalUpdatePipeline } from "../../src/services/incremental-update-pipeline.js";
-import type { UpdateResult } from "../../src/services/incremental-update-types.js";
+import type { UpdateResult, UpdateOptions } from "../../src/services/incremental-update-types.js";
 import { GitHubNotFoundError } from "../../src/services/github-client-errors.js";
 import {
   RepositoryNotFoundError,
@@ -320,6 +320,13 @@ describe("IncrementalUpdateCoordinator", () => {
         excludePatterns: testRepo.excludePatterns,
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         correlationId: expect.any(String), // correlationId
+        // Repo-level embedding metadata fallback (#591); testRepo predates
+        // per-repository provider support so all fields are undefined
+        repoEmbedding: {
+          provider: undefined,
+          model: undefined,
+          dimensions: undefined,
+        },
       });
 
       // Verify metadata was updated
@@ -1838,6 +1845,43 @@ describe("IncrementalUpdateCoordinator", () => {
       expect(git.remote).not.toHaveBeenCalled();
       expect(git.pull).toHaveBeenCalledWith("origin", "main");
       expect(order).toEqual(["pull"]);
+    });
+  });
+
+  describe("per-repository embedding provider (issue #591)", () => {
+    it("passes the repository's embedding metadata to the pipeline as repoEmbedding", async () => {
+      // Repository indexed with a non-default provider — the pipeline needs
+      // this metadata as the fallback when the collection has no embedding
+      // metadata of its own (legacy collections).
+      mockRepositoryService.getRepository = mock(async () => ({
+        ...testRepo,
+        embeddingProvider: "transformersjs",
+        embeddingModel: "Xenova/all-MiniLM-L6-v2",
+        embeddingDimensions: 384,
+      }));
+
+      await coordinator.updateRepository("test-repo");
+
+      const callOptions = (mockUpdatePipeline.processChanges as ReturnType<typeof mock>).mock
+        .calls[0]?.[1] as UpdateOptions | undefined;
+      expect(callOptions?.repoEmbedding).toEqual({
+        provider: "transformersjs",
+        model: "Xenova/all-MiniLM-L6-v2",
+        dimensions: 384,
+      });
+    });
+
+    it("passes undefined embedding fields for repositories without provider metadata", async () => {
+      // testRepo predates per-repository provider support — fields absent
+      await coordinator.updateRepository("test-repo");
+
+      const callOptions = (mockUpdatePipeline.processChanges as ReturnType<typeof mock>).mock
+        .calls[0]?.[1] as UpdateOptions | undefined;
+      expect(callOptions?.repoEmbedding).toEqual({
+        provider: undefined,
+        model: undefined,
+        dimensions: undefined,
+      });
     });
   });
 });

--- a/tests/services/incremental-update-pipeline.test.ts
+++ b/tests/services/incremental-update-pipeline.test.ts
@@ -17,6 +17,7 @@ import type { EmbeddingProvider } from "../../src/providers/index.js";
 import type { ChromaStorageClient } from "../../src/storage/index.js";
 import type { FileChange, UpdateOptions } from "../../src/services/incremental-update-types.js";
 import type { GraphIngestionService } from "../../src/graph/ingestion/GraphIngestionService.js";
+import { UpdateDimensionMismatchError } from "../../src/services/incremental-update-coordinator-errors.js";
 
 describe("IncrementalUpdatePipeline", () => {
   let pipeline: IncrementalUpdatePipeline;
@@ -818,6 +819,191 @@ describe("IncrementalUpdatePipeline", () => {
           process.env["CHUNK_MAX_TOKENS"] = savedChunkMaxTokens;
         }
       }
+    });
+  });
+
+  describe("per-repository provider resolution (issue #591)", () => {
+    const baseOptions: UpdateOptions = {
+      repository: "test-repo",
+      localPath: "",
+      collectionName: "test_collection",
+      includeExtensions: [".ts", ".js", ".md"],
+      excludePatterns: ["node_modules/**", "dist/**"],
+    };
+
+    /** Build a fake provider with identity fields and call tracking. */
+    function fakeProvider(
+      providerId: string,
+      modelId: string,
+      dimensions: number
+    ): EmbeddingProvider {
+      return {
+        providerId,
+        modelId,
+        dimensions,
+        generateEmbedding: mock(async () => new Array(dimensions).fill(0.1) as number[]),
+        generateEmbeddings: mock(async (texts: string[]) =>
+          texts.map(() => new Array(dimensions).fill(0.1) as number[])
+        ),
+        healthCheck: mock(async () => true),
+        getCapabilities: () => ({
+          maxBatchSize: 100,
+          maxTokensPerText: 8191,
+          supportsGPU: false,
+          requiresNetwork: false,
+          estimatedLatencyMs: 1,
+        }),
+      };
+    }
+
+    it("embeds with the provider from collection metadata, not the default", async () => {
+      await mkdir(join(testDir, "src"), { recursive: true });
+      await writeFile(join(testDir, "src/a.ts"), "export const a = 1;");
+
+      const repoProvider = fakeProvider("transformersjs", "Xenova/all-MiniLM-L6-v2", 384);
+      const resolver = {
+        resolve: mock(() => repoProvider),
+      };
+      mockStorageClient.getCollectionEmbeddingMetadata = mock(async () => ({
+        provider: "transformersjs",
+        model: "Xenova/all-MiniLM-L6-v2",
+        dimensions: 384,
+      }));
+
+      const resolvingPipeline = new IncrementalUpdatePipeline(
+        fileChunker,
+        mockEmbeddingProvider,
+        mockStorageClient,
+        logger,
+        undefined,
+        undefined,
+        undefined,
+        resolver as unknown as ConstructorParameters<typeof IncrementalUpdatePipeline>[7]
+      );
+
+      const result = await resolvingPipeline.processChanges(
+        [{ path: "src/a.ts", status: "added" }],
+        { ...baseOptions, localPath: testDir }
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(result.stats.chunksUpserted).toBeGreaterThan(0);
+      // Resolver consulted with the collection's metadata
+      expect(resolver.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "transformersjs", dimensions: 384 })
+      );
+      // The repository provider embedded the chunks; the default did not
+      expect(repoProvider.generateEmbeddings).toHaveBeenCalled();
+      expect(mockEmbeddingProvider.generateEmbeddings).not.toHaveBeenCalled();
+    });
+
+    it("falls back to options.repoEmbedding when the collection has no metadata", async () => {
+      await mkdir(join(testDir, "src"), { recursive: true });
+      await writeFile(join(testDir, "src/b.ts"), "export const b = 2;");
+
+      const repoProvider = fakeProvider("ollama", "nomic-embed-text", 768);
+      const resolver = { resolve: mock(() => repoProvider) };
+      mockStorageClient.getCollectionEmbeddingMetadata = mock(async () => null);
+
+      const resolvingPipeline = new IncrementalUpdatePipeline(
+        fileChunker,
+        mockEmbeddingProvider,
+        mockStorageClient,
+        logger,
+        undefined,
+        undefined,
+        undefined,
+        resolver as unknown as ConstructorParameters<typeof IncrementalUpdatePipeline>[7]
+      );
+
+      const result = await resolvingPipeline.processChanges(
+        [{ path: "src/b.ts", status: "added" }],
+        {
+          ...baseOptions,
+          localPath: testDir,
+          repoEmbedding: { provider: "ollama", model: "nomic-embed-text", dimensions: 768 },
+        }
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(resolver.resolve).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "ollama" })
+      );
+      expect(repoProvider.generateEmbeddings).toHaveBeenCalled();
+      expect(mockEmbeddingProvider.generateEmbeddings).not.toHaveBeenCalled();
+    });
+
+    it("uses the default provider when neither collection nor repo metadata name one", async () => {
+      await mkdir(join(testDir, "src"), { recursive: true });
+      await writeFile(join(testDir, "src/c.ts"), "export const c = 3;");
+
+      const resolver = { resolve: mock(() => fakeProvider("x", "y", 1)) };
+      mockStorageClient.getCollectionEmbeddingMetadata = mock(async () => null);
+
+      const resolvingPipeline = new IncrementalUpdatePipeline(
+        fileChunker,
+        mockEmbeddingProvider,
+        mockStorageClient,
+        logger,
+        undefined,
+        undefined,
+        undefined,
+        resolver as unknown as ConstructorParameters<typeof IncrementalUpdatePipeline>[7]
+      );
+
+      const result = await resolvingPipeline.processChanges(
+        [{ path: "src/c.ts", status: "added" }],
+        { ...baseOptions, localPath: testDir }
+      );
+
+      expect(result.errors).toHaveLength(0);
+      expect(resolver.resolve).not.toHaveBeenCalled();
+      expect(mockEmbeddingProvider.generateEmbeddings).toHaveBeenCalled();
+    });
+
+    it("fails fast on dimension mismatch BEFORE deleting any chunks", async () => {
+      await mkdir(join(testDir, "src"), { recursive: true });
+      await writeFile(join(testDir, "src/d.ts"), "export const d = 4;");
+
+      // Collection is 384-dim but no resolver is wired, so the 1536-dim
+      // default would be used — the destructive pre-#591 scenario. The
+      // pipeline must throw before processModifiedFile deletes old chunks.
+      mockStorageClient.getCollectionEmbeddingMetadata = mock(async () => ({
+        provider: "transformersjs",
+        model: "Xenova/all-MiniLM-L6-v2",
+        dimensions: 384,
+      }));
+
+      const noResolverPipeline = new IncrementalUpdatePipeline(
+        fileChunker,
+        mockEmbeddingProvider, // 1536-dim default
+        mockStorageClient,
+        logger
+      );
+
+      await expect(
+        noResolverPipeline.processChanges([{ path: "src/d.ts", status: "modified" }], {
+          ...baseOptions,
+          localPath: testDir,
+        })
+      ).rejects.toThrow(UpdateDimensionMismatchError);
+
+      // Nothing was deleted and nothing was embedded
+      expect(mockStorageClient.deleteDocumentsByFilePrefix).not.toHaveBeenCalled();
+      expect(mockEmbeddingProvider.generateEmbeddings).not.toHaveBeenCalled();
+    });
+
+    it("does not consult collection metadata for delete-only updates", async () => {
+      const metadataMock = mock(async () => null);
+      mockStorageClient.getCollectionEmbeddingMetadata = metadataMock;
+
+      const result = await pipeline.processChanges([{ path: "src/gone.ts", status: "deleted" }], {
+        ...baseOptions,
+        localPath: testDir,
+      });
+
+      expect(result.stats.filesDeleted).toBe(1);
+      expect(metadataMock).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/services/incremental-update-pipeline.test.ts
+++ b/tests/services/incremental-update-pipeline.test.ts
@@ -981,6 +981,7 @@ describe("IncrementalUpdatePipeline", () => {
         logger
       );
 
+      // eslint-disable-next-line @typescript-eslint/await-thenable
       await expect(
         noResolverPipeline.processChanges([{ path: "src/d.ts", status: "modified" }], {
           ...baseOptions,

--- a/tests/unit/providers/repository-provider-resolver.test.ts
+++ b/tests/unit/providers/repository-provider-resolver.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for RepositoryEmbeddingProviderResolver (#591).
+ *
+ * Verifies per-repository provider resolution: default fallback, cache
+ * behavior, default-provider short-circuit, provider-aware defaults fill
+ * (#581), and factory error propagation.
+ */
+
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { RepositoryEmbeddingProviderResolver } from "../../../src/providers/repository-provider-resolver.js";
+import { EmbeddingProviderFactory } from "../../../src/providers/EmbeddingProviderFactory.js";
+import { EmbeddingValidationError } from "../../../src/providers/errors.js";
+import type { EmbeddingProvider, EmbeddingProviderConfig } from "../../../src/providers/types.js";
+
+/**
+ * Build a lightweight fake provider with the identity fields the resolver
+ * inspects. Embedding methods are never called by the resolver itself.
+ */
+function fakeProvider(providerId: string, modelId: string, dimensions: number): EmbeddingProvider {
+  return {
+    providerId,
+    modelId,
+    dimensions,
+    generateEmbedding: mock(async () => new Array(dimensions).fill(0) as number[]),
+    generateEmbeddings: mock(async (texts: string[]) =>
+      texts.map(() => new Array(dimensions).fill(0) as number[])
+    ),
+    healthCheck: mock(async () => true),
+    getCapabilities: () => ({
+      maxBatchSize: 100,
+      maxTokensPerText: 8191,
+      supportsGPU: false,
+      requiresNetwork: false,
+      estimatedLatencyMs: 1,
+    }),
+  };
+}
+
+describe("RepositoryEmbeddingProviderResolver", () => {
+  let factory: EmbeddingProviderFactory;
+  let createProviderMock: ReturnType<typeof mock>;
+  let defaultProvider: EmbeddingProvider;
+  let resolver: RepositoryEmbeddingProviderResolver;
+
+  beforeEach(() => {
+    defaultProvider = fakeProvider("openai", "text-embedding-3-small", 1536);
+
+    factory = new EmbeddingProviderFactory();
+    createProviderMock = mock((config: EmbeddingProviderConfig) =>
+      fakeProvider(config.provider, config.model, config.dimensions)
+    );
+    factory.createProvider = createProviderMock as unknown as typeof factory.createProvider;
+
+    resolver = new RepositoryEmbeddingProviderResolver(factory, defaultProvider);
+  });
+
+  test("returns the default provider when metadata names no provider", () => {
+    const provider = resolver.resolve({});
+    expect(provider).toBe(defaultProvider);
+    expect(createProviderMock).not.toHaveBeenCalled();
+  });
+
+  test("creates a provider matching full metadata", () => {
+    const provider = resolver.resolve({
+      provider: "transformersjs",
+      model: "Xenova/all-MiniLM-L6-v2",
+      dimensions: 384,
+    });
+
+    expect(provider.providerId).toBe("transformersjs");
+    expect(provider.modelId).toBe("Xenova/all-MiniLM-L6-v2");
+    expect(provider.dimensions).toBe(384);
+    expect(createProviderMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("caches providers by provider:model:dimensions", () => {
+    const meta = { provider: "transformersjs", model: "Xenova/all-MiniLM-L6-v2", dimensions: 384 };
+    const first = resolver.resolve(meta);
+    const second = resolver.resolve({ ...meta });
+
+    expect(second).toBe(first);
+    expect(createProviderMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("different configurations get distinct cache entries", () => {
+    const a = resolver.resolve({ provider: "transformersjs", model: "m-a", dimensions: 384 });
+    const b = resolver.resolve({ provider: "transformersjs", model: "m-b", dimensions: 384 });
+
+    expect(a).not.toBe(b);
+    expect(createProviderMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("reuses the default instance when metadata describes it exactly", () => {
+    const provider = resolver.resolve({
+      provider: "openai",
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+    });
+
+    expect(provider).toBe(defaultProvider);
+    expect(createProviderMock).not.toHaveBeenCalled();
+  });
+
+  test("fills missing model and dimensions from provider defaults (#581)", () => {
+    const provider = resolver.resolve({ provider: "transformersjs" });
+
+    // Provider-aware defaults: transformersjs → Xenova/all-MiniLM-L6-v2 @ 384
+    expect(provider.modelId).toBe("Xenova/all-MiniLM-L6-v2");
+    expect(provider.dimensions).toBe(384);
+    const config = createProviderMock.mock.calls[0]?.[0] as EmbeddingProviderConfig;
+    expect(config.model).toBe("Xenova/all-MiniLM-L6-v2");
+    expect(config.dimensions).toBe(384);
+  });
+
+  test("fills missing dimensions when only model is recorded", () => {
+    resolver.resolve({ provider: "transformersjs", model: "Xenova/all-MiniLM-L6-v2" });
+
+    const config = createProviderMock.mock.calls[0]?.[0] as EmbeddingProviderConfig;
+    expect(config.dimensions).toBe(384);
+  });
+
+  test("propagates factory errors for unsupported providers", () => {
+    factory.createProvider = ((config: EmbeddingProviderConfig) => {
+      throw new EmbeddingValidationError(`Unsupported provider: ${config.provider}`, "provider");
+    }) as typeof factory.createProvider;
+    resolver = new RepositoryEmbeddingProviderResolver(factory, defaultProvider);
+
+    expect(() => resolver.resolve({ provider: "no-such-provider", dimensions: 42 })).toThrow(
+      EmbeddingValidationError
+    );
+  });
+});


### PR DESCRIPTION
Fixes #591

## Summary

Server-side incremental updates (MCP `trigger_incremental_update`, `update-all`, local-folder updates, index repair, folder watcher) embedded chunks with the **process-global** provider regardless of what the repository was indexed with. Observed in production 2026-06-07: a transformersjs/384-dim repo updated by a server whose global provider is openai/1536 had **every vector rejected by ChromaDB** (35 files, 494 chunks deleted, 0 upserted). Since #589 this fails *safe* (SHA held, repo stays `ready`) but could never *succeed* — such repos were stuck retrying until someone ran the CLI with `EMBEDDING_PROVIDER=...`.

## Changes

### New shared resolver — `src/providers/repository-provider-resolver.ts`
`RepositoryEmbeddingProviderResolver` extracts the provider-cache pattern previously duplicated in `SearchService.getOrCreateProvider` and `DocumentSearchService.getProviderForRepository`: cache keyed `provider:model:dimensions`, default-provider short-circuit, factory construction, and **#581 provider-aware defaults** for incomplete metadata. Accepts a structural `ProviderFactoryLike` so both the real factory and the services' narrow factory interfaces satisfy it.

### Pipeline-centric per-update provider selection — `incremental-update-pipeline.ts`
One change point covers all four `processChanges` call sites. Selection order when content-producing changes exist:
1. **Collection embedding metadata** (`app:embedding_*`, ground truth)
2. **`options.repoEmbedding`** (repository metadata — fallback for legacy collections)
3. Pipeline default provider (pre-#591 behavior)

Plus a **fail-fast dimension guard**: if the collection records dimensions and the selected provider disagrees, `UpdateDimensionMismatchError` is thrown **before the per-file loop** — the destructive part of the old failure was delete-then-reject; nothing is deleted on a mismatch.

### Callers and wiring
- Git coordinator, local-folder coordinator, and `IndexRepairService` pass `repoEmbedding` from repository metadata (~5 lines each); the folder-watcher path is covered by collection metadata
- `src/index.ts` (server) and `cli/utils/dependency-init.ts` (CLI) wire one shared resolver into the pipelines

### Dedup refactor
`SearchService` and `DocumentSearchService` now delegate to the shared resolver (two hand-rolled copies removed). Behavioral improvement in `DocumentSearchService`: a repo recording only `embeddingProvider` now gets **provider-aware defaults** (#581) instead of being paired with the default provider's (possibly foreign) model name.

## Tests
- New resolver unit suite (8 tests): cache, default short-circuit, #581 defaults fill, error propagation
- Pipeline (5 new): provider from collection metadata (asserts repo provider embeds, default does not), `repoEmbedding` fallback, default fallback, **fail-fast before any `deleteDocumentsByFilePrefix` call**, delete-only updates skip metadata lookup
- Coordinator (2 new): `repoEmbedding` pass-through with and without repo metadata
- All existing search/doc-search/coordinator/repair tests pass unchanged (one assertion extended for the new options field)

## Verification
- `bun run typecheck` clean · `bun run build` clean · prettier/eslint clean on changed files (CRLF noise excluded)
- `bun run test:coverage`: **5,112 pass**, coverage **91.28% funcs / 92.44% lines** (≥90%). 5 failures are the known local-environment flakes (4× table-extractor export tests — worktree sharp build under full-suite load, 90/90 in isolation; 1× RoslynParser dotnet warmup) — same set as PR #590's worktree, unrelated to this change, green on CI
- **E2E with the local serializer ($0 OpenAI)**: scratch repo indexed `--provider transformersjs` while `.env` is OpenAI-shaped → commit → `bun run cli update` with **no provider env at all** → log shows `Using repository-specific embedding provider … dimensions: 384`, update `success`, stored vector verified 384-dim in ChromaDB. This is the exact production failure scenario, now working.

## Notes
- PR is ~760 insertions (over the 400-line guideline): the fix + its mandatory test coverage + the dedup refactor form one cohesive unit; splitting would ship the bug fix without the tests proving it or leave a third copy of the provider-cache pattern
- One extra ChromaDB metadata GET per update — negligible (same call search already uses)
- After merge + MCP server restart, `trigger_incremental_update` on transformersjs-backed repos (the #591 repro) should succeed without CLI workarounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
