### PR TITLE
chore: gitignore runtime-generated docx-table test fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,9 @@ mcp_cache/
 mcp_sessions/
 *.mcp.log
 
+# Runtime-generated test fixtures (recreated by DocxTableExtractor's beforeAll)
+tests/fixtures/documents/docx-tables/
+
 # Temporary files
 tmp/
 temp/


### PR DESCRIPTION
## Summary

`tests/fixtures/documents/docx-tables/` is regenerated by the `DocxTableExtractor` test suite's `beforeAll` hook (`createTestDocxTableFiles`) on every `bun test` run. Because the directory was neither tracked nor ignored, it kept reappearing as untracked noise in VS Code / `git status` after each test run.

This adds a single `.gitignore` entry so the working tree stays clean. The fixtures are recreated on demand and never need to be tracked.

## Changes
- `.gitignore`: ignore `tests/fixtures/documents/docx-tables/`

## Verification
- Deleted the directory, ran `bun test tests/unit/documents/DocxTableExtractor.test.ts` -> **44 pass, 0 fail**; the 8 `.docx` fixtures regenerated and `git status` stayed clean (only `.gitignore` modified).
- `bun run typecheck` -> clean (no impact expected from a gitignore-only change).

## Notes
- This diverges slightly from the sibling `tests/fixtures/documents/docx/` directory, whose generated fixtures *are* committed. Ignoring is the cleaner choice for a deterministically-regenerated artifact; happy to commit the binaries instead if matching that convention is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)