### PR TITLE
fix(#591): apply PR #592 post-merge review — harden dimension guard, warn on missing resolver, test doc-search defaults

### DIFF
--- a/src/services/incremental-update-pipeline.ts
+++ b/src/services/incremental-update-pipeline.ts
@@ -357,18 +357,32 @@ export class IncrementalUpdatePipeline {
             "Using repository-specific embedding provider"
           );
         }
+      } else if (providerMeta && !this.providerResolver) {
+        // Metadata records a specific provider but no resolver is wired, so we
+        // cannot honor it — the default provider is used and may mismatch.
+        logger.warn(
+          {
+            operation: "pipeline_provider_resolution",
+            repository: options.repository,
+            recordedProvider: providerMeta.provider,
+            defaultProvider: this.embeddingProvider.providerId,
+          },
+          "Repository records an embedding provider but no resolver is wired - " +
+            "embedding with the default provider"
+        );
       }
 
       // Fail fast on dimension mismatch BEFORE any chunk deletion. The
       // destructive failure mode this prevents: per-file deletes run first,
       // then every embed batch is rejected, leaving files unindexed (#591).
-      if (
-        collectionMeta?.dimensions !== undefined &&
-        embeddingProvider.dimensions !== collectionMeta.dimensions
-      ) {
+      // When the collection metadata read fails (collectionMeta stays null),
+      // fall back to options.repoEmbedding?.dimensions so a transient ChromaDB
+      // error can't silently skip the guard and let the destructive sequence run.
+      const guardDimensions = collectionMeta?.dimensions ?? options.repoEmbedding?.dimensions;
+      if (guardDimensions !== undefined && embeddingProvider.dimensions !== guardDimensions) {
         throw new UpdateDimensionMismatchError(
           options.repository,
-          collectionMeta.dimensions,
+          guardDimensions,
           embeddingProvider.dimensions,
           embeddingProvider.providerId
         );

--- a/tests/services/incremental-update-pipeline.test.ts
+++ b/tests/services/incremental-update-pipeline.test.ts
@@ -994,6 +994,45 @@ describe("IncrementalUpdatePipeline", () => {
       expect(mockEmbeddingProvider.generateEmbeddings).not.toHaveBeenCalled();
     });
 
+    it("falls back to repoEmbedding dimensions for the guard when metadata read fails", async () => {
+      await mkdir(join(testDir, "src"), { recursive: true });
+      await writeFile(join(testDir, "src/e.ts"), "export const e = 5;");
+
+      // getCollectionEmbeddingMetadata throws (transient ChromaDB error) so
+      // collectionMeta stays null. Without the repoEmbedding fallback the guard
+      // would be skipped and per-file deletes would run with the mismatched
+      // 1536-dim default (the #591 destructive sequence). The guard must instead
+      // derive its expected dimensions from options.repoEmbedding (384) and fail
+      // fast before any delete.
+      mockStorageClient.getCollectionEmbeddingMetadata = mock(async () => {
+        throw new Error("ChromaDB unavailable");
+      });
+
+      const noResolverPipeline = new IncrementalUpdatePipeline(
+        fileChunker,
+        mockEmbeddingProvider, // 1536-dim default
+        mockStorageClient,
+        logger
+      );
+
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      await expect(
+        noResolverPipeline.processChanges([{ path: "src/e.ts", status: "modified" }], {
+          ...baseOptions,
+          localPath: testDir,
+          repoEmbedding: {
+            provider: "transformersjs",
+            model: "Xenova/all-MiniLM-L6-v2",
+            dimensions: 384,
+          },
+        })
+      ).rejects.toThrow(UpdateDimensionMismatchError);
+
+      // The guard tripped before processModifiedFile could delete old chunks
+      expect(mockStorageClient.deleteDocumentsByFilePrefix).not.toHaveBeenCalled();
+      expect(mockEmbeddingProvider.generateEmbeddings).not.toHaveBeenCalled();
+    });
+
     it("does not consult collection metadata for delete-only updates", async () => {
       const metadataMock = mock(async () => null);
       mockStorageClient.getCollectionEmbeddingMetadata = metadataMock;

--- a/tests/unit/services/document-search-service.test.ts
+++ b/tests/unit/services/document-search-service.test.ts
@@ -75,15 +75,27 @@ class MockEmbeddingProviderFactory {
   /** Count of createProvider invocations for caching verification */
   createProviderCallCount = 0;
 
+  /** Config passed to the most recent createProvider call (for #581 assertions) */
+  lastConfig: EmbeddingProviderConfig | null = null;
+
   /** When set, createProvider will throw this error */
   private errorToThrow: Error | null = null;
 
-  createProvider(_config: EmbeddingProviderConfig): EmbeddingProvider {
+  createProvider(config: EmbeddingProviderConfig): EmbeddingProvider {
     this.createProviderCallCount++;
+    this.lastConfig = config;
     if (this.errorToThrow) {
       throw this.errorToThrow;
     }
     return new MockEmbeddingProvider();
+  }
+
+  /**
+   * Resolve a provider id to its canonical type. Required for the resolver's
+   * provider-aware default lookup (#581) to engage instead of pass-through.
+   */
+  resolveProviderType(providerId: string): "transformersjs" | undefined {
+    return providerId === "transformersjs" ? "transformersjs" : undefined;
   }
 
   /** Configure factory to throw on next createProvider call */
@@ -94,6 +106,7 @@ class MockEmbeddingProviderFactory {
   /** Reset the factory to default behavior */
   reset(): void {
     this.createProviderCallCount = 0;
+    this.lastConfig = null;
     this.errorToThrow = null;
   }
 }
@@ -871,6 +884,30 @@ describe("DocumentSearchServiceImpl", () => {
       // Second search should use cached provider (factory not called again)
       await service.searchDocuments({ query: "second search" });
       expect(mockFactory.createProviderCallCount).toBe(1);
+    });
+
+    it("applies provider-aware defaults when repo records only embeddingProvider (#581)", async () => {
+      // Repo records the provider but no model/dimensions. After delegating to
+      // the shared resolver (#591), the missing fields are filled with the
+      // transformersjs provider-aware defaults (#581) — NOT the default
+      // provider's model name. Previously this repo would have been paired with
+      // the default provider's (e.g., OpenAI) model.
+      mockRepoService.setRepositories([
+        createMockRepo({
+          name: "provider-only-folder",
+          embeddingProvider: "transformersjs",
+          // no embeddingModel / embeddingDimensions
+        }),
+      ]);
+      mockStorage.setMockResults([]);
+
+      await service.searchDocuments({ query: "test provider-only repo" });
+
+      // Factory created the provider from defaulted config, not the default provider's
+      expect(mockFactory.createProviderCallCount).toBe(1);
+      expect(mockFactory.lastConfig?.provider).toBe("transformersjs");
+      expect(mockFactory.lastConfig?.model).toBe("Xenova/all-MiniLM-L6-v2");
+      expect(mockFactory.lastConfig?.dimensions).toBe(384);
     });
 
     it("should propagate factory errors as ProviderUnavailableError", async () => {


### PR DESCRIPTION
## Summary

Applies all findings from the [post-merge code review of PR #592](https://github.com/sethships/PersonalKnowledgeMCP/pull/592#issuecomment-4641964068) (the review completed just after #592 merged, so the fixes land here). Refs #591.

| # | Severity | Fix |
|---|----------|-----|
| L1 | Low | The fail-fast dimension guard in `incremental-update-pipeline.ts` now falls back to `repoEmbedding`'s recorded dimensions when the collection-metadata read throws — a transient ChromaDB error previously skipped the guard entirely, re-opening the delete-then-reject destructive window the guard exists to close |
| L2 | Low | When provider metadata names a provider but no resolver is wired, the pipeline now `warn`s (recorded vs default provider) instead of silently embedding with the default — a same-dimension/different-provider mismatch would otherwise degrade vectors undetectably |
| M1 | Medium | New test pinning the document-search delegation behavior change: a repo recording only `embeddingProvider` resolves to provider-aware defaults (`Xenova/all-MiniLM-L6-v2` @ 384, #581) instead of the default provider's model name. The factory-throws → `ProviderUnavailableError` case was already covered by an existing test |

## Tests
- New: `falls back to repoEmbedding dimensions for the guard when metadata read fails` (asserts `UpdateDimensionMismatchError` thrown with `deleteDocumentsByFilePrefix` never called)
- New: `applies provider-aware defaults when repo records only embeddingProvider (#581)`

## Verification
- `bun run typecheck` clean · `bun run build` clean · prettier/eslint clean on changed files (CRLF noise excluded)
- `bun run test:coverage`: **5,114 pass**, coverage **91.28% funcs / 92.44% lines**; the 5 failures are the known local worktree flakes (4× table-extractor export tests — sharp under full-suite load, pass in isolation; 1× RoslynParser dotnet warmup) — green on CI
- Targeted: 157 pass across pipeline/doc-search/resolver/coordinator files; both touched source files at 100% line/function coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)
