### PR TITLE
fix(#596): free tree-sitter syntax trees and parse each file once

### DIFF
--- a/src/graph/extraction/EntityExtractor.ts
+++ b/src/graph/extraction/EntityExtractor.ts
@@ -119,25 +119,10 @@ export class EntityExtractor {
     filePath: string,
     options?: ExtractOptions
   ): Promise<ExtractionResult> {
-    const startTime = performance.now();
-
     this.logger.debug({ filePath, options }, "Extracting entities from content");
 
     const parseResult = await this.parser.parseFile(content, filePath);
-    const result = this.extractFromParseResult(parseResult, options);
-
-    this.logger.info(
-      {
-        metric: "extractor.extract_from_content_ms",
-        value: Math.round(performance.now() - startTime),
-        filePath,
-        entityCount: result.entities.length,
-        filteredCount: parseResult.entities.length - result.entities.length,
-      },
-      "Entity extraction completed"
-    );
-
-    return result;
+    return this.extractFromParseResult(parseResult, options);
   }
 
   /**
@@ -158,14 +143,32 @@ export class EntityExtractor {
   /**
    * Build an extraction result from an already-parsed file.
    *
+   * Emits the extraction timing metric, since this is the one step every
+   * caller shares — the ingestion path parses via {@link parseFile} and never
+   * goes through {@link extractFromContent} (issue #596). The reported value
+   * covers the parse plus the filtering done here.
+   *
    * @param parseResult - Result of a previous {@link parseFile} call
    * @param options - Optional filtering options
    * @returns Extraction result with entities and metadata
    */
   extractFromParseResult(parseResult: ParseResult, options?: ExtractOptions): ExtractionResult {
+    const startTime = performance.now();
+
     const entities = options
       ? this.filterEntities(parseResult.entities, options)
       : parseResult.entities;
+
+    this.logger.info(
+      {
+        metric: "extractor.extract_from_content_ms",
+        value: Math.round(parseResult.parseTimeMs + (performance.now() - startTime)),
+        filePath: parseResult.filePath,
+        entityCount: entities.length,
+        filteredCount: parseResult.entities.length - entities.length,
+      },
+      "Entity extraction completed"
+    );
 
     return {
       entities,

--- a/src/graph/extraction/EntityExtractor.ts
+++ b/src/graph/extraction/EntityExtractor.ts
@@ -39,7 +39,7 @@
 import type pino from "pino";
 import { getComponentLogger } from "../../logging/index.js";
 import { CodeParser } from "../parsing/CodeParser.js";
-import type { CodeEntity, SupportedLanguage } from "../parsing/types.js";
+import type { CodeEntity, ParseResult, SupportedLanguage } from "../parsing/types.js";
 import type {
   EntityExtractorConfig,
   ExtractOptions,
@@ -124,14 +124,50 @@ export class EntityExtractor {
     this.logger.debug({ filePath, options }, "Extracting entities from content");
 
     const parseResult = await this.parser.parseFile(content, filePath);
+    const result = this.extractFromParseResult(parseResult, options);
 
-    // Apply filtering if options provided
-    let entities = parseResult.entities;
-    if (options) {
-      entities = this.filterEntities(entities, options);
-    }
+    this.logger.info(
+      {
+        metric: "extractor.extract_from_content_ms",
+        value: Math.round(performance.now() - startTime),
+        filePath,
+        entityCount: result.entities.length,
+        filteredCount: parseResult.entities.length - result.entities.length,
+      },
+      "Entity extraction completed"
+    );
 
-    const result: ExtractionResult = {
+    return result;
+  }
+
+  /**
+   * Parse a source file without extracting anything.
+   *
+   * Exposed so callers that need both entities and relationships can parse
+   * once and feed the same {@link ParseResult} to both extractors, instead of
+   * paying for (and leaking) a second syntax tree per file (issue #596).
+   *
+   * @param content - Source code content to parse
+   * @param filePath - File path (used for extension detection and in results)
+   * @returns Raw parse result
+   */
+  async parseFile(content: string, filePath: string): Promise<ParseResult> {
+    return this.parser.parseFile(content, filePath);
+  }
+
+  /**
+   * Build an extraction result from an already-parsed file.
+   *
+   * @param parseResult - Result of a previous {@link parseFile} call
+   * @param options - Optional filtering options
+   * @returns Extraction result with entities and metadata
+   */
+  extractFromParseResult(parseResult: ParseResult, options?: ExtractOptions): ExtractionResult {
+    const entities = options
+      ? this.filterEntities(parseResult.entities, options)
+      : parseResult.entities;
+
+    return {
       entities,
       filePath: parseResult.filePath,
       language: parseResult.language,
@@ -139,19 +175,6 @@ export class EntityExtractor {
       errors: parseResult.errors,
       success: parseResult.success,
     };
-
-    this.logger.info(
-      {
-        metric: "extractor.extract_from_content_ms",
-        value: Math.round(performance.now() - startTime),
-        filePath,
-        entityCount: entities.length,
-        filteredCount: parseResult.entities.length - entities.length,
-      },
-      "Entity extraction completed"
-    );
-
-    return result;
   }
 
   /**

--- a/src/graph/extraction/RelationshipExtractor.ts
+++ b/src/graph/extraction/RelationshipExtractor.ts
@@ -40,7 +40,7 @@ import path from "node:path";
 import type pino from "pino";
 import { getComponentLogger } from "../../logging/index.js";
 import { CodeParser } from "../parsing/CodeParser.js";
-import type { SupportedLanguage, ImportInfo, ExportInfo } from "../parsing/types.js";
+import type { SupportedLanguage, ImportInfo, ExportInfo, ParseResult } from "../parsing/types.js";
 import type {
   RelationshipExtractorConfig,
   RelationshipExtractOptions,
@@ -134,39 +134,58 @@ export class RelationshipExtractor {
     );
 
     const parseResult = await this.parser.parseFile(content, filePath);
-
-    // Transform imports to ImportRelationship objects
-    let imports = this.transformImports(parseResult.imports, filePath);
-
-    // Transform exports to ExportRelationship objects
-    let exports = this.transformExports(parseResult.exports, filePath);
-
-    // Apply filtering
-    imports = this.filterImports(imports, mergedOptions);
-    exports = this.filterExports(exports, mergedOptions);
-
-    const result: RelationshipExtractionResult = {
-      imports,
-      exports,
-      filePath: parseResult.filePath,
-      language: parseResult.language,
-      parseTimeMs: parseResult.parseTimeMs,
-      errors: parseResult.errors,
-      success: parseResult.success,
-    };
+    const result = this.extractFromParseResult(parseResult, mergedOptions);
 
     this.logger.info(
       {
         metric: "extractor.extract_relationships_ms",
         value: Math.round(performance.now() - startTime),
         filePath,
-        importCount: imports.length,
-        exportCount: exports.length,
+        importCount: result.imports.length,
+        exportCount: result.exports.length,
       },
       "Relationship extraction completed"
     );
 
     return result;
+  }
+
+  /**
+   * Build a relationship extraction result from an already-parsed file.
+   *
+   * Lets callers that need both entities and relationships parse once and
+   * feed the same {@link ParseResult} to both extractors, instead of paying
+   * for (and leaking) a second syntax tree per file (issue #596).
+   *
+   * @param parseResult - Result of a previous parse
+   * @param options - Optional filtering options
+   * @returns Extraction result with relationships and metadata
+   */
+  extractFromParseResult(
+    parseResult: ParseResult,
+    options?: RelationshipExtractOptions
+  ): RelationshipExtractionResult {
+    const mergedOptions = { ...DEFAULT_RELATIONSHIP_EXTRACT_OPTIONS, ...options };
+    const filePath = parseResult.filePath;
+
+    const imports = this.filterImports(
+      this.transformImports(parseResult.imports, filePath),
+      mergedOptions
+    );
+    const exports = this.filterExports(
+      this.transformExports(parseResult.exports, filePath),
+      mergedOptions
+    );
+
+    return {
+      imports,
+      exports,
+      filePath,
+      language: parseResult.language,
+      parseTimeMs: parseResult.parseTimeMs,
+      errors: parseResult.errors,
+      success: parseResult.success,
+    };
   }
 
   /**

--- a/src/graph/extraction/RelationshipExtractor.ts
+++ b/src/graph/extraction/RelationshipExtractor.ts
@@ -125,7 +125,6 @@ export class RelationshipExtractor {
     filePath: string,
     options?: RelationshipExtractOptions
   ): Promise<RelationshipExtractionResult> {
-    const startTime = performance.now();
     const mergedOptions = { ...DEFAULT_RELATIONSHIP_EXTRACT_OPTIONS, ...options };
 
     this.logger.debug(
@@ -134,20 +133,7 @@ export class RelationshipExtractor {
     );
 
     const parseResult = await this.parser.parseFile(content, filePath);
-    const result = this.extractFromParseResult(parseResult, mergedOptions);
-
-    this.logger.info(
-      {
-        metric: "extractor.extract_relationships_ms",
-        value: Math.round(performance.now() - startTime),
-        filePath,
-        importCount: result.imports.length,
-        exportCount: result.exports.length,
-      },
-      "Relationship extraction completed"
-    );
-
-    return result;
+    return this.extractFromParseResult(parseResult, mergedOptions);
   }
 
   /**
@@ -157,6 +143,11 @@ export class RelationshipExtractor {
    * feed the same {@link ParseResult} to both extractors, instead of paying
    * for (and leaking) a second syntax tree per file (issue #596).
    *
+   * Emits the extraction timing metric, since this is the one step every
+   * caller shares — the ingestion path never goes through
+   * {@link extractFromContent}. The reported value covers the parse plus the
+   * transform/filter work done here.
+   *
    * @param parseResult - Result of a previous parse
    * @param options - Optional filtering options
    * @returns Extraction result with relationships and metadata
@@ -165,6 +156,7 @@ export class RelationshipExtractor {
     parseResult: ParseResult,
     options?: RelationshipExtractOptions
   ): RelationshipExtractionResult {
+    const startTime = performance.now();
     const mergedOptions = { ...DEFAULT_RELATIONSHIP_EXTRACT_OPTIONS, ...options };
     const filePath = parseResult.filePath;
 
@@ -175,6 +167,17 @@ export class RelationshipExtractor {
     const exports = this.filterExports(
       this.transformExports(parseResult.exports, filePath),
       mergedOptions
+    );
+
+    this.logger.info(
+      {
+        metric: "extractor.extract_relationships_ms",
+        value: Math.round(parseResult.parseTimeMs + (performance.now() - startTime)),
+        filePath,
+        importCount: imports.length,
+        exportCount: exports.length,
+      },
+      "Relationship extraction completed"
     );
 
     return {

--- a/src/graph/ingestion/GraphIngestionService.ts
+++ b/src/graph/ingestion/GraphIngestionService.ts
@@ -83,6 +83,18 @@ export class GraphIngestionService {
   private _currentOperation: GraphIngestionServiceStatus["currentOperation"] = null;
   private readonly config: Required<GraphIngestionConfig>;
 
+  /**
+   * @param graphAdapter - Graph storage adapter used for all node/edge writes
+   * @param entityExtractor - Parses every file and extracts entities; its
+   *                          `CodeParser` limits (`maxFileSizeBytes`,
+   *                          `parseTimeoutMs`) govern the whole ingestion path
+   * @param relationshipExtractor - Used only for `extractFromParseResult`.
+   *                                Ingestion parses via
+   *                                `entityExtractor.parseFile` (issue #596),
+   *                                so this instance's own `CodeParser` config
+   *                                never applies here.
+   * @param config - Optional ingestion configuration (batch sizes, etc.)
+   */
   constructor(
     private readonly graphAdapter: GraphStorageAdapter,
     private readonly entityExtractor: EntityExtractor,

--- a/src/graph/ingestion/GraphIngestionService.ts
+++ b/src/graph/ingestion/GraphIngestionService.ts
@@ -253,16 +253,16 @@ export class GraphIngestionService {
         await this.deleteRepositoryData(options.repository);
       }
 
-      // Phase 1: Extract entities from all files
+      // Phases 1 + 2: Extract entities and relationships. Both come from a
+      // single parse per file — parsing twice doubled the cost and leaked a
+      // second syntax tree per file (issue #596).
       this.reportProgress(options, "extracting_entities", 10, { totalFiles: files.length });
-      const entityResults = await this.extractAllEntities(files, errors);
+      const { entityResults, relationshipResults } = await this.extractAll(files, errors);
 
-      // Phase 2: Extract relationships from all files
       this.reportProgress(options, "extracting_relationships", 20, {
         totalFiles: files.length,
         entitiesExtracted: this.countTotalEntities(entityResults),
       });
-      const relationshipResults = await this.extractAllRelationships(files, errors);
 
       // Phase 3: Create Repository node
       this.reportProgress(options, "creating_repository_node", 25, {});
@@ -592,14 +592,10 @@ export class GraphIngestionService {
         };
       }
 
-      // Extract entities
-      const entityResult = await this.entityExtractor.extractFromContent(file.content, file.path);
-
-      // Extract relationships
-      const relationshipResult = await this.relationshipExtractor.extractFromContent(
-        file.content,
-        file.path
-      );
+      // Parse once, derive both entities and relationships from it (issue #596)
+      const parseResult = await this.entityExtractor.parseFile(file.content, file.path);
+      const entityResult = this.entityExtractor.extractFromParseResult(parseResult);
+      const relationshipResult = this.relationshipExtractor.extractFromParseResult(parseResult);
 
       // Create File node using runQuery for flexibility
       const fileNodeId = this.generateFileNodeId(repositoryName, file.path);
@@ -758,13 +754,21 @@ export class GraphIngestionService {
   }
 
   /**
-   * Extract entities from all files.
+   * Extract entities and relationships from all files.
+   *
+   * Each file is parsed exactly once and the resulting AST is handed to both
+   * extractors, which is both twice as fast as the previous two-pass version
+   * and half the peak memory (issue #596).
    */
-  private async extractAllEntities(
+  private async extractAll(
     files: FileInput[],
     errors: GraphIngestionError[]
-  ): Promise<Map<string, ExtractionResult>> {
-    const results = new Map<string, ExtractionResult>();
+  ): Promise<{
+    entityResults: Map<string, ExtractionResult>;
+    relationshipResults: Map<string, RelationshipExtractionResult>;
+  }> {
+    const entityResults = new Map<string, ExtractionResult>();
+    const relationshipResults = new Map<string, RelationshipExtractionResult>();
 
     for (const file of files) {
       if (!EntityExtractor.isSupported(file.path)) {
@@ -772,11 +776,15 @@ export class GraphIngestionService {
       }
 
       try {
-        const result = await this.entityExtractor.extractFromContent(file.content, file.path);
-        results.set(file.path, result);
+        const parseResult = await this.entityExtractor.parseFile(file.content, file.path);
+        entityResults.set(file.path, this.entityExtractor.extractFromParseResult(parseResult));
+        relationshipResults.set(
+          file.path,
+          this.relationshipExtractor.extractFromParseResult(parseResult)
+        );
 
-        if (!result.success) {
-          for (const parseError of result.errors) {
+        if (!parseResult.success) {
+          for (const parseError of parseResult.errors) {
             errors.push({
               type: "extraction_error",
               filePath: file.path,
@@ -799,52 +807,7 @@ export class GraphIngestionService {
       }
     }
 
-    return results;
-  }
-
-  /**
-   * Extract relationships from all files.
-   */
-  private async extractAllRelationships(
-    files: FileInput[],
-    errors: GraphIngestionError[]
-  ): Promise<Map<string, RelationshipExtractionResult>> {
-    const results = new Map<string, RelationshipExtractionResult>();
-
-    for (const file of files) {
-      if (!RelationshipExtractor.isSupported(file.path)) {
-        continue;
-      }
-
-      try {
-        const result = await this.relationshipExtractor.extractFromContent(file.content, file.path);
-        results.set(file.path, result);
-
-        if (!result.success) {
-          for (const parseError of result.errors) {
-            errors.push({
-              type: "extraction_error",
-              filePath: file.path,
-              message: parseError.message,
-            });
-          }
-        }
-      } catch (error) {
-        const extractionError = new IngestionExtractionError(
-          error instanceof Error ? error.message : String(error),
-          file.path,
-          { cause: error instanceof Error ? error : undefined }
-        );
-        errors.push({
-          type: "extraction_error",
-          filePath: file.path,
-          message: extractionError.message,
-          originalError: error,
-        });
-      }
-    }
-
-    return results;
+    return { entityResults, relationshipResults };
   }
 
   /**

--- a/src/graph/parsing/TreeSitterParser.ts
+++ b/src/graph/parsing/TreeSitterParser.ts
@@ -317,50 +317,61 @@ export class TreeSitterParser {
         };
       }
 
-      // Check for syntax errors
-      if (tree.rootNode.hasError) {
-        errors.push(...this.collectSyntaxErrors(tree.rootNode));
-      }
+      try {
+        // Check for syntax errors
+        if (tree.rootNode.hasError) {
+          errors.push(...this.collectSyntaxErrors(tree.rootNode));
+        }
 
-      // Extract entities (language-aware)
-      const entities = this.extractEntities(tree.rootNode, filePath, language);
+        // Extract entities (language-aware)
+        const entities = this.extractEntities(tree.rootNode, filePath, language);
 
-      // Extract imports (language-aware)
-      const imports = this.extractImports(tree.rootNode, language);
+        // Extract imports (language-aware)
+        const imports = this.extractImports(tree.rootNode, language);
 
-      // Extract exports (language-aware - Python doesn't have explicit exports)
-      const exports = this.extractExports(tree.rootNode, language);
+        // Extract exports (language-aware - Python doesn't have explicit exports)
+        const exports = this.extractExports(tree.rootNode, language);
 
-      // Extract function calls (language-aware)
-      const calls = this.extractCalls(tree.rootNode, language);
+        // Extract function calls (language-aware)
+        const calls = this.extractCalls(tree.rootNode, language);
 
-      const parseTimeMs = performance.now() - startTime;
+        const parseTimeMs = performance.now() - startTime;
 
-      this.logger.info(
-        {
-          metric: "parser.parse_file_ms",
-          value: Math.round(parseTimeMs),
+        this.logger.info(
+          {
+            metric: "parser.parse_file_ms",
+            value: Math.round(parseTimeMs),
+            filePath,
+            entityCount: entities.length,
+            importCount: imports.length,
+            exportCount: exports.length,
+            callCount: calls.length,
+            errorCount: errors.length,
+          },
+          "File parsed successfully"
+        );
+
+        return {
           filePath,
-          entityCount: entities.length,
-          importCount: imports.length,
-          exportCount: exports.length,
-          callCount: calls.length,
-          errorCount: errors.length,
-        },
-        "File parsed successfully"
-      );
-
-      return {
-        filePath,
-        language,
-        entities,
-        imports,
-        exports,
-        calls,
-        parseTimeMs,
-        errors,
-        success: true,
-      };
+          language,
+          entities,
+          imports,
+          exports,
+          calls,
+          parseTimeMs,
+          errors,
+          success: true,
+        };
+      } finally {
+        // Syntax trees live on the WASM heap, which the JS GC cannot reclaim
+        // (web-tree-sitter 0.26.x registers no finalizer), so an unfreed tree
+        // is a hard leak of roughly 49x the source size (issue #596). Every
+        // extractor above copies plain values out synchronously via
+        // `node.text`, so nothing survives that still points into the tree.
+        // This also covers the detached case where the timeout race below
+        // already rejected: the parse continues and still frees its tree.
+        tree.delete();
+      }
     };
 
     try {

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -66,6 +66,7 @@ import type { GraphIngestionService } from "../graph/ingestion/GraphIngestionSer
 import type { DocExtractionResult } from "../graph/extraction/doc-types.js";
 import type { FileInput } from "../graph/ingestion/types.js";
 import { DocGraphBatcher } from "../graph/extraction/doc-graph-batch.js";
+import { EntityExtractor } from "../graph/extraction/EntityExtractor.js";
 
 /**
  * Service for orchestrating repository indexing operations
@@ -1149,7 +1150,7 @@ export class IngestionService {
 
     if (codeFiles.length > 0) {
       try {
-        const fileInputs = await this.readCodeFilesForGraph(codeFiles);
+        const fileInputs = await this.readCodeFilesForGraph(codeFiles, errors);
         const ingestResult = await this.graphIngestionService.ingestFiles(fileInputs, {
           repository,
           repositoryUrl: url,
@@ -1218,17 +1219,36 @@ export class IngestionService {
   /**
    * Re-read the queued code files so the graph step gets `FileInput`s.
    *
+   * Only files the graph actually parses are read from disk. `createFileNodes`
+   * uses nothing but `path`/`hash`, and `extractAll` skips anything
+   * `EntityExtractor.isSupported` rejects, so reading (say) a multi-MB
+   * `package-lock.json` would reintroduce exactly the memory peak issue #596
+   * removes. Unsupported files are passed through with empty content so they
+   * still get a File node.
+   *
    * A file that disappeared or became unreadable between chunking and the
-   * graph phase is skipped with a warning rather than failing the run — it is
-   * already indexed in ChromaDB, and the next incremental update will retry.
+   * graph phase is skipped rather than failing the run — it is already indexed
+   * in ChromaDB. The skip is recorded as a non-fatal `IndexError` because the
+   * manifest has already fingerprinted the file as processed: no later
+   * incremental update will re-offer it until its content changes or the
+   * repository is force re-indexed, so the graph gap is otherwise invisible.
    *
    * @param codeFiles - Path pairs captured during chunking
+   * @param errors - Indexing error accumulator; mutated on a failed re-read
    * @returns `FileInput`s for every file that could still be read
    */
-  private async readCodeFilesForGraph(codeFiles: readonly CodeFileRef[]): Promise<FileInput[]> {
+  private async readCodeFilesForGraph(
+    codeFiles: readonly CodeFileRef[],
+    errors: IndexError[]
+  ): Promise<FileInput[]> {
     const fileInputs: FileInput[] = [];
 
     for (const codeFile of codeFiles) {
+      if (!EntityExtractor.isSupported(codeFile.relativePath)) {
+        fileInputs.push({ path: codeFile.relativePath, content: "" });
+        continue;
+      }
+
       try {
         fileInputs.push({
           path: codeFile.relativePath,
@@ -1238,6 +1258,14 @@ export class IngestionService {
         this.logger.warn("Skipping file for graph ingestion; re-read failed", {
           file: codeFile.relativePath,
           error,
+        });
+        errors.push({
+          type: "file_error",
+          filePath: codeFile.relativePath,
+          message: `Graph ingestion skipped file; re-read failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+          originalError: error,
         });
       }
     }

--- a/src/services/ingestion-service.ts
+++ b/src/services/ingestion-service.ts
@@ -48,6 +48,7 @@ import type {
   IngestionStatus,
   BatchResult,
   InternalChunk,
+  CodeFileRef,
 } from "./ingestion-types.js";
 import {
   IngestionError,
@@ -470,7 +471,7 @@ export class IngestionService {
       // Accumulators for the graph step that runs after the batch loop.
       // Populated only when `graphIngestionService` is configured — see
       // `processFileBatch` for the gating.
-      const codeFilesForGraph: FileInput[] = [];
+      const codeFilesForGraph: CodeFileRef[] = [];
       const docExtractionResults: DocExtractionResult[] = [];
 
       for (let batchIndex = 0; batchIndex < totalBatches; batchIndex++) {
@@ -894,13 +895,13 @@ export class IngestionService {
           result.filesProcessed++;
           result.chunksCreated += chunks.length;
           chunkedRelativePaths.push(fileInfo.relativePath);
-          // Capture for the post-batch graph step so it doesn't re-read disk.
-          // Only retained when the graph service is configured — otherwise the
-          // memory cost of holding every code file's content is wasted.
+          // Queue for the post-batch graph step. Paths only: holding every
+          // code file's content until then piles onto the batch loop's peak
+          // (issue #596). Only queued when the graph service is configured.
           if (this.graphIngestionService) {
             result.codeFilesForGraph.push({
-              path: fileInfo.relativePath,
-              content,
+              relativePath: fileInfo.relativePath,
+              absolutePath: fileInfo.absolutePath,
             });
           }
         }
@@ -1127,7 +1128,9 @@ export class IngestionService {
    * @param url - Repository URL or local path; required by `ingestFiles` for
    *              the Repository node. Empty strings are tolerated by the
    *              graph layer for local-folder sources.
-   * @param codeFiles - Code-file `FileInput`s captured during chunking.
+   * @param codeFiles - Code-file path pairs captured during chunking; their
+   *                    content is re-read here rather than retained across
+   *                    the batch loop.
    * @param docResults - Per-doc-file `DocExtractionResult`s captured during
    *                     chunking.
    * @param options - Indexing options (used to forward the progress callback
@@ -1137,7 +1140,7 @@ export class IngestionService {
   private async runGraphIngestion(
     repository: string,
     url: string,
-    codeFiles: readonly FileInput[],
+    codeFiles: readonly CodeFileRef[],
     docResults: readonly DocExtractionResult[],
     options: IndexOptions,
     errors: IndexError[]
@@ -1146,7 +1149,8 @@ export class IngestionService {
 
     if (codeFiles.length > 0) {
       try {
-        const ingestResult = await this.graphIngestionService.ingestFiles([...codeFiles], {
+        const fileInputs = await this.readCodeFilesForGraph(codeFiles);
+        const ingestResult = await this.graphIngestionService.ingestFiles(fileInputs, {
           repository,
           repositoryUrl: url,
           force: options.force ?? false,
@@ -1164,7 +1168,7 @@ export class IngestionService {
         }
         this.logger.info("Code graph ingestion completed", {
           repository,
-          fileCount: codeFiles.length,
+          fileCount: fileInputs.length,
           status: ingestResult.status,
         });
       } catch (error) {
@@ -1209,6 +1213,36 @@ export class IngestionService {
         });
       }
     }
+  }
+
+  /**
+   * Re-read the queued code files so the graph step gets `FileInput`s.
+   *
+   * A file that disappeared or became unreadable between chunking and the
+   * graph phase is skipped with a warning rather than failing the run — it is
+   * already indexed in ChromaDB, and the next incremental update will retry.
+   *
+   * @param codeFiles - Path pairs captured during chunking
+   * @returns `FileInput`s for every file that could still be read
+   */
+  private async readCodeFilesForGraph(codeFiles: readonly CodeFileRef[]): Promise<FileInput[]> {
+    const fileInputs: FileInput[] = [];
+
+    for (const codeFile of codeFiles) {
+      try {
+        fileInputs.push({
+          path: codeFile.relativePath,
+          content: await Bun.file(codeFile.absolutePath).text(),
+        });
+      } catch (error) {
+        this.logger.warn("Skipping file for graph ingestion; re-read failed", {
+          file: codeFile.relativePath,
+          error,
+        });
+      }
+    }
+
+    return fileInputs;
   }
 
   /**
@@ -1345,13 +1379,22 @@ export class IngestionService {
     timeoutMs: number,
     operationName: string
   ): Promise<T> {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         reject(new Error(`${operationName} timed out after ${timeoutMs}ms`));
       }, timeoutMs);
     });
 
-    return Promise.race([promise, timeoutPromise]);
+    try {
+      return await Promise.race([promise, timeoutPromise]);
+    } finally {
+      // Always clear the timer; an uncleared one keeps its closure (and the
+      // event loop) alive for the full timeout after the race is settled.
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId);
+      }
+    }
   }
 
   /**

--- a/src/services/ingestion-types.ts
+++ b/src/services/ingestion-types.ts
@@ -8,7 +8,6 @@
  */
 
 import type { DocExtractionResult } from "../graph/extraction/doc-types.js";
-import type { FileInput } from "../graph/ingestion/types.js";
 
 /**
  * Options for indexing a repository
@@ -365,6 +364,19 @@ export interface InternalChunk {
 }
 
 /**
+ * A code file queued for graph ingestion, identified by path only.
+ *
+ * The content is read back from `absolutePath` when the graph phase runs.
+ */
+export interface CodeFileRef {
+  /** Repository-relative path, used as the graph File node's path */
+  relativePath: string;
+
+  /** Absolute path on disk, used to re-read the content */
+  absolutePath: string;
+}
+
+/**
  * Internal type for batch processing results
  */
 export interface BatchResult {
@@ -414,9 +426,9 @@ export interface BatchResult {
   processedRelativePaths: string[];
 
   /**
-   * `FileInput`-shaped pairs for code files in this batch, captured during
-   * chunking so the post-batch graph step (`GraphIngestionService.ingestFiles`)
-   * doesn't have to re-read the same files from disk.
+   * Paths of the code files in this batch, captured during chunking so the
+   * post-batch graph step (`GraphIngestionService.ingestFiles`) knows which
+   * files to feed the graph.
    *
    * Document files (markdown / pdf / docx / txt) are excluded — they flow
    * through `docExtractionResults` instead.
@@ -426,15 +438,13 @@ export interface BatchResult {
    * code is gated on that field). Consumers should not infer "no code files"
    * from emptiness.
    *
-   * MEMORY: This holds full file content until the post-batch graph step
-   * completes. For repos with `graphIngestionService` configured and
-   * >10K code files, expect ~content_total_bytes of additional retained
-   * memory across the run. Standalone `cli graph populate` already has the
-   * same characteristic (it materializes the same list upfront via
-   * `scanDirectory`); the trade-off is identical. A future follow-up could
-   * stream `ingestFiles` per-batch to bound memory at one batch.
+   * MEMORY: paths only, deliberately. An earlier revision carried the full
+   * file content here to spare the graph step a re-read, which retained
+   * ~content_total_bytes for the whole run — on top of the chunks and
+   * embeddings the batch loop is already holding (issue #596). The content is
+   * re-read in the graph phase instead, by which point that peak has passed.
    */
-  codeFilesForGraph: FileInput[];
+  codeFilesForGraph: CodeFileRef[];
 
   /**
    * Per-document `DocExtractionResult` payloads collected while chunking.

--- a/tests/services/ingestion-service-doc-graph.test.ts
+++ b/tests/services/ingestion-service-doc-graph.test.ts
@@ -552,4 +552,83 @@ describe("IngestionService - doc-graph wiring (#580)", () => {
     );
     expect(result.stats.filesProcessed).toBeGreaterThan(0);
   });
+
+  it("records a file_error when the graph-phase re-read fails and still ingests the readable files", async () => {
+    const service = buildService(true);
+    scanner.setMockFiles([file("src/a.ts", ".ts"), file("src/b.ts", ".ts")]);
+
+    // `src/b.ts` chunks fine but becomes unreadable before the graph phase
+    // re-reads it — the first `.text()` (chunking) succeeds, the second
+    // (graph re-read) throws EBUSY.
+    const reads = new Map<string, number>();
+    (Bun as any).file = (path: string) => ({
+      text: async () => {
+        const count = (reads.get(path) ?? 0) + 1;
+        reads.set(path, count);
+        if (path.endsWith("src/b.ts") && count > 1) {
+          throw new Error("EBUSY: resource busy or locked");
+        }
+        return "export function code() { return 1; }";
+      },
+      json: async () => ({}),
+      arrayBuffer: async () => new ArrayBuffer(0),
+      stream: () => null,
+      size: 36,
+      type: "text/plain",
+    });
+
+    const result = await service.indexRepository("https://github.com/test/repo.git");
+
+    const ingestFilesCall = graph.calls.find((c) => c.kind === "ingestFiles");
+    expect(ingestFilesCall).toBeDefined();
+    if (ingestFilesCall && ingestFilesCall.kind === "ingestFiles") {
+      expect(ingestFilesCall.files.map((f) => f.path)).toEqual(["src/a.ts"]);
+    }
+
+    // The skip is recorded: the manifest has already fingerprinted `src/b.ts`,
+    // so no later incremental update re-offers it.
+    const skipError = result.errors.find((e) => e.filePath === "src/b.ts");
+    expect(skipError).toBeDefined();
+    expect(skipError!.type).toBe("file_error");
+    expect(skipError!.message).toContain("Graph ingestion skipped file; re-read failed");
+    expect(skipError!.message).toContain("EBUSY");
+  });
+
+  it("does not read unsupported code files from disk at the graph phase", async () => {
+    const service = buildService(true);
+    scanner.setMockFiles([file("src/a.ts", ".ts"), file("package-lock.json", ".json")]);
+
+    const graphPhaseReads: string[] = [];
+    const reads = new Map<string, number>();
+    (Bun as any).file = (path: string) => ({
+      text: async () => {
+        const count = (reads.get(path) ?? 0) + 1;
+        reads.set(path, count);
+        if (count > 1) graphPhaseReads.push(path);
+        return "export function code() { return 1; }";
+      },
+      json: async () => ({}),
+      arrayBuffer: async () => new ArrayBuffer(0),
+      stream: () => null,
+      size: 36,
+      type: "text/plain",
+    });
+
+    await service.indexRepository("https://github.com/test/repo.git");
+
+    // Only the tree-sitter-parsable file is re-read; the lockfile still gets a
+    // File node, but with empty content (issue #596 peak-memory guard).
+    expect(graphPhaseReads.some((p) => p.endsWith("package-lock.json"))).toBe(false);
+
+    const ingestFilesCall = graph.calls.find((c) => c.kind === "ingestFiles");
+    expect(ingestFilesCall).toBeDefined();
+    if (ingestFilesCall && ingestFilesCall.kind === "ingestFiles") {
+      const lockfile = ingestFilesCall.files.find((f) => f.path === "package-lock.json");
+      expect(lockfile).toBeDefined();
+      expect(lockfile!.content).toBe("");
+      expect(
+        ingestFilesCall.files.find((f) => f.path === "src/a.ts")!.content.length
+      ).toBeGreaterThan(0);
+    }
+  });
 });

--- a/tests/services/ingestion-service-doc-graph.test.ts
+++ b/tests/services/ingestion-service-doc-graph.test.ts
@@ -12,8 +12,9 @@
  * `graphIngestionService` and indexes a repository containing doc files,
  * the post-batch graph step fires with:
  *
- * 1. The right `FileInput[]` for `ingestFiles` (code files only, content
- *    captured during chunking — NOT re-read from disk),
+ * 1. The right `FileInput[]` for `ingestFiles` (code files only, queued by
+ *    path during chunking and re-read at the graph phase — see issue #596 for
+ *    why the content is no longer retained across the batch loop),
  * 2. The right `DocExtractionResult[]` for `ingestDocumentGraph` (one entry
  *    per markdown / pdf / docx / txt file, format & sections derived from
  *    the chunking-pipeline `ExtractionResult`),
@@ -464,7 +465,7 @@ describe("IngestionService - doc-graph wiring (#580)", () => {
     expect(graph.calls[1]!.kind).toBe("ingestDocumentGraph");
   });
 
-  it("forwards code files to ingestFiles using content captured during chunking", async () => {
+  it("forwards code files to ingestFiles with content re-read at the graph phase", async () => {
     const service = buildService(true);
     scanner.setMockFiles([file("src/a.ts", ".ts"), file("src/b.ts", ".ts")]);
 
@@ -476,8 +477,9 @@ describe("IngestionService - doc-graph wiring (#580)", () => {
       expect(ingestFilesCall.files).toHaveLength(2);
       const paths = ingestFilesCall.files.map((f) => f.path).sort();
       expect(paths).toEqual(["src/a.ts", "src/b.ts"]);
-      // Content was captured during chunking (not re-read from disk after the
-      // batch loop). All entries must have a non-empty content string.
+      // Only the paths are carried across the batch loop; the content is read
+      // back here. All entries must still arrive with a non-empty content
+      // string (issue #596).
       expect(ingestFilesCall.files.every((f) => f.content.length > 0)).toBe(true);
     }
   });

--- a/tests/unit/graph/ingestion/GraphIngestionService.test.ts
+++ b/tests/unit/graph/ingestion/GraphIngestionService.test.ts
@@ -26,6 +26,7 @@ import type {
   ExtractionResult,
   RelationshipExtractionResult,
 } from "../../../../src/graph/extraction/types.js";
+import type { ParseResult } from "../../../../src/graph/parsing/types.js";
 import { initializeLogger, resetLogger } from "../../../../src/logging/index.js";
 
 // Initialize logger for tests (silent mode)
@@ -162,6 +163,27 @@ function createSampleRelationshipResult(filePath: string): RelationshipExtractio
 }
 
 /**
+ * Sample parse result.
+ *
+ * The service parses each file once and feeds the result to both extractors
+ * (issue #596), so tests stub the parse and then stub what each extractor
+ * makes of it.
+ */
+function createSampleParseResult(filePath: string): ParseResult {
+  return {
+    success: true,
+    filePath,
+    language: "typescript",
+    parseTimeMs: 10,
+    entities: [],
+    imports: [],
+    exports: [],
+    calls: [],
+    errors: [],
+  };
+}
+
+/**
  * Sample file input
  */
 function createSampleFileInput(filePath: string, content?: string): FileInput {
@@ -176,11 +198,19 @@ describe("GraphIngestionService", () => {
   let mockNeo4jClient: Neo4jStorageClient;
   let mockEntityExtractor: EntityExtractor;
   let mockRelationshipExtractor: RelationshipExtractor;
+  let parseFileSpy: ReturnType<typeof spyOn<EntityExtractor, "parseFile">>;
 
   beforeEach(() => {
     mockNeo4jClient = createMockNeo4jClient();
     mockEntityExtractor = createMockEntityExtractor();
     mockRelationshipExtractor = createMockRelationshipExtractor();
+
+    // Stub the single parse the service performs per file, so tests that only
+    // care about extractor output don't run tree-sitter. Individual tests
+    // override this when they need to control parse timing or failures.
+    parseFileSpy = spyOn(mockEntityExtractor, "parseFile").mockImplementation(
+      (_content, filePath) => Promise.resolve(createSampleParseResult(filePath))
+    );
 
     service = new GraphIngestionService(
       mockNeo4jClient,
@@ -244,20 +274,21 @@ describe("GraphIngestionService", () => {
         repositoryUrl: "https://github.com/test/test-repo",
       };
 
-      // Use a deferred promise to control when extraction completes
-      let resolveExtraction: ((value: ExtractionResult) => void) | null = null;
-      const extractionPromise = new Promise<ExtractionResult>((resolve) => {
-        resolveExtraction = resolve;
+      // Use a deferred promise to control when the parse completes
+      let resolveParse: ((value: ParseResult) => void) | null = null;
+      const parsePromise = new Promise<ParseResult>((resolve) => {
+        resolveParse = resolve;
       });
 
       // Mock runQuery to return no existing repo
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
-      // Spy on entity extractor to block until we say so
-      const extractSpy = spyOn(mockEntityExtractor, "extractFromContent").mockReturnValue(
-        extractionPromise
+      // Spy on the parse to block until we say so
+      const extractSpy = spyOn(mockEntityExtractor, "parseFile").mockReturnValue(parsePromise);
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
+        createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -275,8 +306,8 @@ describe("GraphIngestionService", () => {
       // Try to start second ingestion - should fail immediately
       await expect(service.ingestFiles(files, options)).rejects.toThrow(IngestionInProgressError);
 
-      // Now resolve the extraction to let first ingestion complete
-      resolveExtraction!(createSampleExtractionResult("test.ts"));
+      // Now resolve the parse to let first ingestion complete
+      resolveParse!(createSampleParseResult("test.ts"));
 
       // Wait for first ingestion to complete
       try {
@@ -286,6 +317,7 @@ describe("GraphIngestionService", () => {
       }
 
       extractSpy.mockRestore();
+      entitySpy.mockRestore();
       relSpy.mockRestore();
     });
 
@@ -360,10 +392,10 @@ describe("GraphIngestionService", () => {
         (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
         // Spy on extractors
-        const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+        const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
           createSampleExtractionResult("test.ts")
         );
-        const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+        const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
           createSampleRelationshipResult("test.ts")
         );
 
@@ -392,10 +424,10 @@ describe("GraphIngestionService", () => {
         .mockResolvedValue([]); // all other queries
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -421,10 +453,10 @@ describe("GraphIngestionService", () => {
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -456,10 +488,12 @@ describe("GraphIngestionService", () => {
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
       // Spy on entity extractor to throw error
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockRejectedValue(
-        new Error("Parse error")
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockImplementation(
+        () => {
+          throw new Error("Parse error");
+        }
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -484,11 +518,11 @@ describe("GraphIngestionService", () => {
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockImplementation(
-        (_, filePath) => Promise.resolve(createSampleExtractionResult(filePath))
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockImplementation(
+        (parseResult) => createSampleExtractionResult(parseResult.filePath)
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockImplementation(
-        (_, filePath) => Promise.resolve(createSampleRelationshipResult(filePath))
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockImplementation(
+        (parseResult) => createSampleRelationshipResult(parseResult.filePath)
       );
 
       const files = [
@@ -506,6 +540,38 @@ describe("GraphIngestionService", () => {
       relSpy.mockRestore();
     });
 
+    it("should parse each file exactly once (issue #596)", async () => {
+      const options: GraphIngestionOptions = {
+        repository: "test-repo",
+        repositoryUrl: "https://github.com/test/test-repo",
+      };
+
+      (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
+
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockImplementation(
+        (parseResult) => createSampleExtractionResult(parseResult.filePath)
+      );
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockImplementation(
+        (parseResult) => createSampleRelationshipResult(parseResult.filePath)
+      );
+
+      const files = [
+        createSampleFileInput("src/index.ts"),
+        createSampleFileInput("src/utils.ts"),
+        createSampleFileInput("src/helpers.ts"),
+      ];
+      await service.ingestFiles(files, options);
+
+      // Entities and relationships must both come from the same parse — the
+      // two-pass version parsed every file twice, leaking a second tree each.
+      expect(parseFileSpy).toHaveBeenCalledTimes(files.length);
+      expect(entitySpy).toHaveBeenCalledTimes(files.length);
+      expect(relSpy).toHaveBeenCalledTimes(files.length);
+
+      entitySpy.mockRestore();
+      relSpy.mockRestore();
+    });
+
     it("should skip unsupported file types", async () => {
       const options: GraphIngestionOptions = {
         repository: "test-repo",
@@ -516,10 +582,10 @@ describe("GraphIngestionService", () => {
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -548,10 +614,10 @@ describe("GraphIngestionService", () => {
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -573,10 +639,10 @@ describe("GraphIngestionService", () => {
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -599,10 +665,10 @@ describe("GraphIngestionService", () => {
       );
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -741,10 +807,10 @@ describe("GraphIngestionService", () => {
       (mockNeo4jClient.runQuery as ReturnType<typeof mock>).mockResolvedValue([]);
 
       // Spy on extractors
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         createSampleExtractionResult("test.ts")
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 
@@ -847,10 +913,10 @@ describe("GraphIngestionService", () => {
         errors: [],
       };
 
-      const entitySpy = spyOn(mockEntityExtractor, "extractFromContent").mockResolvedValue(
+      const entitySpy = spyOn(mockEntityExtractor, "extractFromParseResult").mockReturnValue(
         manyEntitiesResult
       );
-      const relSpy = spyOn(mockRelationshipExtractor, "extractFromContent").mockResolvedValue(
+      const relSpy = spyOn(mockRelationshipExtractor, "extractFromParseResult").mockReturnValue(
         createSampleRelationshipResult("test.ts")
       );
 

--- a/tests/unit/graph/parsing/TreeSitterParser.memory.test.ts
+++ b/tests/unit/graph/parsing/TreeSitterParser.memory.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Memory regression test for TreeSitterParser (issue #596).
+ *
+ * web-tree-sitter allocates syntax trees on the WASM heap, which the JS
+ * garbage collector cannot reclaim: version 0.26.x registers no finalizer, so
+ * a tree that is never `delete()`d is leaked outright. A full re-index parses
+ * tens of thousands of files, which is how a missing `tree.delete()` grew into
+ * an out-of-memory crash at ~3.7GB RSS.
+ *
+ * This test parses a real source file repeatedly and asserts RSS stays flat.
+ * Without the fix the same loop retains roughly 49x the source size per
+ * iteration, several hundred megabytes over the iteration count used here.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import path from "node:path";
+import { TreeSitterParser } from "../../../../src/graph/parsing/TreeSitterParser.js";
+import { LanguageLoader } from "../../../../src/graph/parsing/LanguageLoader.js";
+import { initializeLogger, resetLogger } from "../../../../src/logging/index.js";
+
+/** Iterations measured after warmup. */
+const ITERATIONS = 40;
+
+/** Iterations discarded first, so lazy WASM/grammar init isn't counted. */
+const WARMUP_ITERATIONS = 5;
+
+/**
+ * Ceiling on RSS growth across the measured iterations.
+ *
+ * Deliberately generous: the fixed parser holds nothing between iterations,
+ * but the WASM heap never shrinks and the runtime is free to keep arenas
+ * warm. The unfixed parser blows past this by an order of magnitude.
+ */
+const MAX_RSS_GROWTH_MB = 100;
+
+describe("TreeSitterParser memory", () => {
+  let parser: TreeSitterParser;
+  let source: string;
+
+  beforeAll(async () => {
+    initializeLogger({ level: "error", format: "json" });
+    parser = new TreeSitterParser();
+
+    // Real, non-trivial source: the parser's own implementation (~145KB).
+    source = await Bun.file(
+      path.join(process.cwd(), "src/graph/parsing/TreeSitterParser.ts")
+    ).text();
+    expect(source.length).toBeGreaterThan(100_000);
+  });
+
+  afterAll(() => {
+    LanguageLoader.resetInstance();
+    resetLogger();
+  });
+
+  it(
+    "should not grow RSS when parsing the same file repeatedly",
+    async () => {
+      for (let i = 0; i < WARMUP_ITERATIONS; i++) {
+        await parser.parseFile(source, "TreeSitterParser.ts");
+      }
+
+      Bun.gc(true);
+      const rssBefore = process.memoryUsage.rss();
+
+      for (let i = 0; i < ITERATIONS; i++) {
+        const result = await parser.parseFile(source, "TreeSitterParser.ts");
+        expect(result.entities.length).toBeGreaterThan(0);
+      }
+
+      Bun.gc(true);
+
+      // Compared in MB so a failure reports the leak size directly.
+      const growthMb = Math.round((process.memoryUsage.rss() - rssBefore) / 1024 / 1024);
+      expect(growthMb).toBeLessThan(MAX_RSS_GROWTH_MB);
+    },
+    { timeout: 300_000 }
+  );
+});


### PR DESCRIPTION
Fixes #596.

## Root cause

Full re-index of Muzehub-code (5,056 files) crashed bun 1.3.13 with an illegal-instruction panic at ~3.7GB RSS after ~51 minutes, always during the graph parse phase. Two compounding problems:

1. **Leaked syntax trees.** `TreeSitterParser.parseFile` allocated a web-tree-sitter `Tree` and never called `tree.delete()`. Trees live on the WASM heap, which JS GC cannot reclaim (web-tree-sitter 0.26.x registers no finalizer). Measured: ~49x source size retained per parse; parsing 400 real files (5.7MB source) leaked 281MB. Muzehub-code has ~46MB of parseable source.
2. **Double parse.** The graph phase parsed every file twice: once in `extractAllEntities`, again in `extractAllRelationships` (and the incremental `ingestFile` path had the same shape). 46MB x 49 x 2 = ~4.4GB projected, matching the observed 3.74GB RSS / 4.80GB commit at crash.

The embedding/ChromaDB phase was audited and is properly bounded; it is not implicated.

## Changes

- **`TreeSitterParser.ts`**: `tree.delete()` in a `finally` after all extraction. Safe because every extractor copies plain values out synchronously via `node.text`; nothing retains a node reference. Also covers extractor throws and the detached path where the parse timeout race already rejected.
- **`GraphIngestionService.ts`**: `extractAllEntities` + `extractAllRelationships` collapsed into one `extractAll` that parses each file exactly once and feeds both extractors. Same single-parse change in the incremental `ingestFile` path. Progress events and public API unchanged.
- **`EntityExtractor.ts` / `RelationshipExtractor.ts`**: split into `parseFile` + `extractFromParseResult`; `extractFromContent` composes them, so existing callers are unaffected.
- **`IngestionService`**: `codeFilesForGraph` now queues `{relativePath, absolutePath}` instead of full file content (~46MB retained across the whole run on large repos); content is re-read in the graph phase. A file that became unreadable in between is skipped with a warning. `withTimeout` now clears its timer in a `finally`.

## Verification

- `bun run typecheck`: clean
- `bun run build`: clean
- Targeted suites (`tests/unit/graph/parsing`, `extraction`, `ingestion`, `tests/services`): **683 pass / 0 fail** (the Roslyn C# tests requiring the .NET SDK fail identically on clean main; pre-existing, unrelated)
- Full `bun test` exits 1 with no summary on this machine, identically on clean main; that is pre-existing issue #579
- New regression test `TreeSitterParser.memory.test.ts`: 40 parses of 145KB real source must stay under 100MB RSS growth. Passes with the fix (0MB growth); leaks 280MB with `tree.delete()` removed.

## Notes

- This also defuses the 500-file incremental threshold dead-end from the issue: the incremental path leaked the same way (two trees per changed file) and the threshold was accidentally acting as a leak limiter. With trees freed, both paths are bounded; no checkpoint/resume machinery is needed.
- The bun illegal-instruction panic is bun's failure mode under a monotonic multi-GB WASM heap; with the leak fixed there is nothing to file upstream unless we want a cleaner OOM error.
- PR is ~630 changed lines, over the 400-line guideline: the leak fix, the single-parse refactor it exposed, and their test coverage are one cohesive change; splitting would ship the refactor without its regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
